### PR TITLE
docs: Synchronize README.md and documentation directories with implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,7 +207,9 @@ PR CI time reduced from ~50+ min to ~15-18 min via paths-based benchmark trigger
 
 ## MCP Server Interaction Patterns
 - The MCP server implements lazy loading of tools (ADR-024) to optimize initialization.
-- The server exposes advanced tools including `checkpoint_episode` and `recommend_playbook` for complex task handoff and state preservation.
+- The server exposes advanced tools for complex task handoff and state preservation:
+  - `checkpoint_episode`: Create a checkpoint for an in-progress episode. Use this when switching agents, pausing long-running tasks, or before risky operations.
+  - `recommend_playbook`: Get an actionable playbook with step-by-step guidance for a task.
 
 ## Storage Optimization (Batch Eviction)
 - Capacity eviction in Turso uses batch 'DELETE' with 'IN (...)' clauses for episodes and embeddings to avoid N+1 query overhead.

--- a/README.md
+++ b/README.md
@@ -35,14 +35,25 @@ The Rust Self-Learning Memory System provides persistent memory across agent int
 ## Features
 
 ### 🧠 Episodic Memory
-- Complete episode lifecycle (start → execute → score → learn → retrieve)
+- Episode lifecycle management (start → execute → score → learn → retrieve)
 - Detailed execution step logging with tool usage tracking
-- Intelligent reward scoring with efficiency and quality bonuses
+- Reward scoring with efficiency and quality bonuses based on multiple factors
 - Automatic reflection generation for learning
+
+
+### Episode Checkpoints & Handoff
+- Supports saving task state via checkpoints to allow pausing or task handoffs between agents.
+- Checkpoints capture progress, findings, pending actions, and required context.
+
+
+### CSM Cascading Retrieval
+- Integrates Chaotic Semantic Memory (CSM) to reduce embedding API calls.
+- Implements a cascading retrieval pipeline using 100% CPU-local, zero-API methods.
+- Tiers include BM25 exact match, HDC similarity, and ConceptGraph expansion before falling back to API embeddings.
 
 ### 📚 Multiple Storage Backends
 - **Turso Cloud**: Remote libSQL database (default)
-- **redb Cache**: Fast embedded key-value storage
+- **redb Cache**: Embedded key-value storage
 - **Local SQLite**: Local file-based database (fallback)
 - Automatic caching with TTL-based invalidation
 
@@ -486,11 +497,11 @@ batch_size = 100
                                │
          ┌─────────────────────┼─────────────────────┐
          │                     │                     │
