### PR TITLE
docs(plans): mark WG-109 complete and reduce clippy suppressions

### DIFF
--- a/memory-core/src/lib.rs
+++ b/memory-core/src/lib.rs
@@ -24,8 +24,10 @@
 // - map_unwrap_or: map_or is less readable than the explicit pattern
 // - float_cmp: Intentional exact comparisons for known values (e.g., 1.0, 0.5)
 // - assigning_clones: clone_from is not always more efficient
+// - similar_names: Short variable names common in mathematical contexts
 // - missing_docs: Documentation for all public items would require extensive rework
 // - cognitive_complexity: Complex functions exist; refactoring tracked as tech debt
+// - expect_used/unwrap_used: Required for infallible operations and test assertions
 #![allow(clippy::cognitive_complexity)]
 #![allow(clippy::cast_precision_loss)]
 #![allow(clippy::cast_possible_truncation)]
@@ -44,7 +46,6 @@
 #![allow(clippy::map_unwrap_or)]
 #![allow(clippy::float_cmp)]
 #![allow(clippy::assigning_clones)]
-#![allow(clippy::uninlined_format_args)]
 #![allow(clippy::similar_names)]
 #![allow(clippy::expect_used)]
 #![allow(clippy::unwrap_used)]

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -135,7 +135,7 @@ Impact analysis of `d-o-hub/github-template-ai-agents` and `d-o-hub/chaotic_sema
 | Task | WG | Status | Details |
 |------|----|--------|---------|
 | Version-retained persistence | WG-108 | 🔵 Backlog | Track concept drift across episode versions |
-| `BundleAccumulator` sliding window | WG-109 | 🔵 Backlog | Recency-weighted context for pattern retrieval |
+| `BundleAccumulator` sliding window | WG-109 | ✅ Complete (WG-117) | Recency-weighted context for pattern retrieval |
 | SIMD-accelerated similarity | WG-110 | 🔵 Backlog | Marginal perf gain — defer until benchmarks justify |
 
 ## v0.1.29 Sprint (Complete ✅)

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -76,7 +76,7 @@ Types re-exported under `csm` feature flag in `memory-core/src/retrieval/mod.rs`
 | WG-124 | Procedural memory type: learned heuristics-as-skills (ParamAgent-inspired) | 🔵 Backlog | 124 |
 | WG-125 | Evaluate Routing-Free MoE for DyMoE replacement (arXiv:2604.00801) | 🔵 Backlog | 125 |
 | WG-108 | Version-retained persistence (concept drift tracking) | 🔵 Backlog | 108 |
-| WG-109 | `BundleAccumulator` sliding window (recency-weighted context) | 🔵 Backlog | 109 |
+| WG-109 | `BundleAccumulator` sliding window (recency-weighted context) | ✅ Complete (WG-117) | 109 |
 | WG-110 | SIMD-accelerated similarity (defer until benchmarks justify) | 🔵 Backlog | 110 |
 | WG-126 | Cross-agent memory collaboration via contrastive trajectory distillation (MemCollab, arXiv:2603.23234) | 🔵 Backlog | 126 |
 | WG-127 | Semantic gist extraction + CogniRank reranking (CogitoRAG, arXiv:2602.15895) | 🔵 Backlog | 127 |


### PR DESCRIPTION
## Summary
- WG-109 (BundleAccumulator sliding window) already implemented as WG-117 in v0.1.31
- Remove unused `uninlined_format_args` clippy suppression (lint not triggered)
- Clippy suppressions: 23 → 22 (target ≤20)

## Changes
| File | Change |
|------|--------|
| `memory-core/src/lib.rs` | Remove unused suppression |
| `plans/GOAP_STATE.md` | WG-109 status → Complete |
| `plans/ROADMAPS/ROADMAP_ACTIVE.md` | WG-109 status → Complete |

## Test plan
- [x] All 3195 tests pass
- [x] All doctests pass
- [x] Quality gates pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)