### PR TITLE
fix: resolve all pre-existing clippy warnings and split oversized api.rs

### DIFF
--- a/memory-cli/tests/episode_update_test.rs
+++ b/memory-cli/tests/episode_update_test.rs
@@ -238,7 +238,7 @@ mod tests {
     }
 
     /// Test that tag operations persist across storage
-    /// Note: This test requires TURSO_DB_URL and TURSO_AUTH_TOKEN environment variables
+    /// Note: This test requires `TURSO_DB_URL` and `TURSO_AUTH_TOKEN` environment variables
     /// and is ignored by default. Run with `cargo test -- --ignored` to execute.
     #[tokio::test]
     #[cfg(feature = "turso")]

--- a/memory-core/src/memory/api.rs
+++ b/memory-core/src/memory/api.rs
@@ -3,6 +3,7 @@
 //! This module contains all public methods that users interact with,
 //! organized by functionality area.
 
+use super::SelfLearningMemory;
 use crate::error::Result;
 use crate::memory::attribution::{
     RecommendationFeedback, RecommendationSession, RecommendationStats,
@@ -10,9 +11,6 @@ use crate::memory::attribution::{
 use crate::monitoring::AgentMetrics;
 use crate::procedural::ProceduralMemory;
 use std::time::Duration;
-use tracing::warn;
-
-use super::SelfLearningMemory;
 
 // ============================================================================
 // Monitoring and Statistics
@@ -89,182 +87,6 @@ impl SelfLearningMemory {
     /// Clear all cached query results (v0.1.12)
     pub fn clear_cache(&self) {
         super::monitoring::clear_cache(&self.query_cache);
-    }
-}
-
-impl SelfLearningMemory {
-    async fn persist_recommendation_session(&self, session: &RecommendationSession) {
-        if let Some(storage) = &self.turso_storage {
-            if let Err(err) = storage.store_recommendation_session(session).await {
-                warn!(
-                    session_id = %session.session_id,
-                    episode_id = %session.episode_id,
-                    error = %err,
-                    "Failed to persist recommendation session to durable storage"
-                );
-            }
-        }
-
-        if let Some(cache) = &self.cache_storage {
-            if let Err(err) = cache.store_recommendation_session(session).await {
-                warn!(
-                    session_id = %session.session_id,
-                    episode_id = %session.episode_id,
-                    error = %err,
-                    "Failed to persist recommendation session to cache storage"
-                );
-            }
-        }
-    }
-
-    async fn persist_recommendation_feedback(&self, feedback: &RecommendationFeedback) {
-        if let Some(storage) = &self.turso_storage {
-            if let Err(err) = storage.store_recommendation_feedback(feedback).await {
-                warn!(
-                    session_id = %feedback.session_id,
-                    error = %err,
-                    "Failed to persist recommendation feedback to durable storage"
-                );
-            }
-        }
-
-        if let Some(cache) = &self.cache_storage {
-            if let Err(err) = cache.store_recommendation_feedback(feedback).await {
-                warn!(
-                    session_id = %feedback.session_id,
-                    error = %err,
-                    "Failed to persist recommendation feedback to cache storage"
-                );
-            }
-        }
-    }
-
-    async fn fetch_session_for_episode_from_storage(
-        &self,
-        episode_id: uuid::Uuid,
-    ) -> Option<RecommendationSession> {
-        if let Some(storage) = &self.turso_storage {
-            match storage
-                .get_recommendation_session_for_episode(episode_id)
-                .await
-            {
-                Ok(Some(session)) => {
-                    self.recommendation_tracker
-                        .record_session(session.clone())
-                        .await;
-                    return Some(session);
-                }
-                Ok(None) => {}
-                Err(err) => warn!(
-                    episode_id = %episode_id,
-                    error = %err,
-                    "Failed to load recommendation session from durable storage"
-                ),
-            }
-        }
-
-        if let Some(cache) = &self.cache_storage {
-            match cache
-                .get_recommendation_session_for_episode(episode_id)
-                .await
-            {
-                Ok(Some(session)) => {
-                    self.recommendation_tracker
-                        .record_session(session.clone())
-                        .await;
-                    return Some(session);
-                }
-                Ok(None) => {}
-                Err(err) => warn!(
-                    episode_id = %episode_id,
-                    error = %err,
-                    "Failed to load recommendation session from cache storage"
-                ),
-            }
-        }
-
-        None
-    }
-
-    async fn fetch_feedback_from_storage(
-        &self,
-        session_id: uuid::Uuid,
-    ) -> Option<RecommendationFeedback> {
-        if let Some(storage) = &self.turso_storage {
-            match storage.get_recommendation_feedback(session_id).await {
-                Ok(Some(feedback)) => {
-                    if let Err(err) = self
-                        .recommendation_tracker
-                        .record_feedback(feedback.clone())
-                        .await
-                    {
-                        warn!(
-                            session_id = %session_id,
-                            error = %err,
-                            "Failed to cache recommendation feedback after durable load"
-                        );
-                    }
-                    return Some(feedback);
-                }
-                Ok(None) => {}
-                Err(err) => warn!(
-                    session_id = %session_id,
-                    error = %err,
-                    "Failed to load recommendation feedback from durable storage"
-                ),
-            }
-        }
-
-        if let Some(cache) = &self.cache_storage {
-            match cache.get_recommendation_feedback(session_id).await {
-                Ok(Some(feedback)) => {
-                    if let Err(err) = self
-                        .recommendation_tracker
-                        .record_feedback(feedback.clone())
-                        .await
-                    {
-                        warn!(
-                            session_id = %session_id,
-                            error = %err,
-                            "Failed to cache recommendation feedback after cache load"
-                        );
-                    }
-                    return Some(feedback);
-                }
-                Ok(None) => {}
-                Err(err) => warn!(
-                    session_id = %session_id,
-                    error = %err,
-                    "Failed to load recommendation feedback from cache storage"
-                ),
-            }
-        }
-
-        None
-    }
-
-    async fn fetch_recommendation_stats_from_storage(&self) -> Option<RecommendationStats> {
-        if let Some(storage) = &self.turso_storage {
-            match storage.get_recommendation_stats().await {
-                Ok(stats) => return Some(stats),
-                Err(err) => warn!(
-                    error = %err,
-                    "Failed to load recommendation stats from durable storage"
-                ),
-            }
-        }
-
-        if let Some(cache) = &self.cache_storage {
-            match cache.get_recommendation_stats().await {
-                Ok(stats) => return Some(stats),
-                Err(err) => warn!(
-                    error = %err,
-                    "Failed to load recommendation stats from cache storage"
-                ),
-            }
-        }
-
-        None
     }
 }
 

--- a/memory-core/src/memory/mod.rs
+++ b/memory-core/src/memory/mod.rs
@@ -58,6 +58,7 @@ mod management;
 mod monitoring;
 pub mod pattern_api;
 mod pattern_search;
+mod persistence;
 pub mod playbook;
 mod queries;
 pub mod query_api;

--- a/memory-core/src/memory/persistence.rs
+++ b/memory-core/src/memory/persistence.rs
@@ -1,0 +1,190 @@
+//! Private persistence helper methods for `SelfLearningMemory`.
+//!
+//! These methods bridge the recommendation attribution system with durable
+//! storage (Turso) and cache storage (redb), providing fallback chain logic
+//! for loading sessions, feedback, and statistics.
+
+use crate::memory::attribution::{
+    RecommendationFeedback, RecommendationSession, RecommendationStats,
+};
+use tracing::warn;
+
+use super::SelfLearningMemory;
+
+impl SelfLearningMemory {
+    pub(crate) async fn persist_recommendation_session(&self, session: &RecommendationSession) {
+        if let Some(storage) = &self.turso_storage {
+            if let Err(err) = storage.store_recommendation_session(session).await {
+                warn!(
+                    session_id = %session.session_id,
+                    episode_id = %session.episode_id,
+                    error = %err,
+                    "Failed to persist recommendation session to durable storage"
+                );
+            }
+        }
+
+        if let Some(cache) = &self.cache_storage {
+            if let Err(err) = cache.store_recommendation_session(session).await {
+                warn!(
+                    session_id = %session.session_id,
+                    episode_id = %session.episode_id,
+                    error = %err,
+                    "Failed to persist recommendation session to cache storage"
+                );
+            }
+        }
+    }
+
+    pub(crate) async fn persist_recommendation_feedback(&self, feedback: &RecommendationFeedback) {
+        if let Some(storage) = &self.turso_storage {
+            if let Err(err) = storage.store_recommendation_feedback(feedback).await {
+                warn!(
+                    session_id = %feedback.session_id,
+                    error = %err,
+                    "Failed to persist recommendation feedback to durable storage"
+                );
+            }
+        }
+
+        if let Some(cache) = &self.cache_storage {
+            if let Err(err) = cache.store_recommendation_feedback(feedback).await {
+                warn!(
+                    session_id = %feedback.session_id,
+                    error = %err,
+                    "Failed to persist recommendation feedback to cache storage"
+                );
+            }
+        }
+    }
+
+    pub(crate) async fn fetch_session_for_episode_from_storage(
+        &self,
+        episode_id: uuid::Uuid,
+    ) -> Option<RecommendationSession> {
+        if let Some(storage) = &self.turso_storage {
+            match storage
+                .get_recommendation_session_for_episode(episode_id)
+                .await
+            {
+                Ok(Some(session)) => {
+                    self.recommendation_tracker
+                        .record_session(session.clone())
+                        .await;
+                    return Some(session);
+                }
+                Ok(None) => {}
+                Err(err) => warn!(
+                    episode_id = %episode_id,
+                    error = %err,
+                    "Failed to load recommendation session from durable storage"
+                ),
+            }
+        }
+
+        if let Some(cache) = &self.cache_storage {
+            match cache
+                .get_recommendation_session_for_episode(episode_id)
+                .await
+            {
+                Ok(Some(session)) => {
+                    self.recommendation_tracker
+                        .record_session(session.clone())
+                        .await;
+                    return Some(session);
+                }
+                Ok(None) => {}
+                Err(err) => warn!(
+                    episode_id = %episode_id,
+                    error = %err,
+                    "Failed to load recommendation session from cache storage"
+                ),
+            }
+        }
+
+        None
+    }
+
+    pub(crate) async fn fetch_feedback_from_storage(
+        &self,
+        session_id: uuid::Uuid,
+    ) -> Option<RecommendationFeedback> {
+        if let Some(storage) = &self.turso_storage {
+            match storage.get_recommendation_feedback(session_id).await {
+                Ok(Some(feedback)) => {
+                    if let Err(err) = self
+                        .recommendation_tracker
+                        .record_feedback(feedback.clone())
+                        .await
+                    {
+                        warn!(
+                            session_id = %session_id,
+                            error = %err,
+                            "Failed to cache recommendation feedback after durable load"
+                        );
+                    }
+                    return Some(feedback);
+                }
+                Ok(None) => {}
+                Err(err) => warn!(
+                    session_id = %session_id,
+                    error = %err,
+                    "Failed to load recommendation feedback from durable storage"
+                ),
+            }
+        }
+
+        if let Some(cache) = &self.cache_storage {
+            match cache.get_recommendation_feedback(session_id).await {
+                Ok(Some(feedback)) => {
+                    if let Err(err) = self
+                        .recommendation_tracker
+                        .record_feedback(feedback.clone())
+                        .await
+                    {
+                        warn!(
+                            session_id = %session_id,
+                            error = %err,
+                            "Failed to cache recommendation feedback after cache load"
+                        );
+                    }
+                    return Some(feedback);
+                }
+                Ok(None) => {}
+                Err(err) => warn!(
+                    session_id = %session_id,
+                    error = %err,
+                    "Failed to load recommendation feedback from cache storage"
+                ),
+            }
+        }
+
+        None
+    }
+
+    pub(crate) async fn fetch_recommendation_stats_from_storage(
+        &self,
+    ) -> Option<RecommendationStats> {
+        if let Some(storage) = &self.turso_storage {
+            match storage.get_recommendation_stats().await {
+                Ok(stats) => return Some(stats),
+                Err(err) => warn!(
+                    error = %err,
+                    "Failed to load recommendation stats from durable storage"
+                ),
+            }
+        }
+
+        if let Some(cache) = &self.cache_storage {
+            match cache.get_recommendation_stats().await {
+                Ok(stats) => return Some(stats),
+                Err(err) => warn!(
+                    error = %err,
+                    "Failed to load recommendation stats from cache storage"
+                ),
+            }
+        }
+
+        None
+    }
+}

--- a/memory-core/src/retrieval/cascade/mod.rs
+++ b/memory-core/src/retrieval/cascade/mod.rs
@@ -9,8 +9,6 @@
 //! The cascade eliminates 50-70% of embedding API calls by satisfying
 //! queries from CPU-local tiers before falling back to the API.
 
-use anyhow::Result;
-
 mod concept_graph;
 pub use concept_graph::ConceptGraph;
 
@@ -198,7 +196,7 @@ impl CascadeRetriever {
     /// 4. API fallback (requires external embedding call)
     ///
     /// Without `csm`, returns empty results (placeholder behavior).
-    pub fn retrieve(&self, query: &str) -> Result<CascadeResult> {
+    pub fn retrieve(&self, query: &str) -> CascadeResult {
         #[cfg(feature = "csm")]
         {
             self.retrieve_with_csm(query)
@@ -209,18 +207,18 @@ impl CascadeRetriever {
             // Placeholder implementation - returns empty results
             // query is intentionally unused in placeholder mode
             let _ = query;
-            Ok(CascadeResult {
+            CascadeResult {
                 episode_ids: Vec::new(),
                 scores: Vec::new(),
                 contributing_tiers: Vec::new(),
                 api_calls: 0,
-            })
+            }
         }
     }
 
     /// Full cascade implementation using CSM components.
     #[cfg(feature = "csm")]
-    fn retrieve_with_csm(&self, query: &str) -> Result<CascadeResult> {
+    fn retrieve_with_csm(&self, query: &str) -> CascadeResult {
         use super::{compute_weights, merge_results};
 
         // Tier 1: BM25 keyword search
@@ -228,12 +226,12 @@ impl CascadeRetriever {
 
         // Check if BM25 produced sufficient results
         if bm25_results.sufficient {
-            return Ok(CascadeResult {
+            return CascadeResult {
                 episode_ids: bm25_results.ids(),
                 scores: bm25_results.scores(),
                 contributing_tiers: vec!["bm25".to_string()],
                 api_calls: 0,
-            });
+            };
         }
 
         // Tier 2: HDC similarity search
@@ -247,20 +245,20 @@ impl CascadeRetriever {
 
             // Check if merged results are sufficient
             if merged.len() >= self.config.min_results {
-                return Ok(CascadeResult {
+                return CascadeResult {
                     episode_ids: merged.iter().map(|(id, _)| id.clone()).collect(),
                     scores: merged.iter().map(|(_, s)| *s).collect(),
                     contributing_tiers: vec!["bm25".to_string(), "hdc".to_string()],
                     api_calls: 0,
-                });
+                };
             }
         } else if hdc_results.sufficient {
-            return Ok(CascadeResult {
+            return CascadeResult {
                 episode_ids: hdc_results.ids(),
                 scores: hdc_results.scores(),
                 contributing_tiers: vec!["hdc".to_string()],
                 api_calls: 0,
-            });
+            };
         }
 
         // Tier 3: ConceptGraph expansion (optional)
@@ -268,12 +266,12 @@ impl CascadeRetriever {
             let concept_results = self.retrieve_concept_graph(query);
 
             if concept_results.sufficient {
-                return Ok(CascadeResult {
+                return CascadeResult {
                     episode_ids: concept_results.ids(),
                     scores: concept_results.scores(),
                     contributing_tiers: vec!["concept_graph".to_string()],
                     api_calls: 0,
-                });
+                };
             }
         }
 
@@ -288,7 +286,7 @@ impl CascadeRetriever {
             bm25_results.results.clone()
         };
 
-        Ok(CascadeResult {
+        CascadeResult {
             episode_ids: best_results.iter().map(|(id, _)| id.clone()).collect(),
             scores: best_results.iter().map(|(_, s)| *s).collect(),
             contributing_tiers: if best_results.is_empty() {
@@ -306,7 +304,7 @@ impl CascadeRetriever {
                 tiers
             },
             api_calls: 1, // Indicates API call would be needed
-        })
+        }
     }
 
     /// BM25 keyword search (Tier 1).

--- a/memory-core/src/retrieval/cascade/tests.rs
+++ b/memory-core/src/retrieval/cascade/tests.rs
@@ -57,7 +57,7 @@ fn test_placeholder_retrieve_without_csm() {
     {
         let mut retriever = CascadeRetriever::default_config();
         retriever.add_episode("ep-1", "Test episode");
-        let result = retriever.retrieve("test query").unwrap();
+        let result = retriever.retrieve("test query");
         // Without CSM feature, returns empty results
         assert!(result.episode_ids.is_empty());
         assert!(result.scores.is_empty());
@@ -120,7 +120,7 @@ mod csm_tests {
         retriever.add_episode("ep-5", "error handling patterns in async code");
 
         // Query with exact keyword match should return 0 API calls
-        let result = retriever.retrieve("authentication JWT token").unwrap();
+        let result = retriever.retrieve("authentication JWT token");
 
         // Should find the matching episode
         assert!(!result.episode_ids.is_empty());
@@ -145,9 +145,7 @@ mod csm_tests {
         retriever.add_episode("ep-5", "fix memory leak in cache implementation");
 
         // Semantic-like query (similar words but not exact match)
-        let result = retriever
-            .retrieve("user authentication and login security")
-            .unwrap();
+        let result = retriever.retrieve("user authentication and login security");
 
         // Should find related episodes
         assert!(!result.episode_ids.is_empty());
@@ -165,7 +163,7 @@ mod csm_tests {
         let retriever = CascadeRetriever::default_config();
 
         // Empty index should indicate API call needed
-        let result = retriever.retrieve("any query").unwrap();
+        let result = retriever.retrieve("any query");
 
         assert!(result.episode_ids.is_empty());
         // Should indicate API fallback needed
@@ -182,11 +180,11 @@ mod csm_tests {
         retriever.add_episode("ep-3", "unique_keyword_gamma optimization");
 
         // Query that matches exactly should hit BM25
-        let result = retriever.retrieve("unique_keyword_alpha").unwrap();
+        let result = retriever.retrieve("unique_keyword_alpha");
         assert!(result.contributing_tiers.contains(&"bm25".to_string()));
 
         // Query with no exact match but similar content should use HDC
-        let result = retriever.retrieve("implement alpha feature").unwrap();
+        let result = retriever.retrieve("implement alpha feature");
         // Either BM25 (if partial match) or HDC (if semantic similarity)
         assert!(!result.episode_ids.is_empty() || result.api_calls > 0);
     }
@@ -212,7 +210,7 @@ mod csm_tests {
         retriever.add_episode("ep-5", "async task spawning performance tips");
 
         // Query that matches multiple aspects
-        let result = retriever.retrieve("Rust async programming").unwrap();
+        let result = retriever.retrieve("Rust async programming");
 
         // Should have results from merging BM25 and HDC
         assert!(!result.episode_ids.is_empty());
@@ -238,7 +236,7 @@ mod csm_tests {
         retriever.add_episode("ep-1", "authentication implementation");
         retriever.add_episode("ep-2", "database connection setup");
 
-        let result = retriever.retrieve("authentication").unwrap();
+        let result = retriever.retrieve("authentication");
 
         // Without merge, should only use single tier
         assert!(result.contributing_tiers.len() <= 1);
@@ -274,7 +272,7 @@ mod csm_tests {
         retriever.add_episode("ep-2", "database pool connection");
         retriever.add_episode("ep-3", "rate limiting API");
 
-        let result = retriever.retrieve("authentication").unwrap();
+        let result = retriever.retrieve("authentication");
 
         // All scores should be in 0.0-1.0 range
         for score in &result.scores {
@@ -295,7 +293,7 @@ mod csm_tests {
             retriever.add_episode(&format!("ep-{i}"), &format!("episode {i} content"));
         }
 
-        let result = retriever.retrieve("episode").unwrap();
+        let result = retriever.retrieve("episode");
 
         // Should not exceed top_k
         assert!(result.episode_ids.len() <= 3);
@@ -350,7 +348,7 @@ mod csm_tests {
         retriever.add_episode("ep-5", "refactor error handling patterns");
 
         // Query with abbreviated terms that need expansion
-        let result = retriever.retrieve("fix auth bug").unwrap();
+        let result = retriever.retrieve("fix auth bug");
 
         // Should find results via concept graph expansion ("auth" → authentication domain)
         assert!(!result.episode_ids.is_empty());

--- a/memory-mcp/examples/batch_operations_demo.rs
+++ b/memory-mcp/examples/batch_operations_demo.rs
@@ -329,7 +329,8 @@ async fn demo_complex_workflow() -> anyhow::Result<()> {
         20 + 80 + 80 + 40 + 60 // Sum of all operations
     );
     println!("  Operations: {}", response.results.len());
-    println!("  Speedup: ~{:.1}x", 280.0 / duration.as_millis() as f64);
+    let speedup = 280.0 / (duration.as_secs_f64() * 1000.0);
+    println!("  Speedup: ~{speedup:.1}x");
 
     // Show execution timeline
     println!("\n  Execution Timeline:");

--- a/memory-mcp/src/bin/server_impl/oauth.rs
+++ b/memory-mcp/src/bin/server_impl/oauth.rs
@@ -205,11 +205,9 @@ mod tests {
         };
 
         let result = super::validate_bearer_token("some.token.here", &config);
-        match result {
-            AuthorizationResult::InvalidToken(msg) => {
-                assert!(msg.contains("OAUTH_TOKEN_SECRET is missing"));
-            }
-            _ => panic!("Expected InvalidToken error, got {:?}", result),
-        }
+        assert!(
+            matches!(&result, AuthorizationResult::InvalidToken(msg) if msg.contains("OAUTH_TOKEN_SECRET is missing")),
+            "Expected InvalidToken error about missing secret, got {result:?}"
+        );
     }
 }

--- a/memory-mcp/src/bin/server_impl/tools/episode_handlers.rs
+++ b/memory-mcp/src/bin/server_impl/tools/episode_handlers.rs
@@ -7,6 +7,14 @@ pub async fn handle_bulk_episodes(
 ) -> anyhow::Result<Vec<Content>> {
     use uuid::Uuid;
 
+    #[derive(serde::Serialize)]
+    struct BulkEpisodeResult {
+        requested_count: usize,
+        found_count: usize,
+        missing_count: usize,
+        episodes: Vec<serde_json::Value>,
+    }
+
     let args: Value = arguments.unwrap_or(json!({}));
     let client_id = get_client_id(&args);
 
@@ -76,14 +84,6 @@ pub async fn handle_bulk_episodes(
             serde_json::to_value(ep)
                 .map_err(|e| anyhow::anyhow!("Failed to serialize episode: {e}"))?,
         );
-    }
-
-    #[derive(serde::Serialize)]
-    struct BulkEpisodeResult {
-        requested_count: usize,
-        found_count: usize,
-        missing_count: usize,
-        episodes: Vec<serde_json::Value>,
     }
 
     let bulk_result = BulkEpisodeResult {

--- a/memory-mcp/tests/oauth_security_tests.rs
+++ b/memory-mcp/tests/oauth_security_tests.rs
@@ -7,13 +7,13 @@
 #![allow(clippy::doc_markdown)]
 #![allow(missing_docs)]
 
+#[path = "../src/bin/server_impl/mod.rs"]
+mod server_impl;
+
 use do_memory_mcp::protocol::OAuthConfig;
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use serde::{Deserialize, Serialize};
 use server_impl::{AuthorizationResult, validate_bearer_token};
-
-#[path = "../src/bin/server_impl/mod.rs"]
-mod server_impl;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct Claims {


### PR DESCRIPTION
## Summary

Resolves all pre-existing clippy warnings across the workspace and brings api.rs under the 500 LOC limit.

## Changes

### Oversized file split
- Extracted 5 persistence helpers from `api.rs` (508 LOC) to new `persistence.rs`
- `api.rs` is now 332 LOC (under 500 limit)

### Clippy fixes
| File | Warning | Fix |
|------|---------|-----|
| `cascade/mod.rs` | `clippy::unnecessary_wraps` | Removed `Result` wrapper from `retrieve()` (always returned `Ok`) |
| `cascade/tests.rs` | follow-up | Removed `.unwrap()` calls on `retrieve()` |
| `oauth.rs` | `clippy::panic` + `uninlined_format_args` | Replaced `match` + `panic!` with `assert!` + `matches!` |
| `episode_handlers.rs` | `clippy::items_after_statements` | Moved `struct` definition before statements |
| `batch_operations_demo.rs` | `clippy::cast_precision_loss` | Changed `as_millis() as f64` to `as_secs_f64() * 1000.0` |
| `oauth_security_tests.rs` | `clippy::items_after_statements` | Moved `mod` declaration before `use` |
| `episode_update_test.rs` | `clippy::doc_markdown` | Added backticks around env var names |

## Validation
- **clippy**: 0 warnings ✅
- **fmt**: PASS ✅
- **tests**: 3,317 passed, 167 skipped, 0 failures ✅
- **quality-gates**: PASS ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recommendation attribution capabilities to record sessions and feedback, retrieve stored data, and view aggregate statistics.
  * Added procedural memory management with store, retrieve, delete, and query operations.

* **Bug Fixes**
  * Fixed serialization issue in bulk episode operations.

* **Tests**
  * Improved OAuth security testing and updated cascade retriever tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-o-hub/rust-self-learning-memory/pull/579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->