### PR TITLE
⚡ [performance] Use tokio async create_dir_all in async contexts

### DIFF
--- a/memory-cli/src/config/storage.rs
+++ b/memory-cli/src/config/storage.rs
@@ -146,7 +146,7 @@ async fn try_local_sqlite_fallback(
         if local_db_url.starts_with("sqlite:") || local_db_url.starts_with("file:") {
             let db_path = extract_db_path(&local_db_url);
 
-            ensure_directory_exists(db_path)?;
+            ensure_directory_exists(db_path).await?;
 
             match do_memory_storage_turso::TursoStorage::new(&format!("file:{}", db_path), "").await
             {
@@ -183,9 +183,10 @@ fn extract_db_path(url: &str) -> &str {
 }
 
 /// Ensure parent directory exists
-fn ensure_directory_exists(path: &str) -> Result<()> {
+async fn ensure_directory_exists(path: &str) -> Result<()> {
     if let Some(parent) = std::path::Path::new(path).parent() {
-        std::fs::create_dir_all(parent)
+        tokio::fs::create_dir_all(parent)
+            .await
             .context(format!("Failed to create directory: {}", parent.display()))?;
     }
     Ok(())
@@ -337,7 +338,7 @@ async fn try_setup_local_sqlite_for_redis(
     if let Ok(local_db_url) = std::env::var("LOCAL_DATABASE_URL") {
         if local_db_url.starts_with("sqlite:") || local_db_url.starts_with("file:") {
             let db_path = extract_db_path(&local_db_url);
-            ensure_directory_exists(db_path)?;
+            ensure_directory_exists(db_path).await?;
 
             match do_memory_storage_turso::TursoStorage::new(&format!("file:{}", db_path), "").await
             {
@@ -407,7 +408,7 @@ async fn try_setup_fallback_storage(
     if let Ok(local_db_url) = std::env::var("LOCAL_DATABASE_URL") {
         if local_db_url.starts_with("sqlite:") || local_db_url.starts_with("file:") {
             let db_path = extract_db_path(&local_db_url);
-            ensure_directory_exists(db_path)?;
+            ensure_directory_exists(db_path).await?;
 
             match do_memory_storage_turso::TursoStorage::new(&format!("file:{}", db_path), "").await
             {

--- a/memory-core/src/embeddings/local.rs
+++ b/memory-core/src/embeddings/local.rs
@@ -55,7 +55,7 @@ impl LocalEmbeddingProvider {
     /// # Returns
     /// Configured local embedding provider
     pub async fn new(config: LocalConfig) -> Result<Self> {
-        let cache_dir = Self::get_cache_dir()?;
+        let cache_dir = Self::get_cache_dir().await?;
 
         let provider = Self {
             config,
@@ -139,7 +139,7 @@ impl LocalEmbeddingProvider {
     }
 
     /// Get the cache directory for models
-    fn get_cache_dir() -> Result<std::path::PathBuf> {
+    async fn get_cache_dir() -> Result<std::path::PathBuf> {
         let home = std::env::var("HOME")
             .or_else(|_| std::env::var("USERPROFILE"))
             .context("Could not determine home directory")?;
@@ -149,7 +149,9 @@ impl LocalEmbeddingProvider {
             .join("memory-core")
             .join("embeddings");
 
-        std::fs::create_dir_all(&cache_dir).context("Failed to create cache directory")?;
+        tokio::fs::create_dir_all(&cache_dir)
+            .await
+            .context("Failed to create cache directory")?;
 
         Ok(cache_dir)
     }

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,6 +1,0 @@
-💡 **What:** Replaced synchronous `std::fs::create_dir_all` calls inside `memory-cli/src/config/storage.rs` and `memory-core/src/embeddings/local.rs` with `tokio::fs::create_dir_all().await`. Propagated the async signatures (`ensure_directory_exists` and `get_cache_dir`) appropriately.
-
-🎯 **Why:** To adhere to async/await best practices and prevent blocking the Tokio executor thread during initialization processes. When a synchronous I/O call blocks a worker thread in an asynchronous runtime, it effectively stalls other concurrent tasks until the operation completes, resulting in lower throughput and potential starvation.
-
-📊 **Measured Improvement:**
-The optimization focuses on architectural correctness rather than a noticeable absolute speedup. Since directory creation primarily happens once during startup (or lazy initialization), a microbenchmark would only show minimal differences (in the realm of microseconds). Therefore, this change is not evaluated on numerical improvement, but instead guarantees the removal of a blocking sync call inside the Tokio async executor.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,6 @@
+💡 **What:** Replaced synchronous `std::fs::create_dir_all` calls inside `memory-cli/src/config/storage.rs` and `memory-core/src/embeddings/local.rs` with `tokio::fs::create_dir_all().await`. Propagated the async signatures (`ensure_directory_exists` and `get_cache_dir`) appropriately.
+
+🎯 **Why:** To adhere to async/await best practices and prevent blocking the Tokio executor thread during initialization processes. When a synchronous I/O call blocks a worker thread in an asynchronous runtime, it effectively stalls other concurrent tasks until the operation completes, resulting in lower throughput and potential starvation.
+
+📊 **Measured Improvement:**
+The optimization focuses on architectural correctness rather than a noticeable absolute speedup. Since directory creation primarily happens once during startup (or lazy initialization), a microbenchmark would only show minimal differences (in the realm of microseconds). Therefore, this change is not evaluated on numerical improvement, but instead guarantees the removal of a blocking sync call inside the Tokio async executor.


### PR DESCRIPTION
💡 **What:** Replaced synchronous `std::fs::create_dir_all` calls inside `memory-cli/src/config/storage.rs` and `memory-core/src/embeddings/local.rs` with `tokio::fs::create_dir_all().await`. Propagated the async signatures (`ensure_directory_exists` and `get_cache_dir`) appropriately.

🎯 **Why:** To adhere to async/await best practices and prevent blocking the Tokio executor thread during initialization processes. When a synchronous I/O call blocks a worker thread in an asynchronous runtime, it effectively stalls other concurrent tasks until the operation completes, resulting in lower throughput and potential starvation.

📊 **Measured Improvement:** 
The optimization focuses on architectural correctness rather than a noticeable absolute speedup. Since directory creation primarily happens once during startup (or lazy initialization), a microbenchmark would only show minimal differences (in the realm of microseconds). Therefore, this change is not evaluated on numerical improvement, but instead guarantees the removal of a blocking sync call inside the Tokio async executor.

---
*PR created automatically by Jules for task [5435721918941470479](https://jules.google.com/task/5435721918941470479) started by @d-o-hub*