### PR TITLE
🧪 Add edge case tests for TimeSeriesExtractor::meets_threshold

### DIFF
--- a/memory-mcp/src/mcp/tools/advanced_pattern_analysis/time_series.rs
+++ b/memory-mcp/src/mcp/tools/advanced_pattern_analysis/time_series.rs
@@ -73,3 +73,33 @@ impl Default for TimeSeriesExtractor {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_meets_threshold_cases() {
+        let extractor = TimeSeriesExtractor::default();
+        let cases: &[(&[f64], usize, bool)] = &[
+            (&[], 0, false),              // empty, zero threshold
+            (&[], 3, false),              // empty, nonzero threshold
+            (&[1.0], 0, true),            // non-empty, zero threshold
+            (&[1.0], 1, true),            // exact match
+            (&[1.0], 2, false),           // below threshold
+            (&[1.0, 2.0, 3.0], 3, true),  // exact N
+            (&[1.0, 2.0, 3.0], 4, false), // N-1
+            (&[1.0, 2.0, 3.0], 2, true),  // N+1 (more than needed)
+        ];
+
+        for (values, min_points, expected) in cases {
+            assert_eq!(
+                extractor.meets_threshold(values, *min_points),
+                *expected,
+                "values.len()={}, min_points={}",
+                values.len(),
+                min_points
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 🎯 What
Adds missing unit tests for `meets_threshold` in `time_series.rs`.
The method had no test coverage for empty slices, exact boundaries,
or zero-threshold scenarios.

## 📊 Coverage
- Empty slice + zero threshold -> `false` (documents intentional guard)
- Empty slice + nonzero threshold -> `false`
- Non-empty + zero threshold -> `true`
- Exact length match -> `true`
- Length below threshold -> `false`
- Length above threshold -> `true`

## ✨ Result
`meets_threshold` now has deterministic coverage of all logical branches.
Safe to refactor with confidence.

---
*PR created automatically by Jules for task [15979975183183886739](https://jules.google.com/task/15979975183183886739) started by @d-o-hub*