### PR TITLE
Validate skills against master skill template

### DIFF
--- a/.claude/skills/build-compile/SKILL.md
+++ b/.claude/skills/build-compile/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: build-compile
+description: Build Rust code with proper error handling and optimization for development, testing, and production. Use when compiling the self-learning memory project or troubleshooting build errors.
+---
+
 # Build and Compile
 
 Build Rust code with proper error handling and optimization.

--- a/.claude/skills/code-quality/SKILL.md
+++ b/.claude/skills/code-quality/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: code-quality
+description: Maintain high code quality through formatting, linting, and static analysis using rustfmt, clippy, and cargo audit. Use to ensure consistent code style and catch common mistakes.
+---
+
 # Code Quality
 
 Maintain high code quality through formatting, linting, and static analysis.

--- a/.claude/skills/context-retrieval/SKILL.md
+++ b/.claude/skills/context-retrieval/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: context-retrieval
+description: Retrieve relevant episodic context from memory for informed decision-making. Use when you need past episodes, patterns, or solutions to similar tasks.
+---
+
 # Context Retrieval
 
 Retrieve relevant episodic context from memory for informed decision-making.

--- a/.claude/skills/debug-troubleshoot/SKILL.md
+++ b/.claude/skills/debug-troubleshoot/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: debug-troubleshoot
+description: Systematic debugging approach for Rust async code with Tokio, Turso, and redb. Use when diagnosing runtime issues, performance problems, async deadlocks, database connection issues, or panics.
+---
+
 # Debug and Troubleshoot
 
 Systematic debugging approach for Rust async code with Tokio, Turso, and redb.

--- a/.claude/skills/episode-complete/SKILL.md
+++ b/.claude/skills/episode-complete/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: episode-complete
+description: Complete and score a learning episode to extract patterns and update heuristics. Use when finalizing a task to enable pattern extraction and future learning.
+---
+
 # Episode Complete
 
 Complete and score a learning episode to extract patterns and update heuristics.

--- a/.claude/skills/episode-log-steps/SKILL.md
+++ b/.claude/skills/episode-log-steps/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: episode-log-steps
+description: Log execution steps during episode execution for detailed tracking and learning. Use when recording tool usage, decision points, errors, or milestones during task execution.
+---
+
 # Episode Log Steps
 
 Log execution steps during episode execution for detailed tracking and learning.

--- a/.claude/skills/episode-start/SKILL.md
+++ b/.claude/skills/episode-start/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: episode-start
+description: Start a new learning episode in the self-learning memory system with proper context. Use this skill when beginning a new task that should be tracked for learning from execution patterns.
+---
+
 # Episode Start
 
 Start a new learning episode in the self-learning memory system.

--- a/.claude/skills/feature-implement/SKILL.md
+++ b/.claude/skills/feature-implement/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: feature-implement
+description: Systematic approach to implementing new features in the Rust memory system following project conventions. Use when adding new functionality with proper testing and documentation.
+---
+
 # Feature Implementation
 
 Systematic approach to implementing new features in the Rust memory system.

--- a/.claude/skills/storage-sync/SKILL.md
+++ b/.claude/skills/storage-sync/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: storage-sync
+description: Synchronize memories between Turso (durable) and redb (cache) storage layers. Use when cache appears stale, after failures, or during periodic maintenance.
+---
+
 # Storage Sync
 
 Synchronize memories between Turso (durable) and redb (cache) storage layers.

--- a/.claude/skills/test-fix/SKILL.md
+++ b/.claude/skills/test-fix/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: test-fix
+description: Systematic approach to diagnosing and fixing failing tests in Rust projects. Use when tests fail and you need to diagnose root causes, fix async/await issues, handle race conditions, or resolve database connection problems.
+---
+
 # Test Fix
 
 Systematic approach to diagnosing and fixing failing tests.

--- a/.claude/skills/test-runner/SKILL.md
+++ b/.claude/skills/test-runner/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: test-runner
+description: Execute and manage Rust tests including unit tests, integration tests, and doc tests. Use when running tests to ensure code quality and correctness.
+---
+
 # Test Runner
 
 Execute and manage Rust tests for the self-learning memory project.


### PR DESCRIPTION
- Restructured all skill files from .claude/skills/*.md to .claude/skills/*/SKILL.md
- Added YAML frontmatter to all skills with name and description fields
- Converted 11 skills to proper format:
  - episode-start: Start learning episodes with context
  - episode-log-steps: Log execution steps during episodes
  - episode-complete: Complete and score episodes
  - context-retrieval: Retrieve relevant episodic context
  - storage-sync: Synchronize Turso and redb storage
  - build-compile: Build and compile Rust code
  - test-runner: Execute and manage tests
  - test-fix: Diagnose and fix failing tests
  - code-quality: Maintain code quality with rustfmt/clippy
  - debug-troubleshoot: Debug async Rust code systematically
  - feature-implement: Implement new features following conventions
- Removed old .md files from skills root directory
- All skills now follow skill-creator template requirements

Skills are now properly formatted for Claude Code with:
- Lowercase-hyphenated names
- Clear, specific descriptions with when-to-use guidance
- Well-structured content with sections and examples
- DO/DON'T best practices