### PR TITLE
fix(ci): resolve CLI test timeouts with serial execution

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,3 +18,12 @@ retries = 1
 slow-timeout = { period = "120s", terminate-after = 2 }
 failure-output = "final"
 status-level = "skip"
+
+# CLI integration tests that spawn cargo run need longer timeouts
+[[profile.default.overrides]]
+filter = "package(memory-cli) and test(Update)"
+slow-timeout = { period = "180s", terminate-after = 2 }
+
+[[profile.ci.overrides]]
+filter = "package(memory-cli) and test(Update)"
+slow-timeout = { period = "180s", terminate-after = 2 }

--- a/memory-cli/tests/cli_update_test.rs
+++ b/memory-cli/tests/cli_update_test.rs
@@ -1,5 +1,10 @@
 //! CLI integration tests for episode update command
+//!
+//! Note: These tests spawn `cargo run` which is slow, so they have extended
+//! timeouts in `.config/nextest.toml` and use `#[serial]` to avoid resource
+//! contention when running in parallel.
 
+use serial_test::serial;
 use std::process::Command;
 
 /// Helper function to run memory-cli command
@@ -22,6 +27,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[serial]
     fn test_update_command_help() {
         let (success, stdout, _stderr) = run_command(&["episode", "update", "--help"]);
         assert!(success);
@@ -34,6 +40,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_update_command_invalid_id() {
         let (success, _stdout, stderr) = run_command(&[
             "episode",
@@ -49,6 +56,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_update_command_description_only() {
         // This test requires a working memory system, so we'll just test the help
         let (success, stdout, _stderr) = run_command(&["episode", "update", "--help"]);
@@ -57,6 +65,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_update_command_with_dry_run() {
         let (success, stdout, _stderr) = run_command(&[
             "--dry-run", // Global flag must come before subcommand
@@ -72,6 +81,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_update_command_metadata_format() {
         let (success, stdout, _stderr) = run_command(&["episode", "update", "--help"]);
         assert!(success);


### PR DESCRIPTION
## Summary
- Add timeout overrides in nextest.toml for CLI integration tests (180s)
- Add `#[serial]` attribute to cli_update_test.rs tests to prevent resource contention when spawning cargo run processes
- All 2795 tests now pass without timeout

## Test plan
- [x] `cargo clippy --workspace --tests -- -D warnings` passes
- [x] `cargo nextest run --all` passes (2795 tests)
- [x] CI Quick Check should pass
- [x] CI tests should pass without timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)