### PR TITLE
fix: remove invalid unwrap calls on start_episode return value

### DIFF
--- a/memory-core/examples/async_pattern_extraction.rs
+++ b/memory-core/examples/async_pattern_extraction.rs
@@ -93,8 +93,7 @@ async fn create_and_complete_episode(memory: &SelfLearningMemory, description: &
     let context = TaskContext::default();
     let episode_id = memory
         .start_episode(description.to_string(), context, TaskType::Testing)
-        .await
-        .unwrap();
+        .await;
 
     // Add some execution steps
     for i in 0..5 {

--- a/memory-core/tests/async_extraction.rs
+++ b/memory-core/tests/async_extraction.rs
@@ -30,8 +30,7 @@ async fn create_test_episode(
     let context = TaskContext::default();
     let episode_id = memory
         .start_episode(description.to_string(), context, TaskType::Testing)
-        .await
-        .unwrap();
+        .await;
 
     // Add execution steps
     for i in 0..step_count {

--- a/memory-core/tests/common/assertions.rs
+++ b/memory-core/tests/common/assertions.rs
@@ -228,8 +228,7 @@ mod tests {
 
         let episode_id = memory
             .start_episode("test".to_string(), test_context(), TaskType::Testing)
-            .await
-            .unwrap();
+            .await;
 
         memory
             .complete_episode(

--- a/memory-core/tests/common/helpers.rs
+++ b/memory-core/tests/common/helpers.rs
@@ -65,8 +65,7 @@ pub async fn setup_memory_with_n_episodes(n: usize) -> SelfLearningMemory {
 
         let episode_id = memory
             .start_episode(format!("Task {}", i), context, TaskType::CodeGeneration)
-            .await
-            .unwrap();
+            .await;
 
         // Add 3-5 steps per episode
         let step_count = 3 + (i % 3);
@@ -231,8 +230,7 @@ async fn create_error_recovery_episode(memory: &SelfLearningMemory) -> Uuid {
             context,
             TaskType::CodeGeneration,
         )
-        .await
-        .unwrap();
+        .await;
 
     // Create error recovery pattern
     let error_step = StepBuilder::new(1, "initial_attempt", "Try operation")
@@ -273,8 +271,7 @@ async fn create_tool_sequence_episode(memory: &SelfLearningMemory) -> Uuid {
             context,
             TaskType::CodeGeneration,
         )
-        .await
-        .unwrap();
+        .await;
 
     memory
         .log_step(
@@ -316,8 +313,7 @@ async fn create_decision_point_episode(memory: &SelfLearningMemory) -> Uuid {
 
     let episode_id = memory
         .start_episode("Check cache".to_string(), context, TaskType::CodeGeneration)
-        .await
-        .unwrap();
+        .await;
 
     memory
         .log_step(
@@ -362,8 +358,7 @@ pub async fn create_test_episode_with_domain(memory: &SelfLearningMemory, domain
             context,
             TaskType::CodeGeneration,
         )
-        .await
-        .unwrap();
+        .await;
 
     let step = create_test_step(1);
     memory.log_step(episode_id, step).await;

--- a/memory-core/tests/compliance.rs
+++ b/memory-core/tests/compliance.rs
@@ -29,8 +29,7 @@ async fn should_create_episodes_with_unique_ids_and_timestamps() {
     // When: We create a new episode
     let episode_id = memory
         .start_episode("Test task".to_string(), test_context(), TaskType::Testing)
-        .await
-        .unwrap();
+        .await;
 
     // Then: The episode should have a unique ID and valid timestamp
     let episode = memory.get_episode(episode_id).await.unwrap();
@@ -51,8 +50,7 @@ async fn should_create_episodes_with_unique_ids_and_timestamps() {
                 test_context(),
                 TaskType::CodeGeneration,
             )
-            .await
-            .unwrap();
+            .await;
         episode_ids.push(id);
     }
 
@@ -74,8 +72,7 @@ async fn should_log_execution_steps_with_ordering_and_metadata() {
     let memory = setup_test_memory();
     let episode_id = memory
         .start_episode("Test task".to_string(), test_context(), TaskType::Testing)
-        .await
-        .unwrap();
+        .await;
 
     // When: We log a step with tool usage and metadata
     let step = StepBuilder::new(1, "test_tool", "Test action")
@@ -141,8 +138,7 @@ async fn should_complete_episodes_with_reward_scoring_and_reflection() {
     let memory = setup_test_memory();
     let episode_id = memory
         .start_episode("Test task".to_string(), test_context(), TaskType::Testing)
-        .await
-        .unwrap();
+        .await;
 
     // When: We complete the episode with a successful outcome
     let outcome = TaskOutcome::Success {
@@ -173,8 +169,7 @@ async fn should_handle_failed_episodes_with_improvements() {
     let memory = setup_test_memory();
     let episode_id = memory
         .start_episode("Test task".to_string(), test_context(), TaskType::Testing)
-        .await
-        .unwrap();
+        .await;
 
     // When: We complete the episode with a failure outcome
     let outcome = TaskOutcome::Failure {
@@ -199,8 +194,7 @@ async fn should_score_partial_success_between_failure_and_success() {
     let memory = setup_test_memory();
     let episode_id = memory
         .start_episode("Test task".to_string(), test_context(), TaskType::Testing)
-        .await
-        .unwrap();
+        .await;
 
     // When: We complete the episode with a partial success outcome
     let outcome = TaskOutcome::PartialSuccess {
@@ -266,8 +260,7 @@ async fn should_extract_different_pattern_types_based_on_episode_structure() {
             test_context(),
             TaskType::CodeGeneration,
         )
-        .await
-        .unwrap();
+        .await;
 
     // And: Add sequential steps
     for i in 1..=3 {
@@ -361,8 +354,7 @@ async fn should_retrieve_relevant_episodes_with_context_filtering_and_limits() {
                     context.clone(),
                     TaskType::CodeGeneration,
                 )
-                .await
-                .unwrap();
+                .await;
 
             memory3
                 .complete_episode(
@@ -430,8 +422,7 @@ async fn should_maintain_episode_integrity_after_completion() {
     let memory = setup_test_memory();
     let episode_id = memory
         .start_episode("Test".to_string(), test_context(), TaskType::Testing)
-        .await
-        .unwrap();
+        .await;
     memory
         .complete_episode(
             episode_id,
@@ -467,8 +458,7 @@ async fn should_report_accurate_statistics() {
                 test_context(),
                 TaskType::CodeGeneration,
             )
-            .await
-            .unwrap();
+            .await;
 
         if i < 3 {
             memory

--- a/memory-core/tests/input_validation.rs
+++ b/memory-core/tests/input_validation.rs
@@ -101,8 +101,7 @@ async fn should_handle_large_inputs_without_data_loss() {
         // When: We create an episode with large data
         let id = memory
             .start_episode(description.clone(), context.clone(), TaskType::Other)
-            .await
-            .unwrap();
+            .await;
 
         // Then: Large description should be stored completely
         if test_case.description_size > 100 {
@@ -247,8 +246,7 @@ async fn should_handle_special_characters_and_edge_cases_gracefully() {
                 TaskContext::default(),
                 TaskType::Other,
             )
-            .await
-            .unwrap();
+            .await;
 
         // Then: The description should be preserved exactly
         let episode = memory.get_episode(id).await.unwrap();
@@ -313,8 +311,7 @@ async fn should_handle_deeply_nested_json_structures() {
     // When: We create an episode with deeply nested JSON parameters
     let id = memory
         .start_episode("Test".to_string(), TaskContext::default(), TaskType::Other)
-        .await
-        .unwrap();
+        .await;
 
     let step = StepBuilder::new(1, "tool", "action")
         .parameters(nested.clone())
@@ -364,8 +361,7 @@ async fn should_provide_type_safe_uuid_handling() {
             TaskContext::default(),
             TaskType::Other,
         )
-        .await
-        .unwrap();
+        .await;
 
     let episode = memory.get_episode(real_id).await;
 

--- a/memory-core/tests/learning_cycle.rs
+++ b/memory-core/tests/learning_cycle.rs
@@ -35,8 +35,7 @@ async fn should_execute_complete_learning_cycle_end_to_end() {
             context.clone(),
             TaskType::CodeGeneration,
         )
-        .await
-        .unwrap();
+        .await;
 
     // Then: The episode should be created and incomplete
     let episode = memory.get_episode(episode_id).await.unwrap();
@@ -130,8 +129,7 @@ async fn should_learn_from_multiple_episodes_in_same_domain() {
                 context,
                 TaskType::CodeGeneration,
             )
-            .await
-            .unwrap();
+            .await;
 
         // Add steps - using create_success_step helper
         for j in 0..3 {
@@ -183,8 +181,7 @@ async fn should_learn_from_failed_episodes_with_improvement_insights() {
             context,
             TaskType::CodeGeneration,
         )
-        .await
-        .unwrap();
+        .await;
     let mut step1 = ExecutionStep::new(1, "raft_impl".to_string(), "Implement Raft".to_string());
     step1.result = Some(ExecutionResult::Error {
         message: "Network partition".to_string(),
@@ -242,8 +239,7 @@ async fn should_handle_concurrent_episode_operations_safely() {
 
             let episode_id = mem
                 .start_episode(format!("Task {}", i), context, TaskType::CodeGeneration)
-                .await
-                .unwrap();
+                .await;
 
             // Add step
             let mut step = ExecutionStep::new(1, "worker".to_string(), "Work".to_string());
@@ -301,8 +297,7 @@ async fn should_extract_patterns_accurately_from_error_recovery_episodes() {
             context.clone(),
             TaskType::CodeGeneration,
         )
-        .await
-        .unwrap();
+        .await;
 
     // Simulate error recovery pattern
     let mut error_step = ExecutionStep::new(

--- a/memory-core/tests/performance.rs
+++ b/memory-core/tests/performance.rs
@@ -55,8 +55,7 @@ async fn setup_memory_with_n_episodes(n: usize) -> SelfLearningMemory {
 
         let episode_id = memory
             .start_episode(format!("Task {}", i), context, TaskType::CodeGeneration)
-            .await
-            .unwrap();
+            .await;
 
         // Add 3-5 steps per episode
         let step_count = 3 + (i % 3);
@@ -261,8 +260,7 @@ async fn should_store_1000_episodes_without_performance_degradation() {
                 test_context(),
                 TaskType::CodeGeneration,
             )
-            .await
-            .unwrap();
+            .await;
 
         let step = create_test_step(1);
         memory.log_step(episode_id, step).await;
@@ -316,8 +314,7 @@ async fn should_store_10000_episodes_without_performance_degradation() {
                 test_context(),
                 TaskType::CodeGeneration,
             )
-            .await
-            .unwrap();
+            .await;
 
         let step = create_test_step(1);
         memory.log_step(episode_id, step).await;
@@ -367,8 +364,7 @@ async fn should_create_episodes_very_quickly() {
                 test_context(),
                 TaskType::CodeGeneration,
             )
-            .await
-            .unwrap();
+            .await;
         creation_times.push(start.elapsed());
     }
 
@@ -452,8 +448,7 @@ async fn should_not_leak_memory_under_continuous_operation() {
         let mem = memory.clone();
         let episode_id = mem
             .start_episode(format!("Task {}", i), test_context(), TaskType::Testing)
-            .await
-            .unwrap();
+            .await;
 
         for j in 0..5 {
             mem.log_step(episode_id, create_test_step(j + 1)).await;
@@ -499,8 +494,7 @@ async fn should_not_leak_memory_over_1000_iterations() {
         let mem = memory.clone();
         let episode_id = mem
             .start_episode(format!("Task {}", i), test_context(), TaskType::Testing)
-            .await
-            .unwrap();
+            .await;
 
         for j in 0..5 {
             mem.log_step(episode_id, create_test_step(j + 1)).await;
@@ -549,8 +543,7 @@ async fn should_cleanup_cache_when_exceeding_limits() {
     for i in 0..200 {
         let episode_id = memory
             .start_episode(format!("Task {}", i), test_context(), TaskType::Testing)
-            .await
-            .unwrap();
+            .await;
 
         memory
             .complete_episode(
@@ -632,8 +625,7 @@ async fn should_complete_episodes_concurrently_without_conflicts() {
                 test_context(),
                 TaskType::CodeGeneration,
             )
-            .await
-            .unwrap();
+            .await;
         episode_ids.push(id);
     }
 
@@ -714,8 +706,7 @@ async fn should_log_steps_very_quickly() {
     let memory = setup_test_memory();
     let episode_id = memory
         .start_episode("Test".to_string(), test_context(), TaskType::Testing)
-        .await
-        .unwrap();
+        .await;
 
     let mut step_times = vec![];
 
@@ -753,8 +744,7 @@ async fn should_complete_episodes_quickly_with_pattern_extraction() {
                 test_context(),
                 TaskType::CodeGeneration,
             )
-            .await
-            .unwrap();
+            .await;
 
         // Add a few steps
         for j in 1..=3 {

--- a/memory-core/tests/regression.rs
+++ b/memory-core/tests/regression.rs
@@ -284,8 +284,7 @@ async fn setup_memory_with_10k_episodes() -> SelfLearningMemory {
 
         let episode_id = memory
             .start_episode(format!("Task {}", i), context, TaskType::CodeGeneration)
-            .await
-            .unwrap();
+            .await;
 
         memory
             .complete_episode(
@@ -320,8 +319,7 @@ async fn should_maintain_pattern_extraction_accuracy_over_time() {
                 episode.context.clone(),
                 episode.task_type,
             )
-            .await
-            .unwrap();
+            .await;
 
         for step in &episode.steps {
             memory.log_step(episode_id, step.clone()).await;
@@ -372,8 +370,7 @@ async fn should_extract_all_pattern_types_correctly() {
             },
             TaskType::CodeGeneration,
         )
-        .await
-        .unwrap();
+        .await;
 
     // When: Logging an error followed by successful recovery
     let mut error_step = ExecutionStep::new(1, "attempt".to_string(), "Try".to_string());
@@ -461,8 +458,7 @@ async fn should_retrieve_relevant_episodes_by_domain() {
                 context,
                 TaskType::CodeGeneration,
             )
-            .await
-            .unwrap();
+            .await;
 
         memory
             .complete_episode(
@@ -490,8 +486,7 @@ async fn should_retrieve_relevant_episodes_by_domain() {
                 context,
                 TaskType::CodeGeneration,
             )
-            .await
-            .unwrap();
+            .await;
 
         memory
             .complete_episode(
@@ -546,8 +541,7 @@ async fn should_maintain_backward_compatible_public_api() {
     // Then: start_episode should work
     let episode_id = memory
         .start_episode("test".to_string(), test_context(), TaskType::Testing)
-        .await
-        .unwrap();
+        .await;
 
     // Then: log_step should work
     let step = create_test_step(1);
@@ -589,8 +583,7 @@ async fn should_maintain_data_structure_compatibility() {
 
     let episode_id = memory
         .start_episode("Test".to_string(), test_context(), TaskType::Testing)
-        .await
-        .unwrap();
+        .await;
 
     let episode = memory.get_episode(episode_id).await.unwrap();
 
@@ -653,8 +646,7 @@ async fn should_prevent_previously_fixed_bugs_from_recurring() {
 
     let episode_id = memory1
         .start_episode("Test".to_string(), test_context(), TaskType::CodeGeneration)
-        .await
-        .unwrap();
+        .await;
 
     for i in 1..=5 {
         memory1.log_step(episode_id, create_test_step(i)).await;
@@ -690,8 +682,7 @@ async fn should_prevent_previously_fixed_bugs_from_recurring() {
 
     let episode_id2 = memory2
         .start_episode("Test".to_string(), test_context(), TaskType::Testing)
-        .await
-        .unwrap();
+        .await;
 
     let outcome = TaskOutcome::Success {
         verdict: "Done".to_string(),
@@ -714,8 +705,7 @@ async fn should_prevent_previously_fixed_bugs_from_recurring() {
 
     let episode_id3 = memory3
         .start_episode("Test".to_string(), test_context(), TaskType::Testing)
-        .await
-        .unwrap();
+        .await;
 
     // When: Completing episode without adding any steps
     let result = memory3
@@ -757,8 +747,7 @@ async fn should_maintain_baseline_episode_creation_performance() {
                 test_context(),
                 TaskType::CodeGeneration,
             )
-            .await
-            .unwrap();
+            .await;
 
         for j in 1..=3 {
             memory.log_step(episode_id, create_test_step(j)).await;


### PR DESCRIPTION
## Summary
- Fixed compilation errors in examples and tests caused by invalid `.unwrap()` calls on `start_episode()` return value
- Resolved GitHub Actions CI failures across all platforms (macOS, Windows, Ubuntu)

## Root Cause
The `start_episode()` method was refactored to return `Uuid` directly instead of `Result<Uuid>`, but 9 files still had `.unwrap()` calls that caused compilation errors.

## Changes
- Removed `.unwrap()` calls after `.await` on `start_episode()` in:
  - `memory-core/examples/async_pattern_extraction.rs`
  - `memory-core/tests/async_extraction.rs`
  - `memory-core/tests/common/assertions.rs`
  - `memory-core/tests/common/helpers.rs`
  - `memory-core/tests/compliance.rs`
  - `memory-core/tests/input_validation.rs`
  - `memory-core/tests/learning_cycle.rs`
  - `memory-core/tests/performance.rs`
  - `memory-core/tests/regression.rs`

## Test Plan
- [x] Build passes: `cargo check --all-features --workspace`
- [x] All modified files compile successfully
- [ ] CI workflows pass on all platforms (will be verified by this PR)

## Impact
96 lines cleaned up, 48 lines of corrected code. No functional changes, only fixes compilation errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)