### PR TITLE
🧹 remove commented-out code in agentfs.rs

### DIFF
--- a/memory-core/src/reward/external/agentfs.rs
+++ b/memory-core/src/reward/external/agentfs.rs
@@ -146,18 +146,9 @@ impl ExternalSignalProvider for AgentFsProvider {
 
         // SDK not integrated - return error if enabled
         // This prevents misleading placeholder data from being used
-        return Err(ExternalSignalError::SdkUnavailable(
+        Err(ExternalSignalError::SdkUnavailable(
             "agentfs-sdk not integrated - enable feature and add SDK dependency to use".to_string(),
-        ));
-
-        // The following code would be used when SDK is integrated:
-        // if self.config.db_path.is_empty() {
-        //     return Err(ExternalSignalError::ConfigMissing(
-        //         "AgentFS database path not configured".to_string(),
-        //     ));
-        // }
-        // let tool_signals = self.fetch_tool_stats(episode);
-        // ... calculate confidence and quality ...
+        ))
     }
 
     async fn health_check(&self) -> ProviderHealth {
@@ -169,15 +160,9 @@ impl ExternalSignalProvider for AgentFsProvider {
         // SDK not integrated - report degraded status with clear message
         // This is "Degraded" not "Unhealthy" because the system still works
         // without external signals; it just lacks ground truth validation
-        return ProviderHealth::Degraded(
+        ProviderHealth::Degraded(
             "SDK not integrated - stub implementation, no real signal data available".to_string(),
-        );
-
-        // The following code would be used when SDK is integrated:
-        // if self.config.db_path.is_empty() {
-        //     return ProviderHealth::Unhealthy("Database path not configured".to_string());
-        // }
-        // match tokio::fs::metadata(&self.config.db_path).await { ... }
+        )
     }
 
     fn validate_config(&self) -> Result<()> {
@@ -209,9 +194,6 @@ impl AgentFsProvider {
     #[allow(dead_code)] // Not used until SDK integrated
     fn fetch_tool_stats(&self, _episode: &crate::episode::Episode) -> Vec<ToolSignal> {
         // Stub: No real data available without SDK
-        // Real implementation would:
-        // let tc = agentfs_sdk::ToolCalls::new(&self.config.db_path).await?;
-        // let stats = tc.stats_for(&step.tool).await?;
         Vec::new()
     }
 }


### PR DESCRIPTION
🎯 **What:** Removed commented-out code blocks in `memory-core/src/reward/external/agentfs.rs` that served as placeholders for future AgentFS SDK integration.

💡 **Why:** This improves maintainability and readability by eliminating dead code and reducing implementation noise. It makes the current stub status of the provider clearer and follows the idiomatic Rust pattern of using implicit returns for trailing expressions.

✅ **Verification:** 
- Verified implementation logic via a standalone Rust script (compiled with `rustc`) because `cargo test` was blocked by environment network constraints. 
- The verification script confirmed that `get_signals` returns the expected error, `health_check` returns the expected degraded status, and `fetch_tool_stats` returns an empty vector.
- Ran `cargo fmt --all -- --check` to ensure formatting standards are maintained.

✨ **Result:** A cleaner, more idiomatic implementation of the AgentFS external signal provider stub.

---
*PR created automatically by Jules for task [8063291631525467899](https://jules.google.com/task/8063291631525467899) started by @d-o-hub*