### PR TITLE
Remove cargo-geiger dependency

### DIFF
--- a/.claude/hooks/pre-commit-security.sh
+++ b/.claude/hooks/pre-commit-security.sh
@@ -48,16 +48,7 @@ if ! cargo test --all; then
     exit 1
 fi
 
-# 6. Unsafe code detection (skip if cargo-geiger not installed)
-if command -v cargo-geiger &> /dev/null; then
-    echo "☢️  Checking for unsafe code..."
-    cargo geiger --output-format GitHubMarkdown > /dev/null
-    echo "✓ Unsafe code scan complete"
-else
-    echo "⚠️  cargo-geiger not installed. Run: cargo install cargo-geiger --locked"
-fi
-
-# 7. Secret scanning
+# 6. Secret scanning
 echo "🔐 Scanning for secrets..."
 if git diff --cached --name-only | xargs grep -inE '(api[_-]?key|password|secret|token|credential)["\']?\s*[:=]' 2>/dev/null; then
     echo "❌ Potential secrets detected in staged files!"

--- a/.github/SECURITY_REVIEW_SCHEDULE.md
+++ b/.github/SECURITY_REVIEW_SCHEDULE.md
@@ -78,7 +78,6 @@
    cargo audit
    cargo deny check advisories
    cargo deny check licenses
-   cargo geiger --output-format GitHubMarkdown
    ```
 
 2. **Hook Effectiveness Review**
@@ -431,7 +430,6 @@
 # Install once per developer machine
 cargo install cargo-audit --locked
 cargo install cargo-deny --locked
-cargo install cargo-geiger --locked
 cargo install cargo-llvm-cov --locked
 ```
 

--- a/.github/SECURITY_REVIEW_SUMMARY.md
+++ b/.github/SECURITY_REVIEW_SUMMARY.md
@@ -34,7 +34,6 @@ The zero-trust security architecture for rust-self-learning-memory has been **su
 | Dependency Review | security.yml | ✅ GitHub action |
 | Vulnerability Audit | ci.yml, security.yml | ✅ cargo-audit |
 | Supply Chain | ci.yml | ✅ cargo-deny |
-| Unsafe Code Detection | ci.yml | ✅ cargo-geiger |
 | Code Formatting | ci.yml, ci-enhanced.yml | ✅ rustfmt |
 | Linting | ci.yml, ci-enhanced.yml | ✅ clippy |
 | Test Coverage | ci.yml, ci-enhanced.yml | ✅ Multi-platform |
@@ -184,7 +183,6 @@ gh run list --workflow=ci.yml
 **Tools Integrated**:
 - ✅ cargo-audit (vulnerability scanning)
 - ✅ cargo-deny (policy enforcement)
-- ✅ cargo-geiger (unsafe code detection)
 
 ---
 

--- a/.github/SECURITY_TRAINING.md
+++ b/.github/SECURITY_TRAINING.md
@@ -170,10 +170,7 @@ fn broken_function( {
 5. **Test Execution** (`cargo test --all`)
    - Blocks if any tests fail
 
-6. **Unsafe Code Scan** (`cargo geiger`)
-   - Reports unsafe code usage
-
-7. **Secret Scanning** (grep pattern matching)
+6. **Secret Scanning** (grep pattern matching)
    - Blocks if hardcoded secrets detected
 
 **Example Scenario**:
@@ -193,8 +190,6 @@ git commit -m "feat: add new feature"
 # ✓ All policies pass
 # 🧪 Running tests...
 # ✓ All tests pass
-# ☢️  Checking for unsafe code...
-# ✓ No unsafe code
 # 🔐 Scanning for secrets...
 # ✓ No secrets detected
 # ✅ All security checks passed!
@@ -471,7 +466,6 @@ git commit -m "chore(deps): add new-crate"
 # Install security tools (one-time setup)
 cargo install cargo-audit --locked
 cargo install cargo-deny --locked
-cargo install cargo-geiger --locked
 cargo install cargo-llvm-cov --locked
 
 # Verify installation
@@ -519,8 +513,7 @@ unsafe {
     // ... unsafe code ...
 }
 
-// cargo-geiger will report this, but won't block
-// Maintainers will review during PR
+// Maintainers will review unsafe code during PR
 ```
 
 ---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,28 +171,6 @@ jobs:
           path: target/deny.log
           retention-days: 7
 
-  unsafe-code-check:
-    name: Unsafe Code Detection (cargo-geiger)
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event.workflow_run.conclusion == 'success' }}
-    steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
-      - name: Install cargo-geiger
-        run: cargo install cargo-geiger --locked
-      - name: Run cargo-geiger
-        run: cargo geiger --output-format GitHubMarkdown | tee unsafe-report.md
-      - name: Upload unsafe code report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: unsafe-code-report
-          path: unsafe-report.md
-          retention-days: 7
-
   quality-gates:
     name: Quality Gates
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -429,7 +429,6 @@ Jobs:
   - coverage:         Code coverage with >90% gate
   - security-audit:   Vulnerability scanning (cargo audit)
   - supply-chain:     License & advisory checks (cargo-deny)
-  - unsafe-code:      Unsafe code detection (cargo-geiger)
 ```
 
 ### Testing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,11 +44,6 @@ Located in `.claude/settings.json`, hooks enforce security at development time:
 - Runs in CI on every push
 - Weekly scheduled scans
 
-#### cargo-geiger
-- Detects unsafe code usage
-- Generates reports on unsafe blocks
-- Helps minimize attack surface
-
 ### 3. Build-Time Security
 
 #### Cargo Configuration (`.cargo/config.toml`)
@@ -70,7 +65,6 @@ Located in `.claude/settings.json`, hooks enforce security at development time:
 - **Coverage**: Tracks code coverage with cargo-llvm-cov
 - **Security Audit**: rustsec/audit-check
 - **Supply Chain**: cargo-deny checks
-- **Unsafe Code**: cargo-geiger detection
 
 #### Security Workflow (`.github/workflows/security.yml`)
 - **Secret Scanning**: Gitleaks on every push
@@ -163,13 +157,11 @@ Before every commit, verify:
 # Install security tools
 cargo install cargo-audit --locked
 cargo install cargo-deny --locked
-cargo install cargo-geiger --locked
 cargo install cargo-llvm-cov --locked
 
 # Verify installation
 cargo audit --version
 cargo deny --version
-cargo geiger --version
 ```
 
 ## References


### PR DESCRIPTION
Remove all cargo-geiger references from the codebase:
- Remove unsafe-code-check job from CI workflow
- Remove cargo-geiger from README CI pipeline section
- Remove cargo-geiger from SECURITY.md documentation
- Remove cargo-geiger from security training guide
- Remove cargo-geiger from security review schedule
- Remove cargo-geiger from security review summary
- Remove cargo-geiger check from pre-commit hook

This removes 54 lines of code related to cargo-geiger across 7 files. The project will no longer scan for unsafe code as part of the security pipeline.