### PR TITLE
⚡ Bolt: Zero-copy episodic memory retrieval caching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-03-27 - [Zero-copy Episodic Memory Retrieval Caching]
+**Learning:** The episodic memory retrieval cache was previously performing deep clones of `Episode` structs (including strings, maps, and vectors) on both cache hits and insertions. Storing `Arc<[Arc<Episode>]>` instead of `Arc<[Episode]>` enables true zero-copy retrieval by only cloning atomic pointers, which is significantly more efficient for large result sets.
+**Action:** When implementing caches for shared data structures, prefer storing collections of `Arc`s to avoid expensive deep clones during retrieval.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,9 +1464,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"

--- a/benches/query_cache_benchmark.rs
+++ b/benches/query_cache_benchmark.rs
@@ -45,6 +45,7 @@ fn create_test_episode(id: usize) -> Episode {
         salient_features: None,
         metadata: std::collections::HashMap::new(),
         tags: Vec::new(),
+        checkpoints: Vec::new(),
     };
 
     // Add 20 execution steps to make it realistic

--- a/memory-core/src/retrieval/cache/lru.rs
+++ b/memory-core/src/retrieval/cache/lru.rs
@@ -104,14 +104,9 @@ impl QueryCache {
                 return None;
             }
 
-            // Cache hit - convert Arc<[Episode]> to Vec<Arc<Episode>>
-            // Dereference each Episode to get &Episode, then clone into Arc<Episode>
+            // Cache hit - clone the Arc pointers from the slice
             metrics.hits += 1;
-            let episodes: Vec<Arc<Episode>> = result
-                .episodes
-                .iter()
-                .map(|ep| Arc::new(ep.clone()))
-                .collect();
+            let episodes: Vec<Arc<Episode>> = result.episodes.to_vec();
             Some(episodes)
         } else {
             // Cache miss
@@ -124,9 +119,9 @@ impl QueryCache {
     /// Store a query result in the cache
     pub fn put(&self, key: CacheKey, episodes: Vec<Arc<Episode>>) {
         let key_hash = key.compute_hash();
-        // Convert Vec<Arc<Episode>> to Arc<[Episode]> by cloning each Episode
-        let episodes_slice: Arc<[Episode]> =
-            episodes.iter().map(|ep| ep.as_ref().clone()).collect();
+        // Convert Vec<Arc<Episode>> to Arc<[Arc<Episode>]>
+        // This is zero-copy for the episodes themselves
+        let episodes_slice: Arc<[Arc<Episode>]> = episodes.into();
         let cached_result = CachedResult {
             episodes: episodes_slice,
             cached_at: Instant::now(),

--- a/memory-core/src/retrieval/cache/types.rs
+++ b/memory-core/src/retrieval/cache/types.rs
@@ -88,7 +88,7 @@ impl CacheKey {
 #[derive(Debug, Clone)]
 pub struct CachedResult {
     /// Cached episodes (Arc for zero-copy retrieval)
-    pub episodes: Arc<[Episode]>,
+    pub episodes: Arc<[Arc<Episode>]>,
     /// Time when this entry was cached
     pub cached_at: Instant,
     /// Time-to-live for this entry


### PR DESCRIPTION
💡 What: Optimized the episodic memory retrieval cache to avoid deep-cloning of `Episode` structs.
🎯 Why: Previously, every cache hit or insertion would deep-clone all episodes in the result set, which is expensive for large episodes containing strings, maps, and vectors.
📊 Impact: Eliminates N heap allocations and N deep clones per cache hit or insertion. Retrieval is now truly zero-copy for episodes.
🔬 Measurement: Verified with `memory-core` unit tests (11/11 passed) and successfully ran `query_cache_benchmark` after fixing a minor struct field mismatch.

---
*PR created automatically by Jules for task [11635794231032606968](https://jules.google.com/task/11635794231032606968) started by @d-o-hub*