### PR TITLE
chore: bump version to 0.1.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@
 - **Skills consolidation** (WG-137) - Reduced from 36→31 skills
 - **Planning docs refresh** (WG-138/139) - Fixed CURRENT.md contradictions, updated CODEBASE_ANALYSIS_LATEST.md
 
+### Fixed
+
+- **Gist module LOC compliance** - Split `gist.rs` (997 LOC) into 6 files under 500 LOC limit
+  - `mod.rs` (75 LOC), `config.rs` (97 LOC), `types.rs` (52 LOC)
+  - `extractor.rs` (271 LOC), `reranker.rs` (311 LOC), `tests.rs` (222 LOC)
+- **Benchmark crate name imports** - Fixed `memory_benches` → `do_memory_benches` imports
+- **Episode struct fields** - Added missing `checkpoints` field to benchmark Episode initialization
+
 ## [0.1.30] - 2026-04-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,7 +1181,7 @@ checksum = "eb3b3318a6ce94bae6f71c71dfbb5c91059ea2afa3c2ac86d8fb9b1f6ea5de83"
 
 [[package]]
 name = "do-memory-benches"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-cli"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-core"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-examples"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "do-memory-core",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-mcp"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-storage-redb"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-storage-turso"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-test-utils"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1394,7 +1394,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "e2e-tests"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.30"
+version = "0.1.31"
 edition = "2024"
 authors = ["Self-Learning Memory Contributors"]
 license = "MIT"

--- a/memory-mcp/Cargo.toml
+++ b/memory-mcp/Cargo.toml
@@ -27,9 +27,9 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 # Local dependencies
-do-memory-core = { path = "../memory-core", version = "0.1.30" }
-do-memory-storage-turso = { path = "../memory-storage-turso", version = "0.1.30" }
-do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.30" }
+do-memory-core = { path = "../memory-core", version = "0.1.31" }
+do-memory-storage-turso = { path = "../memory-storage-turso", version = "0.1.31" }
+do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.31" }
 
 # MCP-specific dependencies
 parking_lot = "0.12.5"

--- a/memory-storage-redb/Cargo.toml
+++ b/memory-storage-redb/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/do-memory-storage-redb"
 
 [dependencies]
 # Core dependencies
-do-memory-core = { path = "../memory-core", version = "0.1.30" }
+do-memory-core = { path = "../memory-core", version = "0.1.31" }
 
 # Async runtime
 tokio = { workspace = true }

--- a/memory-storage-turso/Cargo.toml
+++ b/memory-storage-turso/Cargo.toml
@@ -34,8 +34,8 @@ compression-gzip = ["flate2"]
 
 [dependencies]
 # Core dependencies
-do-memory-core = { path = "../memory-core", version = "0.1.30", features = ["hybrid_search"] }
-do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.30" }
+do-memory-core = { path = "../memory-core", version = "0.1.31", features = ["hybrid_search"] }
+do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.31" }
 
 # Async runtime
 tokio = { workspace = true }


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.1.30 to 0.1.31
- Update all inter-crate dependency version specs
- Update CHANGELOG with recent fixes (gist module split, benchmark imports)

## Changes since v0.1.30

- **CSM cascading retrieval** (WG-128/129/130/131)
- **Hierarchical/gist reranking** (WG-118)
- **AgentFS SDK stub documentation**
- **Gist module LOC compliance** - Split 997 LOC → 6 files
- **Benchmark fixes** - Crate name imports, Episode checkpoints field

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace -D warnings` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)