### PR TITLE
Add test coverage for eval and advanced time-series analysis

### DIFF
--- a/memory-cli/src/commands/eval.rs
+++ b/memory-cli/src/commands/eval.rs
@@ -417,7 +417,10 @@ pub async fn set_threshold(
 }
 
 fn format_time(dt: chrono::DateTime<chrono::Utc>) -> String {
-    let now = chrono::Utc::now();
+    format_time_relative(dt, chrono::Utc::now())
+}
+
+fn format_time_relative(dt: chrono::DateTime<chrono::Utc>, now: chrono::DateTime<chrono::Utc>) -> String {
     let diff = now - dt;
 
     if diff.num_seconds() < 60 {
@@ -430,5 +433,128 @@ fn format_time(dt: chrono::DateTime<chrono::Utc>) -> String {
         format!("{} days ago", diff.num_days())
     } else {
         format!("{} weeks ago", diff.num_weeks())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use do_memory_core::{SelfLearningMemory, TaskContext, TaskType, TaskOutcome, ExecutionStep, MemoryConfig};
+    use crate::config::Config;
+    use crate::output::OutputFormat;
+
+    async fn create_test_episode(
+        memory: &SelfLearningMemory,
+        domain: &str,
+        is_success: bool,
+    ) {
+        let context = TaskContext {
+            domain: domain.to_string(),
+            ..Default::default()
+        };
+        let id = memory.start_episode("test task".to_string(), context, TaskType::CodeGeneration).await;
+
+        // Add multiple steps to increase quality score
+        for i in 1..=5 {
+            let mut step = ExecutionStep::new(i, "test".to_string(), format!("test step {}", i));
+            step.latency_ms = 100;
+            memory.log_step(id, step).await;
+        }
+
+        let outcome = if is_success {
+            TaskOutcome::Success {
+                verdict: "done".to_string(),
+                artifacts: vec!["test.rs".to_string(), "test_spec.rs".to_string(), "README.md".to_string()],
+            }
+        } else {
+            TaskOutcome::Failure {
+                reason: "failed".to_string(),
+                error_details: None,
+            }
+        };
+
+        memory.complete_episode(id, outcome).await.expect("Failed to complete episode");
+    }
+
+    #[tokio::test]
+    async fn test_calibration_empty() {
+        let mut config = MemoryConfig::default();
+        config.quality_threshold = 0.0;
+        let memory = SelfLearningMemory::with_config(config);
+        let config = Config::default();
+
+        let result = calibration(None, false, 5, &memory, &config, OutputFormat::Json).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_calibration_with_data() {
+        let mut config = MemoryConfig::default();
+        config.quality_threshold = 0.0;
+        let memory = SelfLearningMemory::with_config(config);
+        let config = Config::default();
+
+        for _ in 0..6 {
+            create_test_episode(&memory, "domain-a", true).await;
+        }
+        for _ in 0..3 {
+            create_test_episode(&memory, "domain-b", true).await;
+        }
+
+        // Test with show_all = true
+        let result = calibration(None, true, 5, &memory, &config, OutputFormat::Json).await;
+        assert!(result.is_ok());
+
+        // Test with filter
+        let result = calibration(Some("domain-a".to_string()), true, 5, &memory, &config, OutputFormat::Json).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_domain_stats_success() {
+        let mut config = MemoryConfig::default();
+        config.quality_threshold = 0.0;
+        let memory = SelfLearningMemory::with_config(config);
+        let config = Config::default();
+
+        create_test_episode(&memory, "test-domain", true).await;
+
+        let result = domain_stats("test-domain".to_string(), &memory, &config, OutputFormat::Json).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_domain_stats_not_found() {
+        let mut config = MemoryConfig::default();
+        config.quality_threshold = 0.0;
+        let memory = SelfLearningMemory::with_config(config);
+        let config = Config::default();
+
+        let result = domain_stats("non-existent".to_string(), &memory, &config, OutputFormat::Json).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("No episodes found"));
+    }
+
+    #[tokio::test]
+    async fn test_set_threshold_error() {
+        let mut config = MemoryConfig::default();
+        config.quality_threshold = 0.0;
+        let memory = SelfLearningMemory::with_config(config);
+        let config = Config::default();
+
+        let result = set_threshold("domain".to_string(), Some(1.0), None, &memory, &config, OutputFormat::Json).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Custom threshold overrides are not supported"));
+    }
+
+    #[test]
+    fn test_format_time() {
+        let now = chrono::DateTime::from_timestamp(1717171717, 0).unwrap();
+
+        assert_eq!(format_time_relative(now, now), "just now");
+        assert_eq!(format_time_relative(now - chrono::Duration::minutes(5), now), "5 minutes ago");
+        assert_eq!(format_time_relative(now - chrono::Duration::hours(2), now), "2 hours ago");
+        assert_eq!(format_time_relative(now - chrono::Duration::days(3), now), "3 days ago");
+        assert_eq!(format_time_relative(now - chrono::Duration::days(15), now), "2 weeks ago");
     }
 }

--- a/memory-cli/src/commands/eval.rs
+++ b/memory-cli/src/commands/eval.rs
@@ -420,7 +420,10 @@ fn format_time(dt: chrono::DateTime<chrono::Utc>) -> String {
     format_time_relative(dt, chrono::Utc::now())
 }
 
-fn format_time_relative(dt: chrono::DateTime<chrono::Utc>, now: chrono::DateTime<chrono::Utc>) -> String {
+fn format_time_relative(
+    dt: chrono::DateTime<chrono::Utc>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> String {
     let diff = now - dt;
 
     if diff.num_seconds() < 60 {
@@ -439,20 +442,20 @@ fn format_time_relative(dt: chrono::DateTime<chrono::Utc>, now: chrono::DateTime
 #[cfg(test)]
 mod tests {
     use super::*;
-    use do_memory_core::{SelfLearningMemory, TaskContext, TaskType, TaskOutcome, ExecutionStep, MemoryConfig};
     use crate::config::Config;
     use crate::output::OutputFormat;
+    use do_memory_core::{
+        ExecutionStep, MemoryConfig, SelfLearningMemory, TaskContext, TaskOutcome, TaskType,
+    };
 
-    async fn create_test_episode(
-        memory: &SelfLearningMemory,
-        domain: &str,
-        is_success: bool,
-    ) {
+    async fn create_test_episode(memory: &SelfLearningMemory, domain: &str, is_success: bool) {
         let context = TaskContext {
             domain: domain.to_string(),
             ..Default::default()
         };
-        let id = memory.start_episode("test task".to_string(), context, TaskType::CodeGeneration).await;
+        let id = memory
+            .start_episode("test task".to_string(), context, TaskType::CodeGeneration)
+            .await;
 
         // Add multiple steps to increase quality score
         for i in 1..=5 {
@@ -464,7 +467,11 @@ mod tests {
         let outcome = if is_success {
             TaskOutcome::Success {
                 verdict: "done".to_string(),
-                artifacts: vec!["test.rs".to_string(), "test_spec.rs".to_string(), "README.md".to_string()],
+                artifacts: vec![
+                    "test.rs".to_string(),
+                    "test_spec.rs".to_string(),
+                    "README.md".to_string(),
+                ],
             }
         } else {
             TaskOutcome::Failure {
@@ -473,7 +480,10 @@ mod tests {
             }
         };
 
-        memory.complete_episode(id, outcome).await.expect("Failed to complete episode");
+        memory
+            .complete_episode(id, outcome)
+            .await
+            .expect("Failed to complete episode");
     }
 
     #[tokio::test]
@@ -506,7 +516,15 @@ mod tests {
         assert!(result.is_ok());
 
         // Test with filter
-        let result = calibration(Some("domain-a".to_string()), true, 5, &memory, &config, OutputFormat::Json).await;
+        let result = calibration(
+            Some("domain-a".to_string()),
+            true,
+            5,
+            &memory,
+            &config,
+            OutputFormat::Json,
+        )
+        .await;
         assert!(result.is_ok());
     }
 
@@ -519,7 +537,13 @@ mod tests {
 
         create_test_episode(&memory, "test-domain", true).await;
 
-        let result = domain_stats("test-domain".to_string(), &memory, &config, OutputFormat::Json).await;
+        let result = domain_stats(
+            "test-domain".to_string(),
+            &memory,
+            &config,
+            OutputFormat::Json,
+        )
+        .await;
         assert!(result.is_ok());
     }
 
@@ -530,9 +554,20 @@ mod tests {
         let memory = SelfLearningMemory::with_config(config);
         let config = Config::default();
 
-        let result = domain_stats("non-existent".to_string(), &memory, &config, OutputFormat::Json).await;
+        let result = domain_stats(
+            "non-existent".to_string(),
+            &memory,
+            &config,
+            OutputFormat::Json,
+        )
+        .await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("No episodes found"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("No episodes found")
+        );
     }
 
     #[tokio::test]
@@ -542,9 +577,22 @@ mod tests {
         let memory = SelfLearningMemory::with_config(config);
         let config = Config::default();
 
-        let result = set_threshold("domain".to_string(), Some(1.0), None, &memory, &config, OutputFormat::Json).await;
+        let result = set_threshold(
+            "domain".to_string(),
+            Some(1.0),
+            None,
+            &memory,
+            &config,
+            OutputFormat::Json,
+        )
+        .await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Custom threshold overrides are not supported"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Custom threshold overrides are not supported")
+        );
     }
 
     #[test]
@@ -552,9 +600,21 @@ mod tests {
         let now = chrono::DateTime::from_timestamp(1717171717, 0).unwrap();
 
         assert_eq!(format_time_relative(now, now), "just now");
-        assert_eq!(format_time_relative(now - chrono::Duration::minutes(5), now), "5 minutes ago");
-        assert_eq!(format_time_relative(now - chrono::Duration::hours(2), now), "2 hours ago");
-        assert_eq!(format_time_relative(now - chrono::Duration::days(3), now), "3 days ago");
-        assert_eq!(format_time_relative(now - chrono::Duration::days(15), now), "2 weeks ago");
+        assert_eq!(
+            format_time_relative(now - chrono::Duration::minutes(5), now),
+            "5 minutes ago"
+        );
+        assert_eq!(
+            format_time_relative(now - chrono::Duration::hours(2), now),
+            "2 hours ago"
+        );
+        assert_eq!(
+            format_time_relative(now - chrono::Duration::days(3), now),
+            "3 days ago"
+        );
+        assert_eq!(
+            format_time_relative(now - chrono::Duration::days(15), now),
+            "2 weeks ago"
+        );
     }
 }

--- a/memory-cli/src/commands/eval.rs
+++ b/memory-cli/src/commands/eval.rs
@@ -488,8 +488,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_calibration_empty() {
-        let mut config = MemoryConfig::default();
-        config.quality_threshold = 0.0;
+        let config = MemoryConfig {
+            quality_threshold: 0.0,
+            ..Default::default()
+        };
         let memory = SelfLearningMemory::with_config(config);
         let config = Config::default();
 
@@ -499,8 +501,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_calibration_with_data() {
-        let mut config = MemoryConfig::default();
-        config.quality_threshold = 0.0;
+        let config = MemoryConfig {
+            quality_threshold: 0.0,
+            ..Default::default()
+        };
         let memory = SelfLearningMemory::with_config(config);
         let config = Config::default();
 
@@ -530,8 +534,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_domain_stats_success() {
-        let mut config = MemoryConfig::default();
-        config.quality_threshold = 0.0;
+        let config = MemoryConfig {
+            quality_threshold: 0.0,
+            ..Default::default()
+        };
         let memory = SelfLearningMemory::with_config(config);
         let config = Config::default();
 
@@ -549,8 +555,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_domain_stats_not_found() {
-        let mut config = MemoryConfig::default();
-        config.quality_threshold = 0.0;
+        let config = MemoryConfig {
+            quality_threshold: 0.0,
+            ..Default::default()
+        };
         let memory = SelfLearningMemory::with_config(config);
         let config = Config::default();
 
@@ -572,8 +580,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_threshold_error() {
-        let mut config = MemoryConfig::default();
-        config.quality_threshold = 0.0;
+        let config = MemoryConfig {
+            quality_threshold: 0.0,
+            ..Default::default()
+        };
         let memory = SelfLearningMemory::with_config(config);
         let config = Config::default();
 

--- a/memory-mcp/src/mcp/tools/advanced_pattern_analysis/time_series.rs
+++ b/memory-mcp/src/mcp/tools/advanced_pattern_analysis/time_series.rs
@@ -104,3 +104,131 @@ impl Default for TimeSeriesExtractor {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use do_memory_core::{Episode, ExecutionStep, TaskContext, TaskType, TaskOutcome, ExecutionResult, ComplexityLevel};
+    use do_memory_core::episode::structs::{PatternApplication, ApplicationOutcome};
+    use uuid::Uuid;
+
+    fn create_mock_episode(latency_ms: u64, success: bool, complexity: ComplexityLevel) -> Episode {
+        let mut episode = Episode::new(
+            "test task".to_string(),
+            TaskContext {
+                domain: "test".to_string(),
+                complexity,
+                ..Default::default()
+            },
+            TaskType::CodeGeneration,
+        );
+
+        let mut step = ExecutionStep::new(1, "test".to_string(), "test step".to_string());
+        step.latency_ms = latency_ms;
+        step.result = Some(ExecutionResult::Success { output: "ok".to_string() });
+        episode.steps.push(step);
+
+        if success {
+            episode.outcome = Some(TaskOutcome::Success {
+                verdict: "success".to_string(),
+                artifacts: vec![],
+            });
+        } else {
+            episode.outcome = Some(TaskOutcome::Failure {
+                reason: "failed".to_string(),
+                error_details: None,
+            });
+        }
+
+        episode
+    }
+
+    #[test]
+    fn test_extract_metric_execution_time() {
+        let extractor = TimeSeriesExtractor::new();
+        let episode = create_mock_episode(150, true, ComplexityLevel::Simple);
+        let all = vec![episode.clone()];
+
+        let value = extractor.extract_metric("execution_time_ms", &episode, &all);
+        assert_eq!(value, Some(150.0));
+    }
+
+    #[test]
+    fn test_extract_metric_success_rate() {
+        let extractor = TimeSeriesExtractor::new();
+        let ep1 = create_mock_episode(100, true, ComplexityLevel::Simple);
+        let ep2 = create_mock_episode(100, false, ComplexityLevel::Simple);
+        let all = vec![ep1.clone(), ep2.clone()];
+
+        let value = extractor.extract_metric("success_rate", &ep1, &all);
+        assert_eq!(value, Some(50.0));
+    }
+
+    #[test]
+    fn test_extract_metric_complexity() {
+        let extractor = TimeSeriesExtractor::new();
+
+        let ep1 = create_mock_episode(100, true, ComplexityLevel::Simple);
+        assert_eq!(extractor.extract_metric("complexity_score", &ep1, &[]), Some(1.0));
+
+        let ep2 = create_mock_episode(100, true, ComplexityLevel::Moderate);
+        assert_eq!(extractor.extract_metric("complexity_score", &ep2, &[]), Some(2.0));
+
+        let ep3 = create_mock_episode(100, true, ComplexityLevel::Complex);
+        assert_eq!(extractor.extract_metric("complexity_score", &ep3, &[]), Some(3.0));
+    }
+
+    #[test]
+    fn test_extract_metric_pattern_match() {
+        let extractor = TimeSeriesExtractor::new();
+        let mut ep = create_mock_episode(100, true, ComplexityLevel::Simple);
+
+        // No patterns
+        assert_eq!(extractor.extract_metric("pattern_match_score", &ep, &[]), Some(0.0));
+
+        // With applied patterns
+        ep.applied_patterns.push(PatternApplication {
+            pattern_id: Uuid::new_v4(),
+            applied_at_step: 1,
+            outcome: ApplicationOutcome::Helped,
+            notes: None,
+        });
+        assert_eq!(extractor.extract_metric("pattern_match_score", &ep, &[]), Some(1.0));
+
+        // Fallback to pattern density
+        let mut ep_no_applied = create_mock_episode(100, true, ComplexityLevel::Simple);
+        ep_no_applied.patterns.push(Uuid::new_v4());
+        let mut ep_max = create_mock_episode(100, true, ComplexityLevel::Simple);
+        ep_max.patterns.push(Uuid::new_v4());
+        ep_max.patterns.push(Uuid::new_v4());
+        let all = vec![ep_no_applied.clone(), ep_max.clone()];
+        assert_eq!(extractor.extract_metric("pattern_match_score", &ep_no_applied, &all), Some(0.5));
+    }
+
+    #[test]
+    fn test_extract_metric_memory_usage() {
+        let extractor = TimeSeriesExtractor::new();
+        let ep = create_mock_episode(100, true, ComplexityLevel::Simple);
+
+        let value = extractor.extract_metric("memory_usage_mb", &ep, &[]);
+        assert!(value.is_some());
+        assert!(value.unwrap() > 0.0);
+    }
+
+    #[test]
+    fn test_extract_metric_none() {
+        let extractor = TimeSeriesExtractor::new();
+        let ep = create_mock_episode(100, true, ComplexityLevel::Simple);
+
+        assert_eq!(extractor.extract_metric("invalid_metric", &ep, &[]), None);
+    }
+
+    #[test]
+    fn test_meets_threshold() {
+        let extractor = TimeSeriesExtractor::new();
+
+        assert!(!extractor.meets_threshold(&[], 3));
+        assert!(!extractor.meets_threshold(&[1.0, 2.0], 3));
+        assert!(extractor.meets_threshold(&[1.0, 2.0, 3.0], 3));
+    }
+}

--- a/memory-mcp/src/mcp/tools/advanced_pattern_analysis/time_series.rs
+++ b/memory-mcp/src/mcp/tools/advanced_pattern_analysis/time_series.rs
@@ -108,8 +108,11 @@ impl Default for TimeSeriesExtractor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use do_memory_core::{Episode, ExecutionStep, TaskContext, TaskType, TaskOutcome, ExecutionResult, ComplexityLevel};
-    use do_memory_core::episode::structs::{PatternApplication, ApplicationOutcome};
+    use do_memory_core::episode::structs::{ApplicationOutcome, PatternApplication};
+    use do_memory_core::{
+        ComplexityLevel, Episode, ExecutionResult, ExecutionStep, TaskContext, TaskOutcome,
+        TaskType,
+    };
     use uuid::Uuid;
 
     fn create_mock_episode(latency_ms: u64, success: bool, complexity: ComplexityLevel) -> Episode {
@@ -125,7 +128,9 @@ mod tests {
 
         let mut step = ExecutionStep::new(1, "test".to_string(), "test step".to_string());
         step.latency_ms = latency_ms;
-        step.result = Some(ExecutionResult::Success { output: "ok".to_string() });
+        step.result = Some(ExecutionResult::Success {
+            output: "ok".to_string(),
+        });
         episode.steps.push(step);
 
         if success {
@@ -169,13 +174,22 @@ mod tests {
         let extractor = TimeSeriesExtractor::new();
 
         let ep1 = create_mock_episode(100, true, ComplexityLevel::Simple);
-        assert_eq!(extractor.extract_metric("complexity_score", &ep1, &[]), Some(1.0));
+        assert_eq!(
+            extractor.extract_metric("complexity_score", &ep1, &[]),
+            Some(1.0)
+        );
 
         let ep2 = create_mock_episode(100, true, ComplexityLevel::Moderate);
-        assert_eq!(extractor.extract_metric("complexity_score", &ep2, &[]), Some(2.0));
+        assert_eq!(
+            extractor.extract_metric("complexity_score", &ep2, &[]),
+            Some(2.0)
+        );
 
         let ep3 = create_mock_episode(100, true, ComplexityLevel::Complex);
-        assert_eq!(extractor.extract_metric("complexity_score", &ep3, &[]), Some(3.0));
+        assert_eq!(
+            extractor.extract_metric("complexity_score", &ep3, &[]),
+            Some(3.0)
+        );
     }
 
     #[test]
@@ -184,7 +198,10 @@ mod tests {
         let mut ep = create_mock_episode(100, true, ComplexityLevel::Simple);
 
         // No patterns
-        assert_eq!(extractor.extract_metric("pattern_match_score", &ep, &[]), Some(0.0));
+        assert_eq!(
+            extractor.extract_metric("pattern_match_score", &ep, &[]),
+            Some(0.0)
+        );
 
         // With applied patterns
         ep.applied_patterns.push(PatternApplication {
@@ -193,7 +210,10 @@ mod tests {
             outcome: ApplicationOutcome::Helped,
             notes: None,
         });
-        assert_eq!(extractor.extract_metric("pattern_match_score", &ep, &[]), Some(1.0));
+        assert_eq!(
+            extractor.extract_metric("pattern_match_score", &ep, &[]),
+            Some(1.0)
+        );
 
         // Fallback to pattern density
         let mut ep_no_applied = create_mock_episode(100, true, ComplexityLevel::Simple);
@@ -202,7 +222,10 @@ mod tests {
         ep_max.patterns.push(Uuid::new_v4());
         ep_max.patterns.push(Uuid::new_v4());
         let all = vec![ep_no_applied.clone(), ep_max.clone()];
-        assert_eq!(extractor.extract_metric("pattern_match_score", &ep_no_applied, &all), Some(0.5));
+        assert_eq!(
+            extractor.extract_metric("pattern_match_score", &ep_no_applied, &all),
+            Some(0.5)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Added comprehensive unit tests for `memory-cli/src/commands/eval.rs` and `memory-mcp/src/mcp/tools/advanced_pattern_analysis/time_series.rs` to address files with 0% coverage. 

Changes include:
- Unit tests for CLI `calibration`, `domain_stats`, and `set_threshold` commands.
- Refactored CLI `format_time` logic to allow deterministic testing with a fixed clock.
- Unit tests for MCP `TimeSeriesExtractor` covering all extracted metrics and threshold logic.
- Proper initialization of test memory to bypass quality gates for minimal mock episodes.
- Verified CLI tests pass successfully; MCP tests verified for logical correctness via compilation and `cargo check`.

Fixes #592

---
*PR created automatically by Jules for task [18162790941263426509](https://jules.google.com/task/18162790941263426509) started by @d-o-hub*