### PR TITLE
Potential fix for code scanning alert no. 52: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,6 +12,8 @@ name: Security
 jobs:
   secret-scan:
     name: Secret Scanning
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/d-o-hub/rust-self-learning-memory/security/code-scanning/52](https://github.com/d-o-hub/rust-self-learning-memory/security/code-scanning/52)

To fix the problem, we need to explicitly set the least-privilege permissions for the `secret-scan` job, which is missing a `permissions:` block. Based on its actions—checking out code and running Gitleaks—it only needs read access to repository contents. We should add the following block right under the job’s name (after line 14) and before the `runs-on` key:

```yaml
permissions:
  contents: read
```

This restricts the GITHUB_TOKEN for this job to read-only access to repository files and metadata, adhering to the principle of least privilege. No changes to functionality or other jobs are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
