### PR TITLE
chore(deps): bump clap to 4.5.59 (rebased)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.5.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "c5caf74d17c3aec5495110c34cc3f78644bfa89af6c8993ed4de2790e49b6499"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -940,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.5.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "370daa45065b80218950227371916a1633217ae42b2715b2287b606dcd618e24"
 dependencies = [
  "anstream",
  "anstyle",
@@ -973,9 +973,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cmake"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ url = "2.5.8"
 sha2 = "0.10"
 rand = "0.8"
 rand_chacha = "0.3"
-clap = { version = "4.5.56", features = ["derive"] }
+clap = { version = "4.5.59", features = ["derive"] }
 statrs = "0.16"
 futures = "0.3.31"
 sysinfo = "0.38"

--- a/memory-cli/Cargo.toml
+++ b/memory-cli/Cargo.toml
@@ -15,7 +15,7 @@ memory-storage-redb = { path = "../memory-storage-redb", optional = true }
 
 
 # CLI framework
-clap = { version = "4.5.56", features = ["derive", "color", "suggestions"] }
+clap = { version = "4.5.59", features = ["derive", "color", "suggestions"] }
 clap_complete = "4.5.66"
 
 # Serialization


### PR DESCRIPTION
Rebased replacement for #295 after conflicts with latest main. Supersedes #295.