### PR TITLE
Fix CI workflow and add coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         rust: [stable, beta]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
       - uses: Swatinem/rust-cache@v2
@@ -65,8 +65,39 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
-      - name: Build all crates
-        run: cargo build --all --release
+      - name: Build all crates with timing
+        run: cargo build --all --release --timings
+      - name: Upload build timing report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-timings
+          path: target/cargo-timings/cargo-timing.html
+          retention-days: 7
+
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov
+      - name: Generate coverage report
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        env:
+          RUST_LOG: debug
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   security-audit:
     name: Security Audit


### PR DESCRIPTION
…timing

- Fix line 48: change @stable to @master for proper matrix toolchain support This allows the matrix.rust variable to correctly select stable/beta toolchains
- Add coverage reporting job with cargo-llvm-cov
  * Generates LCOV coverage reports
  * Uploads to Codecov (requires CODECOV_TOKEN secret)
  * Runs on all features and workspace crates
- Add build timing reports with cargo build --timings
  * Generates HTML timing report for build performance analysis
  * Uploads as artifact with 7-day retention
  * Helps identify slow dependencies and build bottlenecks