### PR TITLE
fix(cli): resolve compile errors and update test for turso feature

### DIFF
--- a/memory-cli/src/commands/episode/core/bulk.rs
+++ b/memory-cli/src/commands/episode/core/bulk.rs
@@ -4,8 +4,6 @@
 
 use crate::config::Config;
 #[cfg(feature = "turso")]
-use crate::errors::{EnhancedError, helpers};
-#[cfg(feature = "turso")]
 use crate::output::Output;
 use crate::output::OutputFormat;
 use do_memory_core::SelfLearningMemory;

--- a/memory-cli/src/commands/episode/core/complete.rs
+++ b/memory-cli/src/commands/episode/core/complete.rs
@@ -3,8 +3,6 @@
 use super::types::TaskOutcome;
 use crate::config::Config;
 #[cfg(feature = "turso")]
-use crate::errors::{EnhancedError, helpers};
-#[cfg(feature = "turso")]
 use crate::output::Output;
 use crate::output::OutputFormat;
 use do_memory_core::SelfLearningMemory;

--- a/memory-cli/src/commands/episode/core/log_step.rs
+++ b/memory-cli/src/commands/episode/core/log_step.rs
@@ -2,8 +2,6 @@
 
 use crate::config::Config;
 #[cfg(feature = "turso")]
-use crate::errors::{EnhancedError, helpers};
-#[cfg(feature = "turso")]
 use crate::output::Output;
 use crate::output::OutputFormat;
 use do_memory_core::SelfLearningMemory;

--- a/memory-cli/src/commands/episode/core/view.rs
+++ b/memory-cli/src/commands/episode/core/view.rs
@@ -2,8 +2,6 @@
 
 use crate::config::Config;
 #[cfg(feature = "turso")]
-use crate::errors::{EnhancedError, helpers};
-#[cfg(feature = "turso")]
 use crate::output::Output;
 use crate::output::OutputFormat;
 use do_memory_core::SelfLearningMemory;

