### PR TITLE
Potential fix for code scanning alert no. 39: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -8,6 +8,9 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
 
+permissions:
+  contents: read
+
 jobs:
   quick-check:
     name: Quick PR Check (Format + Clippy)


### PR DESCRIPTION
Potential fix for [https://github.com/d-o-hub/rust-self-learning-memory/security/code-scanning/39](https://github.com/d-o-hub/rust-self-learning-memory/security/code-scanning/39)

To fix the detected problem, explicitly set the `permissions` block in the workflow file `.github/workflows/quick-check.yml`, either at the workflow root (before the `jobs:` section) or under the specific job (`quick-check`). Since this workflow only checks the format and runs clippy (it reads code, does not push, open PRs, or write to issues), `contents: read` is sufficient and recommended as a minimal permission. This change should be made above the `jobs:` section, right after the environment variables block, so that it applies to all jobs in the workflow and follows best practices for least-privilege. No new imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
