### PR TITLE
docs(plans): update release docs for v0.1.31

### DIFF
--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1,7 +1,7 @@
 # GOAP State Snapshot
 
-- **Last Updated**: 2026-04-21 (comprehensive analysis + CSM integration)
-- **Version**: `0.1.30` (workspace, released)
+- **Last Updated**: 2026-04-22 (v0.1.31 release)
+- **Version**: `0.1.31` (workspace, released)
 - **Branch**: `main`
 - **Validation**: `plans/STATUS/VALIDATION_LATEST.md`
 - **Gap Analysis**: `plans/STATUS/GAP_ANALYSIS_LATEST.md`
@@ -9,7 +9,7 @@
 
 ---
 
-## v0.1.31 Sprint (Planning 🔵)
+## v0.1.31 Sprint (Complete ✅)
 
 ### GOAP Analysis (2026-04-20)
 
@@ -191,9 +191,9 @@ Impact analysis of `d-o-hub/github-template-ai-agents` and `d-o-hub/chaotic_sema
 
 | Metric | Value | Target |
 |--------|-------|--------|
-| Workspace version | 0.1.30 | — |
-| Latest GitHub release | v0.1.30 | verified 2026-04-20 |
-| Publishable workspace crates | 6 | all at 0.1.30 |
+| Workspace version | 0.1.31 | — |
+| Latest GitHub release | v0.1.31 | verified 2026-04-22 |
+| Publishable workspace crates | 6 | all at 0.1.31 |
 | Total tests | 2,856 | — |
 | Ignored tests | 123 skipped | ceiling ≤125 |
 | `allow(dead_code)` (prod) | 0 | ≤25 | ✅ All in test/bench files (36 total) |

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -1,8 +1,7 @@
 # Active Development Roadmap
 
-**Last Updated**: 2026-04-21 (comprehensive analysis + CSM cascade integration)
-**Released Version**: v0.1.30 (crates.io + GitHub Release)
-**Unreleased on main**: v0.1.31 planning focused on CPU-local retrieval (CSM), token efficiency, and skills consolidation
+**Last Updated**: 2026-04-22 (v0.1.31 release)
+**Released Version**: v0.1.31 (crates.io + GitHub Release)
 **Branch**: `main` (all PRs merged)
 **Epic**: [#373](https://github.com/d-o-hub/rust-self-learning-memory/issues/373) — ALL ISSUES CLOSED
 
@@ -10,27 +9,26 @@
 
 ## Current State
 
-`v0.1.30` was released on 2026-04-16. Workspace and publishable crate versions remain `0.1.30` while `v0.1.31` planning is redirected toward lower CPU usage, lower prompt/token usage, and release/package truth-source cleanup.
+`v0.1.31` was released on 2026-04-22. Workspace and publishable crate versions are `0.1.31`.
 
-Verified publishable workspace packages at `0.1.30`: `do-memory-core`, `do-memory-storage-redb`, `do-memory-storage-turso`, `do-memory-mcp`, `do-memory-cli`, `do-memory-examples`.
-
-The 2026-04-21 comprehensive analysis added a CSM integration phase (BM25+HDC+ConceptGraph cascading retrieval) targeting 50-70% API call elimination, plus 6 new research papers and housekeeping WGs.
+Verified publishable workspace packages at `0.1.31`: `do-memory-core`, `do-memory-storage-redb`, `do-memory-storage-turso`, `do-memory-mcp`, `do-memory-cli`, `do-memory-examples`.
 
 See [STATUS/CURRENT.md](../STATUS/CURRENT.md) for detailed metrics.
 
 ---
 
-## Upcoming Sprint — v0.1.31 (Planning)
+## Completed Sprint — v0.1.31 ✅
 
 **Source**: Release/package verification (2026-04-20) + comprehensive analysis + 2026 academic paper review
 **ADR**: ADR-053 (Accepted)
+**Release**: v0.1.31 published 2026-04-22
 
-### Phase 0: Release & Package Truth
+### Phase 0: Release & Package Truth ✅ Complete
 
 | Task | Description | Status | WG |
 |------|-------------|--------|-----|
 | WG-111 | Verify `v0.1.30` GitHub release and publishable crate parity | ✅ Complete | 111 |
-| WG-112 | Bump workspace + publishable crates to `0.1.31`, update CHANGELOG | 🔵 Planned | 112 |
+| WG-112 | Bump workspace + publishable crates to `0.1.31`, update CHANGELOG | ✅ Complete | 112 |
 | WG-113 | Refresh stale roadmap/status/GOAP truth sources after release verification | ✅ Complete | 113 |
 
 ### Phase 1: CPU Efficiency

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -1,7 +1,7 @@
 # Project Status — Self-Learning Memory System
 
-**Last Updated**: 2026-04-22 (fresh metrics collection + analysis refresh)
-**Released Version**: v0.1.30 (crates.io + GitHub Release), v0.1.31 planning
+**Last Updated**: 2026-04-22 (v0.1.31 release)
+**Released Version**: v0.1.31 (crates.io + GitHub Release)
 **Branch**: `main` (clean)
 **Epic**: [#373](https://github.com/d-o-hub/rust-self-learning-memory/issues/373) — ALL ISSUES CLOSED
 **Edition**: Rust 2024
@@ -13,9 +13,9 @@
 | Metric | Value | Target | Status |
 |--------|-------|--------|--------|
 | Workspace members | 9 | — | — |
-| Workspace version | 0.1.30 | — | ✅ |
-| Latest GitHub release | v0.1.30 | — | ✅ Published 2026-04-16 |
-| Publishable workspace crates | 6 | — | ✅ All at `0.1.30` |
+| Workspace version | 0.1.31 | — | ✅ |
+| Latest GitHub release | v0.1.31 | — | ✅ Published 2026-04-22 |
+| Publishable workspace crates | 6 | — | ✅ All at `0.1.31` |
 | Total tests | 2,902 | — | 2,901 passing, 1 flaky (pre-existing) |
 | Skipped/ignored tests | 123 | ≤125 ceiling | ✅ 70 blocked by upstream libsql bug (ADR-027) |
 | Timed-out tests | 0 | 0 | ✅ |


### PR DESCRIPTION
## Summary

Update planning documents to reflect v0.1.31 release (published 2026-04-22):

- STATUS/CURRENT.md: Version 0.1.31, release date 2026-04-22
- ROADMAP_ACTIVE.md: Sprint marked complete, released version updated
- GOAP_STATE.md: Version and sprint status updated

## Test plan

- [x] Documents reflect actual release state
- [x] Version numbers consistent across files

🤖 Generated with [Claude Code](https://claude.com/claude-code)