### PR TITLE
Potential fix for code scanning alert no. 53: Cleartext logging of sensitive information

### DIFF
--- a/memory-cli/src/commands/embedding.rs
+++ b/memory-cli/src/commands/embedding.rs
@@ -150,7 +150,7 @@ pub fn show_config(config: &Config) -> Result<()> {
         } else {
             "⚠️  Not set"
         };
-        println!("  api_key_env: {} ({})", api_key_env, key_status);
+        println!("  api_key: {}", key_status);
     }
     println!();
 


### PR DESCRIPTION
Potential fix for [https://github.com/d-o-hub/rust-self-learning-memory/security/code-scanning/53](https://github.com/d-o-hub/rust-self-learning-memory/security/code-scanning/53)

In general, to fix cleartext logging issues you either (1) stop logging the sensitive value, (2) mask/redact it, or (3) encrypt it before logging. Here the problematic data is the `api_key_env` string, so the best fix without changing behavior too much is to avoid printing that value directly and instead print a generic, non-sensitive status message about whether an API key is configured.

Concretely, in `memory-cli/src/commands/embedding.rs` around line 147–154, we should change the `println!` that includes `api_key_env` so it no longer interpolates the variable name. We can keep the computed `key_status` string but adjust the output to something like `"  api_key: <status>"` or `"  api_key: configured/not configured"`. This way, we no longer send the tainted `api_key_env` data to the sink, satisfying the analysis, while still giving the user feedback about configuration. No new imports, methods, or additional definitions are needed; we only modify the format string and arguments of the existing `println!`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
