### PR TITLE
code health: update coverage badge generation workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -277,4 +277,6 @@ jobs:
           fi
 
           git commit -m "chore(ci): update coverage badge [skip ci]"
-          git push
+          git fetch origin
+          git pull --rebase origin main
+          git push origin HEAD:main || (git pull --rebase origin main && git push origin HEAD:main)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -201,46 +201,46 @@ jobs:
   coverage-badge:
     name: Generate Coverage Badge
     runs-on: ubuntu-latest
-    needs: [check-quick-check, coverage]
-    if: github.ref == 'refs/heads/main'
+    needs: [coverage]
+    if: >-
+      ${{
+        always() &&
+        github.ref == 'refs/heads/main' &&
+        needs.coverage.result == 'success'
+      }}
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download coverage artifact
         uses: actions/download-artifact@v8
         with:
           name: coverage-report
           path: ./coverage
-        continue-on-error: true
 
       - name: Generate badge
         run: |
           echo "=== Coverage Badge Generation ==="
-
-          # Check if coverage report exists
           if [ ! -f ./coverage/lcov.info ]; then
-            echo "Warning: Coverage report not found at ./coverage/lcov.info"
-            echo "Badge generation skipped"
-            exit 0
+            echo "ERROR: Coverage report not found at ./coverage/lcov.info"
+            exit 1
           fi
 
-          # Extract coverage percentage from lcov.info
-          # This is a simplified calculation - sum of hits / sum of total lines
           TOTAL_LINES=$(grep -c '^DA:' ./coverage/lcov.info || echo "0")
           HIT_LINES=$(grep '^DA:' ./coverage/lcov.info | awk -F',' '{if ($2 > 0) print}' | wc -l || echo "0")
 
           if [ "$TOTAL_LINES" -gt 0 ]; then
             COVERAGE=$(( HIT_LINES * 100 / TOTAL_LINES ))
           else
-            COVERAGE=0
+            echo "ERROR: No DA: lines found in lcov.info"
+            exit 1
           fi
 
           echo "Calculated coverage: ${COVERAGE}%"
-          echo "coverage=${COVERAGE}" >> "$GITHUB_ENV"
 
-          # Determine badge color based on coverage
           if [ "$COVERAGE" -ge 90 ]; then
             COLOR="brightgreen"
           elif [ "$COVERAGE" -ge 80 ]; then
@@ -256,13 +256,25 @@ jobs:
           fi
 
           echo "Badge color: ${COLOR}"
-          echo "color=${COLOR}" >> "$GITHUB_ENV"
+          mkdir -p .github/badges
 
-          echo "=== Badge Generation Complete ==="
+          curl -fsSL \
+            "https://img.shields.io/badge/coverage-${COVERAGE}%25-${COLOR}?style=flat-square" \
+            -o .github/badges/coverage.svg
 
-      - name: Upload badge artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-badge
-          path: ./coverage/lcov.info
-          retention-days: 7
+          echo "Badge written to .github/badges/coverage.svg"
+
+      - name: Commit updated badge
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add .github/badges/coverage.svg
+
+          if git diff --cached --quiet; then
+            echo "No badge changes — README.md already up to date"
+            exit 0
+          fi
+
+          git commit -m "chore(ci): update coverage badge [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![Rust Version](https://img.shields.io/badge/Rust-stable%20(2024%20edition)-yellow)
 ![Quick Check](https://github.com/d-o-hub/rust-self-learning-memory/actions/workflows/quick-check.yml/badge.svg)
 ![Security](https://github.com/d-o-hub/rust-self-learning-memory/actions/workflows/security.yml/badge.svg)
-[![Coverage](https://codecov.io/gh/d-o-hub/rust-self-learning-memory/branch/main/graph/badge.svg)](https://codecov.io/gh/d-o-hub/rust-self-learning-memory)
+![Coverage](.github/badges/coverage.svg)
 ![Open Issues](https://img.shields.io/github/issues/d-o-hub/rust-self-learning-memory)
 
 A self-learning episodic memory system with semantic pattern search, embeddings, MCP server, and optional sandboxed code execution.


### PR DESCRIPTION
What
- Updates `.github/workflows/coverage.yml` to generate an SVG badge correctly, upload the SVG badge and commit it back to the repo using bot credentials when `main` finishes successful coverage tests.
- Removes the requirement for `[check-quick-check]` on `coverage-badge` job.
- Updates `README.md` to point to the newly committed badge instead of the dynamically generated Codecov badge, eliminating an external SVG dependency issue.

Why
- This setup enables hosting the SVG directly inside the git repo (`.github/badges/coverage.svg`), which simplifies documentation, does not depend on an external server and ensures we always have the exact match coverage visualization right within our own source code structure without relying on external UI states.
- Ensures loud failures by exiting 1 on missing information.

Verification
- The workflow has been replaced exactly as the instructions.
- README points to `.github/badges/coverage.svg`.
- Pre-commit verifications (fmt & clippy on workspace) pass.

Result
- Users and contributors will see a high-quality SVG badge from `.github/badges/coverage.svg` locally stored in the repository.

---
*PR created automatically by Jules for task [12929719108545569382](https://jules.google.com/task/12929719108545569382) started by @d-o-hub*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved coverage workflow: stricter validation that fails when coverage data is missing, computes coverage from raw data, and automatically updates a generated coverage badge directly in the repository.
* **Documentation**
  * Replaced the external coverage badge in the README with the new locally generated coverage badge.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-o-hub/rust-self-learning-memory/pull/542)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->