### PR TITLE
fix(skills): align frontmatter name with directory

### DIFF
--- a/.agents/skills/memory-cli-ops/SKILL.md
+++ b/.agents/skills/memory-cli-ops/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: do-memory-cli-ops
+name: memory-cli-ops
 description: Execute and troubleshoot do-memory-cli commands for episode management, pattern analysis, and storage operations. Use this skill when running CLI commands, debugging CLI issues, explaining command usage, or guiding users through CLI workflows.
 ---
 

--- a/.agents/skills/memory-mcp/SKILL.md
+++ b/.agents/skills/memory-mcp/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: do-memory-mcp
+name: memory-mcp
 description: Use and troubleshoot the Memory MCP server for episodic memory retrieval and pattern analysis. Use when working with MCP server tools, validating the MCP implementation, or debugging MCP server issues.
 ---
 


### PR DESCRIPTION
## Summary
- Fix frontmatter `name` field to match directory names per skill-creator naming rule
- `memory-cli-ops`: name `do-memory-cli-ops` → `memory-cli-ops`
- `memory-mcp`: name `do-memory-mcp` → `memory-mcp`

## Validation
All 31 skills now pass frontmatter validation:
- 0 errors
- 0 name mismatches
- All have proper `---` delimiters
- All have `name` and `description` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)