### PR TITLE
Potential fix for code scanning alert no. 51: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,6 +17,8 @@ jobs:
   # Wait for quick check to pass on PRs
   check-quick-check:
     name: Check Quick Check Status
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/d-o-hub/rust-self-learning-memory/security/code-scanning/51](https://github.com/d-o-hub/rust-self-learning-memory/security/code-scanning/51)

The fix is to add a `permissions` block for the job `check-quick-check` in the `.github/workflows/benchmarks.yml` file. Since this job only waits for another workflow check to complete and does not push changes, create artifacts, or interact with PRs/issues, it only needs very basic read permissions. Add this under the job's definition, above `runs-on`.  
Specifically, add:
```yaml
permissions:
  contents: read
```
to job `check-quick-check` (after the name, before runs-on). No other imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
