### PR TITLE
fix(turso): ignore 3 crud tests affected by upstream libsql SIGSEGV (ADR-027)

### DIFF
--- a/memory-storage-turso/src/storage/episodes/crud.rs
+++ b/memory-storage-turso/src/storage/episodes/crud.rs
@@ -223,6 +223,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "Memory corruption bug in libsql native library - malloc_consolidate() unaligned fastbin chunk in CI - see ADR-027"]
     async fn test_store_and_get_episode() -> Result<()> {
         let (storage, _dir) = create_test_storage().await?;
         let mut episode = Episode::new(
@@ -245,6 +246,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "Memory corruption bug in libsql native library - malloc_consolidate() unaligned fastbin chunk in CI - see ADR-027"]
     async fn test_delete_episode() -> Result<()> {
         let (storage, _dir) = create_test_storage().await?;
         let episode = Episode::new(
@@ -263,6 +265,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "Memory corruption bug in libsql native library - malloc_consolidate() unaligned fastbin chunk in CI - see ADR-027"]
     async fn test_store_and_get_summary() -> Result<()> {
         let (storage, _dir) = create_test_storage().await?;
         let episode_id = Uuid::new_v4();


### PR DESCRIPTION
Adds #[ignore] annotations to 3 tests in memory-storage-turso/src/storage/episodes/crud.rs that were failing with SIGSEGV due to the same upstream libsql malloc_consolidate() bug (ADR-027) that affects 71 other Turso tests.

Before: 3 SIGSEGV failures in workspace test suite
After: 3 tests properly skipped, matching the documented pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to address known infrastructure issues in CI environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-o-hub/rust-self-learning-memory/pull/578?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->