-┌───────▼────────┐  ┌────────▼────────┐  ┌────────▼────────┐
-│ Turso Storage  │  │  Redb Cache     │  │  In-Memory      │
-│                │  │                 │  │                 │
-│ libSQL/Remote  │  │   Fast Access   │  │  Temporary      │
-└────────────────┘  └─────────────────┘  └─────────────────┘
+┌───────▼───────────────┐ ┌────────▼──────────────┐ ┌────────▼────────┐
+│do-memory-storage-turso│ │do-memory-storage-redb │ │  In-Memory      │
+│                       │ │                       │ │                 │
+│   libSQL/Remote       │ │   Cache Backend       │ │  Temporary      │
+└───────────────────────┘ └───────────────────────┘ └─────────────────┘
 ```
 
 ## MCP Server Tools

--- a/agent_docs/csm_integration.md
+++ b/agent_docs/csm_integration.md
@@ -118,7 +118,7 @@ More efficient than O(n log n) full sort when k << n. Used in retrieval hot path
 
 **Goal**: Add BM25 keyword index from CSM as first retrieval tier
 
-**Implementation Location**: `memory-core/src/search/bm25.rs` (new)
+**Implementation Location**: `memory-core/src/search/bm25.rs`
 
 **Key Files from CSM**:
 - `retrieval/bm25.rs` - Full Okapi BM25 with TF-IDF scoring
@@ -165,7 +165,7 @@ More efficient than O(n log n) full sort when k << n. Used in retrieval hot path
 
 **Goal**: Add ConceptGraph ontology expansion for synonym retrieval without LLM
 
-**Implementation Location**: `memory-core/src/search/concept_graph.rs` (new)
+**Implementation Location**: `memory-core/src/search/concept_graph.rs`
 
 **Key Files from CSM**:
 - `semantic_bridge.rs` - Concept graph traversal
@@ -182,7 +182,7 @@ More efficient than O(n log n) full sort when k << n. Used in retrieval hot path
 
 **Goal**: Implement cascading retrieval pipeline with tier escalation
 
-**Implementation Location**: `memory-core/src/search/cascade.rs` (new)
+**Implementation Location**: `memory-core/src/search/cascade.rs`
 
 **Proposed API**:
 

--- a/docs/PLAYBOOKS_AND_CHECKPOINTS.md
+++ b/docs/PLAYBOOKS_AND_CHECKPOINTS.md
@@ -1,6 +1,6 @@
 # Playbooks and Checkpoints: Actionable Memory
 
-This guide explains how to use the new Playbook and Checkpoint features introduced in v0.1.22. These features transform passive episodic memory into active, actionable guidance and state management.
+This guide explains how to use the Playbook and Checkpoint features. These features provide actionable guidance based on past episodes and enable state management for tasks.
 
 ## 1. Actionable Playbooks
 

--- a/memory-core/README.md
+++ b/memory-core/README.md
@@ -14,8 +14,8 @@
 
 - **Episodic Memory**: Complete episode lifecycle with detailed step logging and reward scoring
 - **Pattern Recognition**: Automatic extraction of ToolSequences, DecisionPoints, ErrorRecovery, and ContextPatterns
-- **Intelligent Reward Scoring**: Sophisticated multi-factor scoring with efficiency, complexity, and quality bonuses
-- **Smart Reflection**: Generate actionable insights and improvement recommendations from completed episodes
+- **Multi-factor Reward Scoring**: Reward scoring with efficiency, complexity, and quality bonuses
+- **Reflection Generation**: Generate actionable insights and improvement recommendations from completed episodes
 - **Semantic Embeddings**: Optional multi-provider semantic search (OpenAI, Cohere, Ollama, local)
 - **Spatiotemporal Indexing**: Location and time-aware memory retrieval with k-d tree optimization
 - **Dual Storage**: Seamless integration with Turso/libSQL (durable) and redb (cache) backends
@@ -63,6 +63,7 @@ do-memory-core = { version = "0.1", features = ["embeddings-full"] }
 - Pattern similarity matching for relevant experience retrieval
 - Reward-based pattern learning and improvement
 - Frequency and success rate tracking
+- Optimized pattern ranking using O(N) scoring calls and Schwartzian Transform (decorate-sort-undecorate) for efficient evaluation
 
 ### Semantic Search (Optional)
 - Multi-provider embeddings: OpenAI, Mistral, local CPU-based


### PR DESCRIPTION
### Goal
Update README.md and the docs/ and agent_docs/ directories to synchronize them with the current implementation state of the rust-self-learning-memory codebase.

### Changes
* Removed marketing language
* Mentioned O(N) scoring and Schwartzian Transform pattern ranking optimizations in `do-memory-core`
* Used exact crate names in architecture diagram
* Included precise descriptions for `checkpoint_episode` and `recommend_playbook` in `AGENTS.md`
* Stripped "NEW" markers from CSM integration docs
* Verified markdown links
* Ensured tests still pass and files are properly formatted

---
*PR created automatically by Jules for task [6675154233555424020](https://jules.google.com/task/6675154233555424020) started by @d-o-hub*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified episodic memory features, including execution-step logging and reward-scoring details
  * Updated architecture diagram layout for storage layer organization
  * Documented Chaotic Semantic Memory integration strategy with cascading retrieval pipeline
  * Removed version-specific framing from Playbooks and Checkpoints documentation
  * Enhanced pattern recognition capability descriptions using optimized ranking approach

<!-- end of auto-generated comment: release notes by coderabbit.ai -->