### PR TITLE
Potential fix for code scanning alert no. 54: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
   pre-release-tests:
     name: Pre-Release Full Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/d-o-hub/rust-self-learning-memory/security/code-scanning/54](https://github.com/d-o-hub/rust-self-learning-memory/security/code-scanning/54)

Generally, this issue is fixed by explicitly specifying a minimal `permissions` block either at the workflow root (to affect all jobs) or on individual jobs, ensuring each job’s `GITHUB_TOKEN` has only the scopes it needs. For a purely test-running job that only checks out code and runs commands, `contents: read` is typically sufficient.

In this workflow, there is already a tailored `permissions` block on `build-release`, so the cleanest and least disruptive fix is to add an explicit `permissions` block to the `pre-release-tests` job only. That keeps the existing behavior of `build-release` unchanged and aligns with the principle of least privilege for the testing job. Concretely, in `.github/workflows/release.yml`, under `jobs: pre-release-tests:`, add:

```yaml
    permissions:
      contents: read
```

right after the job header (for example, after `name: Pre-Release Full Tests`). No additional imports or external dependencies are required; this is purely a YAML workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
