### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,6 +25,8 @@ jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/d-o-hub/rust-self-learning-memory/security/code-scanning/17](https://github.com/d-o-hub/rust-self-learning-memory/security/code-scanning/17)

To fix this issue, you should explicitly specify a `permissions` block in the `dependency-review` job configuration to limit the default permissions given to the `GITHUB_TOKEN`. Since CodeQL suggests using `{contents: read}` as the minimal starting point, and the actions in the job do not seem to require any write access, you can safely add this minimal permissions block. This involves editing the `.github/workflows/security.yml` file by inserting:

```yaml
permissions:
  contents: read
```

right under the `runs-on: ubuntu-latest` line in the `dependency-review` job (after line 27 and before line 28).

No other code or method changes or imports are necessary since this is a workflow YAML edit only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
