### PR TITLE
🧹 [code health] refactor: replace unsafe unwrap on mistral provider init

### DIFF
--- a/memory-core/src/embeddings/mistral/client.rs
+++ b/memory-core/src/embeddings/mistral/client.rs
@@ -280,27 +280,23 @@ mod tests {
     use crate::embeddings::provider::EmbeddingProvider;
 
     #[test]
-    fn test_provider_creation() {
+    fn test_provider_creation() -> anyhow::Result<()> {
         let config = MistralConfig::mistral_embed();
-        let result = MistralEmbeddingProvider::new("test_key".to_string(), config);
-        assert!(result.is_ok());
-
-        let provider = result.unwrap();
+        let provider = MistralEmbeddingProvider::new("test_key".to_string(), config)?;
         assert_eq!(provider.model_name(), "mistral-embed");
         assert_eq!(provider.embedding_dimension(), 1024);
+        Ok(())
     }
 
     #[test]
-    fn test_provider_creation_codestral() {
+    fn test_provider_creation_codestral() -> anyhow::Result<()> {
         let config = MistralConfig::codestral_embed()
             .with_output_dimension(512)
             .with_output_dtype(OutputDtype::Int8);
-        let result = MistralEmbeddingProvider::new("test_key".to_string(), config);
-        assert!(result.is_ok());
-
-        let provider = result.unwrap();
+        let provider = MistralEmbeddingProvider::new("test_key".to_string(), config)?;
         assert_eq!(provider.model_name(), "codestral-embed");
         assert_eq!(provider.embedding_dimension(), 512);
+        Ok(())
     }
 
     #[test]
@@ -317,11 +313,11 @@ mod tests {
     }
 
     #[test]
-    fn test_metadata() {
+    fn test_metadata() -> anyhow::Result<()> {
         let config = MistralConfig::codestral_embed()
             .with_output_dimension(512)
             .with_output_dtype(OutputDtype::Int8);
-        let provider = MistralEmbeddingProvider::new("test_key".to_string(), config).unwrap();
+        let provider = MistralEmbeddingProvider::new("test_key".to_string(), config)?;
 
         let metadata = provider.metadata();
         assert_eq!(metadata["model"], "codestral-embed");
@@ -330,12 +326,13 @@ mod tests {
         assert_eq!(metadata["provider"], "Mistral AI");
         assert_eq!(metadata["output_dtype"], "int8");
         assert_eq!(metadata["output_dimension"], 512);
+        Ok(())
     }
 
     #[test]
-    fn test_binary_dequantization_not_implemented() {
+    fn test_binary_dequantization_not_implemented() -> anyhow::Result<()> {
         let config = MistralConfig::codestral_binary();
-        let provider = MistralEmbeddingProvider::new("test_key".to_string(), config).unwrap();
+        let provider = MistralEmbeddingProvider::new("test_key".to_string(), config)?;
 
         let test_data = vec![1.0, 2.0, 3.0];
         let result = provider.dequantize_binary_embeddings(test_data);
@@ -346,5 +343,6 @@ mod tests {
                 .to_string()
                 .contains("not yet implemented")
         );
+        Ok(())
     }
 }

--- a/memory-core/src/embeddings/mistral_tests.rs
+++ b/memory-core/src/embeddings/mistral_tests.rs
@@ -8,27 +8,25 @@ mod tests {
     use crate::embeddings::provider::EmbeddingProvider;
 
     #[test]
-    fn test_mistral_provider_creation() {
+    fn test_mistral_provider_creation() -> anyhow::Result<()> {
         let config = MistralConfig::mistral_embed();
-        let result = MistralEmbeddingProvider::new("test_key".to_string(), config);
-        assert!(result.is_ok());
+        let provider = MistralEmbeddingProvider::new("test_key".to_string(), config)?;
 
-        let provider = result.unwrap();
         assert_eq!(provider.model_name(), "mistral-embed");
         assert_eq!(provider.embedding_dimension(), 1024);
+        Ok(())
     }
 
     #[test]
-    fn test_codestral_provider_creation() {
+    fn test_codestral_provider_creation() -> anyhow::Result<()> {
         let config = MistralConfig::codestral_embed()
             .with_output_dimension(512)
             .with_output_dtype(OutputDtype::Int8);
-        let result = MistralEmbeddingProvider::new("test_key".to_string(), config);
-        assert!(result.is_ok());
+        let provider = MistralEmbeddingProvider::new("test_key".to_string(), config)?;
 
-        let provider = result.unwrap();
         assert_eq!(provider.model_name(), "codestral-embed");
         assert_eq!(provider.embedding_dimension(), 512);
+        Ok(())
     }
 
     #[test]
@@ -57,11 +55,11 @@ mod tests {
     }
 
     #[test]
-    fn test_provider_metadata() {
+    fn test_provider_metadata() -> anyhow::Result<()> {
         let config = MistralConfig::codestral_embed()
             .with_output_dimension(512)
             .with_output_dtype(OutputDtype::Int8);
-        let provider = MistralEmbeddingProvider::new("test_key".to_string(), config).unwrap();
+        let provider = MistralEmbeddingProvider::new("test_key".to_string(), config)?;
 
         let metadata = provider.metadata();
         assert_eq!(metadata["model"], "codestral-embed");
@@ -69,6 +67,7 @@ mod tests {
         assert_eq!(metadata["type"], "mistral");
         assert_eq!(metadata["provider"], "Mistral AI");
         assert_eq!(metadata["output_dtype"], "int8");
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
🎯 **What:** 
Refactored `MistralEmbeddingProvider::new` test initializations to return `anyhow::Result<()>` and use `?` instead of `.unwrap()`.

💡 **Why:**
This improves maintainability and robustness by preventing unsafe unwraps and panics, satisfying safety standards in tests that might cause failure without proper error reporting.

✅ **Verification:**
- Tests build and run via `cargo test -p do-memory-core --features mistral`
- `cargo clippy --workspace --all-features` has zero new warnings.
- Pre-commit documentation checks run via `./scripts/check-doctests.sh` pass.

✨ **Result:**
Tests handle setup errors safely and idiomatically with `?` mapping to `anyhow::Result<()>`. This eliminates a code quality hazard from hard panics.

---
*PR created automatically by Jules for task [803178278466151776](https://jules.google.com/task/803178278466151776) started by @d-o-hub*