### PR TITLE
🧹 [code health improvement] Remove commented out code in agentfs stub

### DIFF
--- a/memory-core/src/reward/external/agentfs.rs
+++ b/memory-core/src/reward/external/agentfs.rs
@@ -209,9 +209,7 @@ impl AgentFsProvider {
     #[allow(dead_code)] // Not used until SDK integrated
     fn fetch_tool_stats(&self, _episode: &crate::episode::Episode) -> Vec<ToolSignal> {
         // Stub: No real data available without SDK
-        // Real implementation would:
-        // let tc = agentfs_sdk::ToolCalls::new(&self.config.db_path).await?;
-        // let stats = tc.stats_for(&step.tool).await?;
+        // TODO: Implement when agentfs-sdk is integrated
         Vec::new()
     }
 }


### PR DESCRIPTION
🎯 What: Removed the specific commented-out Rust code (`// let tc = ...`, `// let stats = ...`) in the `fetch_tool_stats` stub of `memory-core/src/reward/external/agentfs.rs` and replaced it with a `// TODO: Implement when agentfs-sdk is integrated` comment.
💡 Why: Removing commented-out code improves readability and maintainability. A `TODO` provides clear intent without cluttering the file with unused execution lines.
✅ Verification: Ran format and lint checks (`./scripts/code-quality.sh`). The modification is trivial (replacing comments with a comment) and does not affect the actual compiled Rust logic.
✨ Result: Cleaner code in `fetch_tool_stats` while preserving intent for future SDK integration.

---
*PR created automatically by Jules for task [5717064010360675187](https://jules.google.com/task/5717064010360675187) started by @d-o-hub*