### PR TITLE
[GOAP] B2.1 normalize ignored test reasons

### DIFF
--- a/plans/GOAP_B2.1_IGNORE_REASON_UPDATE_2026-02-17.md
+++ b/plans/GOAP_B2.1_IGNORE_REASON_UPDATE_2026-02-17.md
@@ -1,0 +1,23 @@
+# GOAP B2.1 Update: Ignored Test Reason Normalization
+**Date**: 2026-02-17
+**Status**: ✅ COMPLETE
+**Phase**: v0.1.16 Phase B.2 (Test Triage)
+
+## Objective
+Ensure intentionally ignored tests have explicit machine-readable reasons in `#[ignore = "..."]` form.
+
+## Baseline
+- Repository scan found 1 remaining bare `#[ignore]` attribute without explicit reason string:
+  - `tests/soak/stability_test.rs`
+
+## Action
+- Converted bare `#[ignore]` to explicit reason form for soak stability test.
+- Kept existing `// REASON:` comments for human-readable context and run instructions.
+
+## Validation
+- `rg -n "#\[ignore\]" --glob '*.rs'` returns 0 matches.
+- Remaining ignored tests use `#[ignore = "..."]` with explicit rationale.
+
+## Impact
+- Improves ignored-test auditability for GOAP B2.1/B2.2.
+- Aligns with sprint checklist requirement to document intentional ignores.

--- a/plans/V0.1.16_SPRINT_CHECKLIST.md
+++ b/plans/V0.1.16_SPRINT_CHECKLIST.md
@@ -16,7 +16,7 @@
   - [ ] Categorize: fixable / needs-infra / obsolete / intentionally-slow
   - [ ] Fix transient test failures
   - [ ] Remove obsolete tests
-  - [ ] Add `// REASON:` comments to intentionally ignored tests
+  - [x] Add `// REASON:` comments to intentionally ignored tests
   - [ ] Target: ≤10 ignored tests
   - [ ] Run `cargo test --all` to verify
   - [ ] Update ROADMAP_ACTIVE.md

--- a/tests/soak/stability_test.rs
+++ b/tests/soak/stability_test.rs
@@ -530,7 +530,10 @@ fn analyze_results(state: &SoakTestState) -> anyhow::Result<()> {
 
 /// Main test entry point
 #[tokio::test]
-#[ignore] // Ignore by default as it's a long-running test
+#[ignore = "Intentionally slow soak test; run manually with --ignored or nightly soak workflow"]
+// REASON: Long-running stability test (60s default, 24h with 'full-soak' feature)
+// Run manually: cargo test --test stability_test test_24_hour_stability -- --ignored
+// Category: Intentionally slow (soak test for production validation)
 async fn test_24_hour_stability() {
     println!("=== 24-Hour Stability Soak Test ===");
     println!("Test duration: {:?}", TEST_DURATION);


### PR DESCRIPTION
## Summary
- update v0.1.16 sprint checklist progress for B2 reason-comment task
- add GOAP progress note for ignored-test reason normalization
- convert remaining bare #[ignore] to explicit reason form in soak test

## Validation
- verified ignored test is explicitly categorized with reason text

Refs: GOAP_V0.1.16 Phase B2.1