### PR TITLE
Configure CI workflows for stable Rust only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, beta]
+        rust: [stable]
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
Remove beta Rust from CI test matrix to standardize on stable toolchain only. All other workflows (ci-enhanced, release, security) already use stable.

This aligns with project standards documented in AGENTS.md and CONTRIBUTING.md which specify using stable Rust toolchain.