### PR TITLE
fix(cli): add missing description for do-memory-cli

### DIFF
--- a/memory-cli/Cargo.toml
+++ b/memory-cli/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+description = "Command-line interface for do-memory-core episodic learning system"
 
 [dependencies]
 # Workspace dependencies


### PR DESCRIPTION
## Summary

Add missing description field to do-memory-cli Cargo.toml, required for crates.io publishing.

## Why

cargo publish requires a description field. Currently do-memory-cli is missing this, which will cause publish to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)