### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,6 +38,8 @@ jobs:
   supply-chain-audit:
     name: Supply Chain Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Potential fix for [https://github.com/d-o-hub/rust-self-learning-memory/security/code-scanning/28](https://github.com/d-o-hub/rust-self-learning-memory/security/code-scanning/28)

To fix the problem, add an explicit `permissions` block to the `supply-chain-audit` job in `.github/workflows/security.yml`. This block should specify only the minimal required permissions for the job to complete its steps—usually, `contents: read` is sufficient unless the job uploads or modifies code, issues, or other repo resources. Review the steps of `supply-chain-audit`: it checks out code, installs tools, runs `cargo audit`, and uploads an artifact. None of these requires write access to the repository contents or other privileged scopes, so `contents: read` suffices. Insert the following under the job:  
```yaml
permissions:
  contents: read
```
Insert this immediately under the `runs-on: ubuntu-latest` line of the `supply-chain-audit` job (i.e., after line 40 and before `steps:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
