### PR TITLE
Potential fix for code scanning alert no. 47: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/d-o-hub/rust-self-learning-memory/security/code-scanning/47](https://github.com/d-o-hub/rust-self-learning-memory/security/code-scanning/47)

To fix the problem, we need to explicitly set the least privilege permissions at either the workflow root or on each individual job. Best practice is to add a top-level `permissions` block (right after `name` and before `on`), which applies to all jobs that do not specify their own block. Since none of these jobs seem to push code, create PRs, or otherwise require write access, setting `contents: read` is the recommended minimal default. If any job specifically needs elevated access, it can override this at the job level.  
**Change required:**  
- Add the following block at the top (e.g. between line 1 and line 2):
  ```yaml
  permissions:
    contents: read
  ```
- This ensures the minimal required permissions apply for all jobs, including the "Unsafe Code Detection (cargo-geiger)" job as highlighted by CodeQL.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
