### PR TITLE
docs: update roadmap with completed v0.1.27 sprint tasks

### DIFF
--- a/plans/GOALS.md
+++ b/plans/GOALS.md
@@ -24,49 +24,49 @@
    - Target: Tag pushed, GitHub Release created with multi-platform binaries
    - Status: ✅ Complete
 
-## v0.1.25 Sprint Goals (In Progress)
+## v0.1.27 Sprint Goals (In Progress)
 
 1. **WG-073**: Bayesian ranking with Wilson score
    - Priority: P1
-   - Owner: feature-implementer
+   - Owner: feature-bayesian
    - Target: Ranking module with confidence bounds
    - Status: ⏳ In Progress
 
 2. **WG-077**: MMR diversity retrieval
    - Priority: P1
-   - Owner: feature-implementer
+   - Owner: feature-mmr
    - Target: Diversity reranking in retrieval
-   - Status: ⏳ In Progress
+   - Status: ✅ Complete (already implemented in diversity/maximizer.rs)
 
 3. **WG-075**: Episode GC/TTL
    - Priority: P1
-   - Owner: feature-implementer
+   - Owner: feature-gc
    - Target: Retention policy and cleanup
    - Status: ⏳ In Progress
 
 4. **WG-078**: MCP Server Card
    - Priority: P2
-   - Owner: feature-implementer
+   - Owner: feature-mcp-card
    - Target: `.well-known/mcp.json` endpoint
-   - Status: ⏳ In Progress
+   - Status: ✅ Complete
 
 5. **WG-079**: spawn_blocking audit
    - Priority: P2
-   - Owner: code-reviewer
+   - Owner: audit-spawn-blocking
    - Target: All CPU-heavy async paths use spawn_blocking
    - Status: ⏳ In Progress
 
 6. **WG-084**: GitHub Pages restoration
    - Priority: P2
-   - Owner: docs
+   - Owner: infra-gh-pages
    - Target: mdBook + cargo doc deployment
-   - Status: ⏳ In Progress
+   - Status: ✅ Complete
 
 7. **WG-085**: llms.txt creation
    - Priority: P2
-   - Owner: docs
+   - Owner: infra-llms-txt
    - Target: LLM context file at repo root
-   - Status: ⏳ In Progress
+   - Status: ✅ Complete
 
 ---
 

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -8,17 +8,17 @@
 - **Branch**: `main`
 - **Version**: `0.1.26` (released 2026-04-01, published to crates.io)
 
-## Current Focus: v0.1.26 Sprint (In Progress)
+## Current Focus: v0.1.27 Sprint (In Progress)
 
 | Task | WG | Status | Details |
 |------|----|--------|---------|
 | Bayesian ranking | WG-073 | ⏳ In Progress | Wilson score from attribution data |
-| Diversity retrieval | WG-077 | ⏳ In Progress | MMR reranking |
+| Diversity retrieval | WG-077 | ✅ Complete | MMR reranking (already implemented in diversity/maximizer.rs) |
 | Episode GC/TTL | WG-075 | ⏳ In Progress | Retention policy |
-| MCP Server Card | WG-078 | ⏳ In Progress | `.well-known/mcp.json` |
+| MCP Server Card | WG-078 | ✅ Complete | `.well-known/mcp.json` |
 | spawn_blocking audit | WG-079 | ⏳ In Progress | CPU-heavy async paths |
-| GitHub Pages | WG-084 | ⏳ In Progress | mdBook + cargo doc |
-| llms.txt | WG-085 | ⏳ In Progress | LLM context file |
+| GitHub Pages | WG-084 | ✅ Complete | mdBook + cargo doc |
+| llms.txt | WG-085 | ✅ Complete | LLM context file |
 
 ### v0.1.26 Release (Complete)
 

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -22,9 +22,9 @@ See [STATUS/CURRENT.md](../STATUS/CURRENT.md) for detailed metrics.
 | Task | Description | Status | WG |
 |------|-------------|--------|----|
 | WG-073 | Bayesian ranking with Wilson score from attribution data | ⏳ In Progress | 73 |
-| WG-077 | MMR diversity retrieval for search results | ⏳ In Progress | 77 |
+| WG-077 | MMR diversity retrieval for search results | ✅ Complete | 77 |
 | WG-075 | Episode GC/TTL with retention policy | ⏳ In Progress | 75 |
-| WG-078 | MCP Server Card at `.well-known/mcp.json` | ⏳ In Progress | 78 |
+| WG-078 | MCP Server Card at `.well-known/mcp.json` | ✅ Complete | 78 |
 
 ### P2: Code Quality
 
@@ -36,8 +36,8 @@ See [STATUS/CURRENT.md](../STATUS/CURRENT.md) for detailed metrics.
 
 | Task | Description | Status |
 |------|-------------|--------|
-| WG-084 | Restore GitHub Pages with mdBook | ⏳ In Progress |
-| WG-085 | Add llms.txt for LLM context | ⏳ In Progress |
+| WG-084 | Restore GitHub Pages with mdBook | ✅ Complete |
+| WG-085 | Add llms.txt for LLM context | ✅ Complete |
 
 ---
 


### PR DESCRIPTION
## Summary

- WG-077 (MMR diversity): marked complete (already implemented in `diversity/maximizer.rs`)
- WG-078 (MCP Server Card): marked complete (`.well-known/mcp.json`)
- WG-084 (GitHub Pages): marked complete (mdBook + cargo doc)
- WG-085 (llms.txt): marked complete (LLM context file)
- Renamed sprint section from v0.1.25 to v0.1.27

## Remaining Tasks

- WG-073: Bayesian ranking with Wilson score (in progress)
- WG-075: Episode GC/TTL with retention policy (in progress)
- WG-079: spawn_blocking audit (in progress)

## Test plan

- [ ] Verify ROADMAP_ACTIVE.md renders correctly
- [ ] Verify GOALS.md reflects accurate status
- [ ] Verify GOAP_STATE.md reflects accurate status

🤖 Generated with [Claude Code](https://claude.com/claude-code)