--- a/memory-cli/src/commands/pattern/core/batch.rs
+++ b/memory-cli/src/commands/pattern/core/batch.rs
@@ -269,11 +269,7 @@ async fn execute_batch_update(
 
     if let Some(rate) = success_rate {
         for pattern in &mut updated_patterns {
-            if let Pattern::DecisionPoint {
-                ref mut outcome_stats,
-                ..
-            } = pattern
-            {
+            if let Pattern::DecisionPoint { outcome_stats, .. } = pattern {
                 let total = outcome_stats.total_count;
                 outcome_stats.success_count = (rate * total as f32) as usize;
                 outcome_stats.failure_count = total - outcome_stats.success_count;

--- a/memory-cli/src/config/storage.rs
+++ b/memory-cli/src/config/storage.rs
@@ -289,9 +289,11 @@ async fn determine_storage_combination(
             // Only redb configured - try to set up local SQLite as durable storage
             #[cfg(feature = "turso")]
             {
-                match try_setup_local_sqlite_for_redis(redb, memory_config_clone).await {
+                match try_setup_local_sqlite_for_redis(redb.clone(), memory_config_clone.clone())
+                    .await
+                {
                     Ok((storage_type, memory)) => (storage_type, StorageType::Redb, memory),
-                    Err(_) => create_redb_only_memory(memory_config, redb),
+                    Err(_) => create_redb_only_memory(memory_config_clone, redb),
                 }
             }
             #[cfg(not(feature = "turso"))]

--- a/memory-cli/tests/episode_update_test.rs
+++ b/memory-cli/tests/episode_update_test.rs
@@ -238,25 +238,30 @@ mod tests {
     }
 
     /// Test that tag operations persist across storage
+    /// Note: This test requires TURSO_DB_URL and TURSO_AUTH_TOKEN environment variables
+    /// and is ignored by default. Run with `cargo test -- --ignored` to execute.
     #[tokio::test]
     #[cfg(feature = "turso")]
+    #[ignore = "requires external Turso database configuration"]
     async fn test_update_persists_to_storage() {
-        use do_memory_storage_turso::TursoClient;
+        use do_memory_core::MemoryConfig;
+        use do_memory_storage_redb::RedbStorage;
+        use do_memory_storage_turso::TursoStorage;
         use std::sync::Arc;
+        use tempfile::NamedTempFile;
 
-        // This test requires actual Turso setup, so we'll skip if not configured
-        let db_url = std::env::var("TURSO_DB_URL").ok();
-        let auth_token = std::env::var("TURSO_AUTH_TOKEN").ok();
+        // This test requires actual Turso setup
+        let db_url = std::env::var("TURSO_DB_URL").expect("TURSO_DB_URL must be set");
+        let auth_token = std::env::var("TURSO_AUTH_TOKEN").expect("TURSO_AUTH_TOKEN must be set");
 
-        if db_url.is_none() || auth_token.is_none() {
-            println!(
-                "Skipping storage persistence test - TURSO_DB_URL and TURSO_AUTH_TOKEN not set"
-            );
-            return;
-        }
-
-        let turso = TursoClient::new(db_url.unwrap(), auth_token.unwrap()).unwrap();
-        let memory = do_memory_core::SelfLearningMemory::with_storage(Arc::new(turso), None, None);
+        let turso = TursoStorage::new(&db_url, &auth_token).await.unwrap();
+        let temp_file = NamedTempFile::new().unwrap();
+        let redb = RedbStorage::new(temp_file.path()).await.unwrap();
+        let memory = do_memory_core::SelfLearningMemory::with_storage(
+            MemoryConfig::default(),
+            Arc::new(turso),
+            Arc::new(redb),
+        );
 
         // Create episode
         let episode_id = memory

--- a/plans/STATUS/CLI_TURSO_SEGFAULT.md
+++ b/plans/STATUS/CLI_TURSO_SEGFAULT.md
@@ -1,0 +1,50 @@
+# CLI Turso Storage Segfault Issue
+
+**Date**: 2026-04-02
+**Severity**: P1 - Critical
+**Status**: Under Investigation
+
+## Problem
+
+The CLI crashes with a segmentation fault when using file-based Turso databases:
+
+```
+SQL attempt 1 failed: SQLite failure: `bad parameter or other API misuse`, retrying...
+Segmentation fault
+```
+
+## Root Cause Analysis
+
+1. **Error occurs during schema initialization** - The `initialize_schema()` method fails with "bad parameter or other API misuse"
+2. **Segfault during retry logic** - After the SQL error, the CLI crashes instead of handling the error gracefully
+
+## Affected Code
+
+- `memory-storage-turso/src/lib_impls/helpers.rs:173` - `execute_with_retry`
+- `memory-storage-turso/src/turso_config.rs:13` - `initialize_schema`
+
+## Potential Causes
+
+1. **libSQL file URL handling** - May be an issue with how libSQL handles file: URLs vs http:// URLs
+2. **Threading/async issue** - The segfault could be caused by a race condition or memory safety issue
+3. **Resource cleanup** - Connection might not be properly closed after error
+
+## Workaround
+
+Use redb-only storage for local development:
+
+```bash
+# Build without turso feature
+cargo build --release -p do-memory-cli
+
+# Or use turso dev server with http:// URL
+turso dev --db-file ./data/memory.db --port 8080
+TURSO_URL="http://127.0.0.1:8080" TURSO_TOKEN="" ./target/release/do-memory-cli health check
+```
+
+## Next Steps
+
+1. Add error handling to prevent segfault on SQL errors
+2. Investigate libSQL file URL handling
+3. Add integration tests for file-based storage
+4. Consider using rusqlite directly for file-based databases


### PR DESCRIPTION
## Summary

- Fix ownership issue in storage.rs - clone `memory_config_clone` before passing to async function
- Fix Rust 2024 pattern matching - remove `ref mut` in batch.rs (implicit borrowing)
- Remove unused imports in episode command files (bulk.rs, complete.rs, log_step.rs, view.rs)
- Update test to use correct `SelfLearningMemory::with_storage` signature
- Document CLI Turso segfault issue in `plans/STATUS/CLI_TURSO_SEGFAULT.md`

## Issues Found

1. **Compile error**: `memory_config_clone` was moved to async function but needed for error case
2. **Rust 2024 incompatibility**: `ref mut` pattern not allowed with implicit borrowing
3. **Unused imports**: `EnhancedError` and `helpers` imports in episode commands
4. **Test API mismatch**: Test used old `with_storage` signature without `MemoryConfig`
5. **Turso segfault**: CLI crashes with segfault when using file-based Turso databases (documented for future fix)

## Test plan

- [x] All tests pass with default features (redb-only)
- [x] CLI compiles with `--features turso`
- [x] Clippy passes with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)