### PR TITLE
Fix Rust benchmark results parsing error

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -48,29 +48,32 @@ jobs:
 
       - name: Run benchmarks
         run: |
-          cargo bench --package memory-benches
+          # Run benchmarks - Criterion will generate JSON output in target/criterion
+          cargo bench --package memory-benches --bench episode_lifecycle
+          cargo bench --package memory-benches --bench pattern_extraction
+          cargo bench --package memory-benches --bench storage_operations
 
       - name: Convert Criterion output to bencher format
         run: |
           # Parse Criterion JSON output and convert to bencher format
-          # Criterion stores results in target/criterion/<benchmark_name>/base/estimates.json
-          find target/criterion -type f -name "estimates.json" | while read -r json_file; do
+          # Only process "new" estimates to avoid duplicates
+          find target/criterion -type f -path "*/new/estimates.json" | while read -r json_file; do
             # Extract benchmark name from path
-            bench_name=$(echo "$json_file" | sed 's|target/criterion/||' | sed 's|/base/estimates.json||' | sed 's|/|-|g')
+            # Path format: target/criterion/<benchmark_name>/new/estimates.json
+            bench_name=$(echo "$json_file" | sed 's|target/criterion/||' | sed 's|/new/estimates.json||' | sed 's|/|-|g')
 
             # Extract mean time in nanoseconds from JSON
-            # Criterion stores time in nanoseconds as point_estimate
             mean_ns=$(grep -o '"point_estimate":[0-9.]*' "$json_file" | head -1 | cut -d: -f2 | cut -d. -f1)
 
             if [ -n "$mean_ns" ] && [ "$mean_ns" != "0" ]; then
-              echo "test $bench_name ... bench: $mean_ns ns/iter"
+              echo "test $bench_name ... bench: $mean_ns ns/iter (+/- 0)"
             fi
           done > bench_results.txt
 
           # Verify we have results
           if [ ! -s bench_results.txt ]; then
-            echo "Warning: No benchmark results found!"
-            echo "Listing criterion output directory:"
+            echo "Error: No benchmark results found!"
+            echo "Listing criterion output:"
             find target/criterion -type f -name "*.json" | head -20
             exit 1
           fi


### PR DESCRIPTION
The benchmark workflow was failing because:
1. The manual conversion script was processing both /base/ and /new/ estimate files, creating duplicate entries
2. Criterion's --output-format bencher flag doesn't include test names in the output, making it incompatible with github-action-benchmark

Changes:
- Modified conversion script to only process /new/estimates.json files to avoid duplicates
- Run each benchmark binary individually to avoid running lib tests
- Ensured output format matches the expected bencher format: "test <name> ... bench: <ns> ns/iter (+/- 0)"

This fixes the "No benchmark result was found" error in CI.