### PR TITLE
fix(publish): add version specs for inter-crate dependencies

### DIFF
--- a/memory-mcp/Cargo.toml
+++ b/memory-mcp/Cargo.toml
@@ -27,9 +27,9 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 # Local dependencies
-do-memory-core = { path = "../memory-core" }
-do-memory-storage-turso = { path = "../memory-storage-turso" }
-do-memory-storage-redb = { path = "../memory-storage-redb" }
+do-memory-core = { path = "../memory-core", version = "0.1.25" }
+do-memory-storage-turso = { path = "../memory-storage-turso", version = "0.1.25" }
+do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.25" }
 
 # MCP-specific dependencies
 parking_lot = "0.12.5"

--- a/memory-storage-redb/Cargo.toml
+++ b/memory-storage-redb/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/do-memory-storage-redb"
 
 [dependencies]
 # Core dependencies
-do-memory-core = { path = "../memory-core" }
+do-memory-core = { path = "../memory-core", version = "0.1.25" }
 
 # Async runtime
 tokio = { workspace = true }

--- a/memory-storage-turso/Cargo.toml
+++ b/memory-storage-turso/Cargo.toml
@@ -34,8 +34,8 @@ compression-gzip = ["flate2"]
 
 [dependencies]
 # Core dependencies
-do-memory-core = { path = "../memory-core", features = ["hybrid_search"] }
-do-memory-storage-redb = { path = "../memory-storage-redb" }
+do-memory-core = { path = "../memory-core", version = "0.1.25", features = ["hybrid_search"] }
+do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.25" }
 
 # Async runtime
 tokio = { workspace = true }


### PR DESCRIPTION
## Summary

Add version specifications to inter-crate dependencies, required for crates.io publishing.

**Problem:** `cargo publish` fails with:
```
all dependencies must have a version requirement specified when publishing.
dependency `do-memory-core` does not specify a version
```

**Changes:**
- Add `version = "0.1.25"` to all inter-crate dependencies
- do-memory-storage-turso → do-memory-core, do-memory-storage-redb
- do-memory-storage-redb → do-memory-core
- do-memory-mcp → do-memory-core, do-memory-storage-turso, do-memory-storage-redb

**After merge:** Will need to create v0.1.26 tag to trigger publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)