### PR TITLE
chore: bump version to 0.1.26 for crates.io publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,7 +1852,7 @@ checksum = "eb3b3318a6ce94bae6f71c71dfbb5c91059ea2afa3c2ac86d8fb9b1f6ea5de83"
 
 [[package]]
 name = "do-memory-benches"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-cli"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-core"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1946,7 +1946,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-examples"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "do-memory-core",
@@ -1961,7 +1961,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-mcp"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-storage-redb"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-storage-turso"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-test-utils"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2076,7 +2076,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "e2e-tests"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.25"
+version = "0.1.26"
 edition = "2024"
 authors = ["Self-Learning Memory Contributors"]
 license = "MIT"

--- a/memory-mcp/Cargo.toml
+++ b/memory-mcp/Cargo.toml
@@ -27,9 +27,9 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 # Local dependencies
-do-memory-core = { path = "../memory-core", version = "0.1.25" }
-do-memory-storage-turso = { path = "../memory-storage-turso", version = "0.1.25" }
-do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.25" }
+do-memory-core = { path = "../memory-core", version = "0.1.26" }
+do-memory-storage-turso = { path = "../memory-storage-turso", version = "0.1.26" }
+do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.26" }
 
 # MCP-specific dependencies
 parking_lot = "0.12.5"

--- a/memory-mcp/package.json
+++ b/memory-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "do-memory-mcp-server",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Model Context Protocol server with secure code execution sandbox for AI agents",
   "main": "index.js",
   "scripts": {

--- a/memory-storage-redb/Cargo.toml
+++ b/memory-storage-redb/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/do-memory-storage-redb"
 
 [dependencies]
 # Core dependencies
-do-memory-core = { path = "../memory-core", version = "0.1.25" }
+do-memory-core = { path = "../memory-core", version = "0.1.26" }
 
 # Async runtime
 tokio = { workspace = true }

--- a/memory-storage-turso/Cargo.toml
+++ b/memory-storage-turso/Cargo.toml
@@ -34,8 +34,8 @@ compression-gzip = ["flate2"]
 
 [dependencies]
 # Core dependencies
-do-memory-core = { path = "../memory-core", version = "0.1.25", features = ["hybrid_search"] }
-do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.25" }
+do-memory-core = { path = "../memory-core", version = "0.1.26", features = ["hybrid_search"] }
+do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.26" }
 
 # Async runtime
 tokio = { workspace = true }


### PR DESCRIPTION
## Summary

Bump version to 0.1.26 for crates.io publishing with fixed dependency specifications.

**Changes:**
- Update workspace version to 0.1.26
- Update inter-crate dependency versions to 0.1.26
- Update npm package version to 0.1.26

**After merge:** Create tag v0.1.26 to trigger release and publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)