### PR TITLE
Recover coverage for relationship storage and core modules

### DIFF
--- a/benches/cosine_similarity_benchmark.rs
+++ b/benches/cosine_similarity_benchmark.rs
@@ -1,10 +1,14 @@
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+//! Benchmarks for cosine similarity implementations.
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use do_memory_core::embeddings::cosine_similarity;
-use rand::{Rng, thread_rng};
+use rand::distr::{Distribution, Uniform};
+use std::hint::black_box;
 
 fn generate_vector(dim: usize) -> Vec<f32> {
-    let mut rng = thread_rng();
-    (0..dim).map(|_| rng.gen_range(-1.0..1.0)).collect()
+    let mut rng = rand::rng();
+    let range = Uniform::new(-1.0, 1.0).unwrap();
+    (0..dim).map(|_| range.sample(&mut rng)).collect()
 }
 
 fn bench_cosine_similarity(c: &mut Criterion) {

--- a/memory-core/src/extraction/tests.rs
+++ b/memory-core/src/extraction/tests.rs
@@ -55,8 +55,7 @@ fn test_extract_from_complete_episode() {
         patterns
             .iter()
             .any(|p| matches!(p, Pattern::ToolSequence { tools, .. } if tools.len() == 3)),
-        "expected ToolSequence pattern with 3 tools, got {:?}",
-        patterns
+        "expected ToolSequence pattern with 3 tools, got {patterns:?}"
     );
 }
 

--- a/memory-core/src/memory/relationships/tests.rs
+++ b/memory-core/src/memory/relationships/tests.rs
@@ -76,57 +76,8 @@ async fn test_get_dependents_empty() {
     assert!(deps.is_empty());
 }
 
-#[tokio::test]
-async fn test_build_relationship_graph_single_node() {
+async fn setup_test_memory() -> (SelfLearningMemory, Uuid, Uuid) {
     let memory = SelfLearningMemory::new();
-
-    // Create an episode
-    let episode_id = memory
-        .start_episode(
-            "Test task".to_string(),
-            TaskContext::default(),
-            TaskType::Testing,
-        )
-        .await;
-
-    let graph = memory
-        .build_relationship_graph(episode_id, 3)
-        .await
-        .unwrap();
-
-    assert_eq!(graph.root, episode_id);
-    assert_eq!(graph.node_count(), 1);
-    assert_eq!(graph.edge_count(), 0);
-}
-
-#[tokio::test]
-async fn test_get_episode_with_relationships() {
-    let memory = SelfLearningMemory::new();
-
-    // Create an episode
-    let episode_id = memory
-        .start_episode(
-            "Test task".to_string(),
-            TaskContext::default(),
-            TaskType::Testing,
-        )
-        .await;
-
-    let result = memory
-        .get_episode_with_relationships(episode_id)
-        .await
-        .unwrap();
-
-    assert_eq!(result.episode.episode_id, episode_id);
-    assert!(result.outgoing.is_empty());
-    assert!(result.incoming.is_empty());
-    assert_eq!(result.total_relationships(), 0);
-}
-
-#[tokio::test]
-async fn test_add_remove_episode_relationship_success() {
-    let memory = SelfLearningMemory::new();
-
     let ep1 = memory
         .start_episode(
             "Task 1".to_string(),
@@ -141,6 +92,35 @@ async fn test_add_remove_episode_relationship_success() {
             TaskType::Testing,
         )
         .await;
+    (memory, ep1, ep2)
+}
+
+#[tokio::test]
+async fn test_build_relationship_graph_single_node() {
+    let (memory, ep1, _) = setup_test_memory().await;
+
+    let graph = memory.build_relationship_graph(ep1, 3).await.unwrap();
+
+    assert_eq!(graph.root, ep1);
+    assert_eq!(graph.node_count(), 1);
+    assert_eq!(graph.edge_count(), 0);
+}
+
+#[tokio::test]
+async fn test_get_episode_with_relationships() {
+    let (memory, ep1, _) = setup_test_memory().await;
+
+    let result = memory.get_episode_with_relationships(ep1).await.unwrap();
+
+    assert_eq!(result.episode.episode_id, ep1);
+    assert!(result.outgoing.is_empty());
+    assert!(result.incoming.is_empty());
+    assert_eq!(result.total_relationships(), 0);
+}
+
+#[tokio::test]
+async fn test_add_remove_episode_relationship_success() {
+    let (memory, ep1, ep2) = setup_test_memory().await;
 
     let rel_id = memory
         .add_episode_relationship(
@@ -169,22 +149,7 @@ async fn test_add_remove_episode_relationship_success() {
 
 #[tokio::test]
 async fn test_find_related_episodes_with_filters() {
-    let memory = SelfLearningMemory::new();
-
-    let ep1 = memory
-        .start_episode(
-            "Task 1".to_string(),
-            TaskContext::default(),
-            TaskType::Testing,
-        )
-        .await;
-    let ep2 = memory
-        .start_episode(
-            "Task 2".to_string(),
-            TaskContext::default(),
-            TaskType::Testing,
-        )
-        .await;
+    let (memory, ep1, ep2) = setup_test_memory().await;
     let ep3 = memory
         .start_episode(
             "Task 3".to_string(),
@@ -224,22 +189,7 @@ async fn test_find_related_episodes_with_filters() {
 
 #[tokio::test]
 async fn test_build_relationship_graph_complex() {
-    let memory = SelfLearningMemory::new();
-
-    let ep1 = memory
-        .start_episode(
-            "Task 1".to_string(),
-            TaskContext::default(),
-            TaskType::Testing,
-        )
-        .await;
-    let ep2 = memory
-        .start_episode(
-            "Task 2".to_string(),
-            TaskContext::default(),
-            TaskType::Testing,
-        )
-        .await;
+    let (memory, ep1, ep2) = setup_test_memory().await;
     let ep3 = memory
         .start_episode(
             "Task 3".to_string(),
@@ -276,22 +226,7 @@ async fn test_build_relationship_graph_complex() {
 
 #[tokio::test]
 async fn test_cycle_detection() {
-    let memory = SelfLearningMemory::new();
-
-    let ep1 = memory
-        .start_episode(
-            "Task 1".to_string(),
-            TaskContext::default(),
-            TaskType::Testing,
-        )
-        .await;
-    let ep2 = memory
-        .start_episode(
-            "Task 2".to_string(),
-            TaskContext::default(),
-            TaskType::Testing,
-        )
-        .await;
+    let (memory, ep1, ep2) = setup_test_memory().await;
 
     // ep1 depends on ep2
     memory
@@ -320,22 +255,7 @@ async fn test_cycle_detection() {
 
 #[tokio::test]
 async fn test_get_all_relationships() {
-    let memory = SelfLearningMemory::new();
-
-    let ep1 = memory
-        .start_episode(
-            "Task 1".to_string(),
-            TaskContext::default(),
-            TaskType::Testing,
-        )
-        .await;
-    let ep2 = memory
-        .start_episode(
-            "Task 2".to_string(),
-            TaskContext::default(),
-            TaskType::Testing,
-        )
-        .await;
+    let (memory, ep1, ep2) = setup_test_memory().await;
 
     memory
         .add_episode_relationship(
@@ -353,22 +273,7 @@ async fn test_get_all_relationships() {
 
 #[tokio::test]
 async fn test_get_relationship_by_id() {
-    let memory = SelfLearningMemory::new();
-
-    let ep1 = memory
-        .start_episode(
-            "Task 1".to_string(),
-            TaskContext::default(),
-            TaskType::Testing,
-        )
-        .await;
-    let ep2 = memory
-        .start_episode(
-            "Task 2".to_string(),
-            TaskContext::default(),
-            TaskType::Testing,
-        )
-        .await;
+    let (memory, ep1, ep2) = setup_test_memory().await;
 
     let rel_id = memory
         .add_episode_relationship(

--- a/memory-core/src/memory/relationships/tests.rs
+++ b/memory-core/src/memory/relationships/tests.rs
@@ -122,3 +122,265 @@ async fn test_get_episode_with_relationships() {
     assert!(result.incoming.is_empty());
     assert_eq!(result.total_relationships(), 0);
 }
+
+#[tokio::test]
+async fn test_add_remove_episode_relationship_success() {
+    let memory = SelfLearningMemory::new();
+
+    let ep1 = memory
+        .start_episode(
+            "Task 1".to_string(),
+            TaskContext::default(),
+            TaskType::Testing,
+        )
+        .await;
+    let ep2 = memory
+        .start_episode(
+            "Task 2".to_string(),
+            TaskContext::default(),
+            TaskType::Testing,
+        )
+        .await;
+
+    let rel_id = memory
+        .add_episode_relationship(
+            ep1,
+            ep2,
+            RelationshipType::DependsOn,
+            RelationshipMetadata::with_reason("Test".to_string()),
+        )
+        .await
+        .unwrap();
+
+    let exists = memory
+        .relationship_exists(ep1, ep2, RelationshipType::DependsOn)
+        .await
+        .unwrap();
+    assert!(exists);
+
+    memory.remove_episode_relationship(rel_id).await.unwrap();
+
+    let exists_after = memory
+        .relationship_exists(ep1, ep2, RelationshipType::DependsOn)
+        .await
+        .unwrap();
+    assert!(!exists_after);
+}
+
+#[tokio::test]
+async fn test_find_related_episodes_with_filters() {
+    let memory = SelfLearningMemory::new();
+
+    let ep1 = memory
+        .start_episode(
+            "Task 1".to_string(),
+            TaskContext::default(),
+            TaskType::Testing,
+        )
+        .await;
+    let ep2 = memory
+        .start_episode(
+            "Task 2".to_string(),
+            TaskContext::default(),
+            TaskType::Testing,
+        )
+        .await;
+    let ep3 = memory
+        .start_episode(
+            "Task 3".to_string(),
+            TaskContext::default(),
+            TaskType::Testing,
+        )
+        .await;
+
+    // ep1 -> ep2 (DependsOn)
+    memory
+        .add_episode_relationship(
+            ep1,
+            ep2,
+            RelationshipType::DependsOn,
+            RelationshipMetadata::default(),
+        )
+        .await
+        .unwrap();
+
+    // ep1 -> ep3 (ParentChild)
+    memory
+        .add_episode_relationship(
+            ep1,
+            ep3,
+            RelationshipType::ParentChild,
+            RelationshipMetadata::default(),
+        )
+        .await
+        .unwrap();
+
+    let filter = RelationshipFilter::new().with_type(RelationshipType::DependsOn);
+    let related = memory.find_related_episodes(ep1, filter).await.unwrap();
+
+    assert_eq!(related.len(), 1);
+    assert_eq!(related[0], ep2);
+}
+
+#[tokio::test]
+async fn test_build_relationship_graph_complex() {
+    let memory = SelfLearningMemory::new();
+
+    let ep1 = memory
+        .start_episode(
+            "Task 1".to_string(),
+            TaskContext::default(),
+            TaskType::Testing,
+        )
+        .await;
+    let ep2 = memory
+        .start_episode(
+            "Task 2".to_string(),
+            TaskContext::default(),
+            TaskType::Testing,
+        )
+        .await;
+    let ep3 = memory
+        .start_episode(
+            "Task 3".to_string(),
+            TaskContext::default(),
+            TaskType::Testing,
+        )
+        .await;
+
+    // ep1 -> ep2 -> ep3
+    memory
+        .add_episode_relationship(
+            ep1,
+            ep2,
+            RelationshipType::RelatedTo,
+            RelationshipMetadata::default(),
+        )
+        .await
+        .unwrap();
+    memory
+        .add_episode_relationship(
+            ep2,
+            ep3,
+            RelationshipType::RelatedTo,
+            RelationshipMetadata::default(),
+        )
+        .await
+        .unwrap();
+
+    let graph = memory.build_relationship_graph(ep1, 2).await.unwrap();
+
+    assert_eq!(graph.node_count(), 3);
+    assert_eq!(graph.edge_count(), 2);
+}
+
+#[tokio::test]
+async fn test_cycle_detection() {
+    let memory = SelfLearningMemory::new();
+
+    let ep1 = memory
+        .start_episode(
+            "Task 1".to_string(),
+            TaskContext::default(),
+            TaskType::Testing,
+        )
+        .await;
+    let ep2 = memory
+        .start_episode(
+            "Task 2".to_string(),
+            TaskContext::default(),
+            TaskType::Testing,
+        )
+        .await;
+
+    // ep1 depends on ep2
+    memory
+        .add_episode_relationship(
+            ep1,
+            ep2,
+            RelationshipType::DependsOn,
+            RelationshipMetadata::default(),
+        )
+        .await
+        .unwrap();
+
+    // ep2 depends on ep1 -> Cycle!
+    let result = memory
+        .add_episode_relationship(
+            ep2,
+            ep1,
+            RelationshipType::DependsOn,
+            RelationshipMetadata::default(),
+        )
+        .await;
+
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("cycle"));
+}
+
+#[tokio::test]
+async fn test_get_all_relationships() {
+    let memory = SelfLearningMemory::new();
+
+    let ep1 = memory
+        .start_episode(
+            "Task 1".to_string(),
+            TaskContext::default(),
+            TaskType::Testing,
+        )
+        .await;
+    let ep2 = memory
+        .start_episode(
+            "Task 2".to_string(),
+            TaskContext::default(),
+            TaskType::Testing,
+        )
+        .await;
+
+    memory
+        .add_episode_relationship(
+            ep1,
+            ep2,
+            RelationshipType::RelatedTo,
+            RelationshipMetadata::default(),
+        )
+        .await
+        .unwrap();
+
+    let all = memory.get_all_relationships().await.unwrap();
+    assert_eq!(all.len(), 1);
+}
+
+#[tokio::test]
+async fn test_get_relationship_by_id() {
+    let memory = SelfLearningMemory::new();
+
+    let ep1 = memory
+        .start_episode(
+            "Task 1".to_string(),
+            TaskContext::default(),
+            TaskType::Testing,
+        )
+        .await;
+    let ep2 = memory
+        .start_episode(
+            "Task 2".to_string(),
+            TaskContext::default(),
+            TaskType::Testing,
+        )
+        .await;
+
+    let rel_id = memory
+        .add_episode_relationship(
+            ep1,
+            ep2,
+            RelationshipType::RelatedTo,
+            RelationshipMetadata::default(),
+        )
+        .await
+        .unwrap();
+
+    let rel = memory.get_relationship_by_id(rel_id).await.unwrap();
+    assert!(rel.is_some());
+    assert_eq!(rel.unwrap().id, rel_id);
+}

--- a/memory-storage-turso/src/relationships_tests.rs
+++ b/memory-storage-turso/src/relationships_tests.rs
@@ -54,11 +54,16 @@ async fn create_test_episode(storage: &TursoStorage) -> Uuid {
     episode_id
 }
 
+async fn setup_test_storage() -> (TursoStorage, TempDir, Uuid, Uuid) {
+    let (storage, dir) = create_test_storage().await;
+    let ep1 = create_test_episode(&storage).await;
+    let ep2 = create_test_episode(&storage).await;
+    (storage, dir, ep1, ep2)
+}
+
 #[tokio::test]
 async fn test_add_relationship() {
-    let (storage, _dir) = create_test_storage().await;
-    let from_id = create_test_episode(&storage).await;
-    let to_id = create_test_episode(&storage).await;
+    let (storage, _dir, from_id, to_id) = setup_test_storage().await;
 
     let metadata = RelationshipMetadata::with_reason("Test relationship".to_string());
     let rel_id = storage
@@ -71,9 +76,7 @@ async fn test_add_relationship() {
 
 #[tokio::test]
 async fn test_get_relationships() {
-    let (storage, _dir) = create_test_storage().await;
-    let from_id = create_test_episode(&storage).await;
-    let to_id = create_test_episode(&storage).await;
+    let (storage, _dir, from_id, to_id) = setup_test_storage().await;
 
     let metadata = RelationshipMetadata::with_reason("Test".to_string());
     storage
@@ -98,9 +101,7 @@ async fn test_get_relationships() {
 
 #[tokio::test]
 async fn test_remove_relationship() {
-    let (storage, _dir) = create_test_storage().await;
-    let from_id = create_test_episode(&storage).await;
-    let to_id = create_test_episode(&storage).await;
+    let (storage, _dir, from_id, to_id) = setup_test_storage().await;
 
     let metadata = RelationshipMetadata::with_reason("Test".to_string());
     let rel_id = storage
@@ -122,9 +123,7 @@ async fn test_remove_relationship() {
 
 #[tokio::test]
 async fn test_relationship_exists() {
-    let (storage, _dir) = create_test_storage().await;
-    let from_id = create_test_episode(&storage).await;
-    let to_id = create_test_episode(&storage).await;
+    let (storage, _dir, from_id, to_id) = setup_test_storage().await;
 
     let exists_before = storage
         .relationship_exists(from_id, to_id, RelationshipType::DependsOn)
@@ -147,9 +146,7 @@ async fn test_relationship_exists() {
 
 #[tokio::test]
 async fn test_get_dependencies() {
-    let (storage, _dir) = create_test_storage().await;
-    let ep1 = create_test_episode(&storage).await;
-    let ep2 = create_test_episode(&storage).await;
+    let (storage, _dir, ep1, ep2) = setup_test_storage().await;
     let ep3 = create_test_episode(&storage).await;
 
     // ep1 depends on ep2 and ep3
@@ -174,9 +171,7 @@ async fn test_get_dependencies() {
 
 #[tokio::test]
 async fn test_weighted_relationships() {
-    let (storage, _dir) = create_test_storage().await;
-    let ep1 = create_test_episode(&storage).await;
-    let ep2 = create_test_episode(&storage).await;
+    let (storage, _dir, ep1, ep2) = setup_test_storage().await;
 
     let mut metadata = RelationshipMetadata::with_reason("Weighted edge".to_string());
     metadata.weight = Some(0.75);
@@ -293,9 +288,7 @@ async fn test_get_weighted_neighbors() {
 
 #[tokio::test]
 async fn test_store_relationship() {
-    let (storage, _dir) = create_test_storage().await;
-    let from_id = create_test_episode(&storage).await;
-    let to_id = create_test_episode(&storage).await;
+    let (storage, _dir, from_id, to_id) = setup_test_storage().await;
 
     let relationship = EpisodeRelationship::new(
         from_id,
@@ -319,9 +312,7 @@ async fn test_store_relationship() {
 
 #[tokio::test]
 async fn test_get_relationships_direction_both() {
-    let (storage, _dir) = create_test_storage().await;
-    let ep1 = create_test_episode(&storage).await;
-    let ep2 = create_test_episode(&storage).await;
+    let (storage, _dir, ep1, ep2) = setup_test_storage().await;
     let ep3 = create_test_episode(&storage).await;
 
     // ep1 -> ep2
@@ -355,9 +346,7 @@ async fn test_get_relationships_direction_both() {
 
 #[tokio::test]
 async fn test_get_relationships_by_type() {
-    let (storage, _dir) = create_test_storage().await;
-    let from_id = create_test_episode(&storage).await;
-    let to_id = create_test_episode(&storage).await;
+    let (storage, _dir, from_id, to_id) = setup_test_storage().await;
 
     storage
         .add_relationship(
@@ -388,9 +377,7 @@ async fn test_get_relationships_by_type() {
 
 #[tokio::test]
 async fn test_get_dependent_episodes() {
-    let (storage, _dir) = create_test_storage().await;
-    let ep1 = create_test_episode(&storage).await;
-    let ep2 = create_test_episode(&storage).await;
+    let (storage, _dir, ep1, ep2) = setup_test_storage().await;
 
     // ep2 depends on ep1
     storage
@@ -413,9 +400,7 @@ async fn test_get_dependent_episodes() {
 
 #[tokio::test]
 async fn test_get_all_relationships() {
-    let (storage, _dir) = create_test_storage().await;
-    let ep1 = create_test_episode(&storage).await;
-    let ep2 = create_test_episode(&storage).await;
+    let (storage, _dir, ep1, ep2) = setup_test_storage().await;
 
     storage
         .add_relationship(
@@ -436,9 +421,7 @@ async fn test_get_all_relationships() {
 
 #[tokio::test]
 async fn test_get_relationship_by_id() {
-    let (storage, _dir) = create_test_storage().await;
-    let ep1 = create_test_episode(&storage).await;
-    let ep2 = create_test_episode(&storage).await;
+    let (storage, _dir, ep1, ep2) = setup_test_storage().await;
 
     let rel_id = storage
         .add_relationship(

--- a/memory-storage-turso/src/relationships_tests.rs
+++ b/memory-storage-turso/src/relationships_tests.rs
@@ -290,3 +290,176 @@ async fn test_get_weighted_neighbors() {
     assert_eq!(ep2_neighbor.1, 0.6);
     assert_eq!(pt1_neighbor.1, 0.4);
 }
+
+#[tokio::test]
+async fn test_store_relationship() {
+    let (storage, _dir) = create_test_storage().await;
+    let from_id = create_test_episode(&storage).await;
+    let to_id = create_test_episode(&storage).await;
+
+    let relationship = EpisodeRelationship::new(
+        from_id,
+        to_id,
+        RelationshipType::ParentChild,
+        RelationshipMetadata::with_reason("Pre-built relationship".to_string()),
+    );
+
+    storage
+        .store_relationship(&relationship)
+        .await
+        .expect("Failed to store relationship");
+
+    let rels = storage
+        .get_relationships(from_id, Direction::Outgoing)
+        .await
+        .expect("Failed to get relationships");
+    assert_eq!(rels.len(), 1);
+    assert_eq!(rels[0].id, relationship.id);
+}
+
+#[tokio::test]
+async fn test_get_relationships_direction_both() {
+    let (storage, _dir) = create_test_storage().await;
+    let ep1 = create_test_episode(&storage).await;
+    let ep2 = create_test_episode(&storage).await;
+    let ep3 = create_test_episode(&storage).await;
+
+    // ep1 -> ep2
+    storage
+        .add_relationship(
+            ep1,
+            ep2,
+            RelationshipType::RelatedTo,
+            RelationshipMetadata::default(),
+        )
+        .await
+        .unwrap();
+
+    // ep3 -> ep1
+    storage
+        .add_relationship(
+            ep3,
+            ep1,
+            RelationshipType::RelatedTo,
+            RelationshipMetadata::default(),
+        )
+        .await
+        .unwrap();
+
+    let both = storage
+        .get_relationships(ep1, Direction::Both)
+        .await
+        .expect("Failed to get both directions");
+    assert_eq!(both.len(), 2);
+}
+
+#[tokio::test]
+async fn test_get_relationships_by_type() {
+    let (storage, _dir) = create_test_storage().await;
+    let from_id = create_test_episode(&storage).await;
+    let to_id = create_test_episode(&storage).await;
+
+    storage
+        .add_relationship(
+            from_id,
+            to_id,
+            RelationshipType::DependsOn,
+            RelationshipMetadata::default(),
+        )
+        .await
+        .unwrap();
+    storage
+        .add_relationship(
+            from_id,
+            to_id,
+            RelationshipType::ParentChild,
+            RelationshipMetadata::default(),
+        )
+        .await
+        .unwrap();
+
+    let deps = storage
+        .get_relationships_by_type(from_id, RelationshipType::DependsOn, Direction::Outgoing)
+        .await
+        .unwrap();
+    assert_eq!(deps.len(), 1);
+    assert_eq!(deps[0].relationship_type, RelationshipType::DependsOn);
+}
+
+#[tokio::test]
+async fn test_get_dependent_episodes() {
+    let (storage, _dir) = create_test_storage().await;
+    let ep1 = create_test_episode(&storage).await;
+    let ep2 = create_test_episode(&storage).await;
+
+    // ep2 depends on ep1
+    storage
+        .add_relationship(
+            ep2,
+            ep1,
+            RelationshipType::DependsOn,
+            RelationshipMetadata::default(),
+        )
+        .await
+        .unwrap();
+
+    let dependents = storage
+        .get_dependent_episodes(ep1)
+        .await
+        .expect("Failed to get dependents");
+    assert_eq!(dependents.len(), 1);
+    assert_eq!(dependents[0], ep2);
+}
+
+#[tokio::test]
+async fn test_get_all_relationships() {
+    let (storage, _dir) = create_test_storage().await;
+    let ep1 = create_test_episode(&storage).await;
+    let ep2 = create_test_episode(&storage).await;
+
+    storage
+        .add_relationship(
+            ep1,
+            ep2,
+            RelationshipType::RelatedTo,
+            RelationshipMetadata::default(),
+        )
+        .await
+        .unwrap();
+
+    let all = storage
+        .get_all_relationships()
+        .await
+        .expect("Failed to get all relationships");
+    assert_eq!(all.len(), 1);
+}
+
+#[tokio::test]
+async fn test_get_relationship_by_id() {
+    let (storage, _dir) = create_test_storage().await;
+    let ep1 = create_test_episode(&storage).await;
+    let ep2 = create_test_episode(&storage).await;
+
+    let rel_id = storage
+        .add_relationship(
+            ep1,
+            ep2,
+            RelationshipType::RelatedTo,
+            RelationshipMetadata::default(),
+        )
+        .await
+        .unwrap();
+
+    let rel = storage
+        .get_relationship_by_id(rel_id)
+        .await
+        .expect("Failed to get relationship by ID");
+    assert!(rel.is_some());
+    assert_eq!(rel.unwrap().id, rel_id);
+
+    let not_found = storage
+        .get_relationship_by_id(Uuid::new_v4())
+        .await
+        .expect("Failed to get non-existent relationship");
+    assert!(not_found.is_none());
+}


### PR DESCRIPTION
This change restores test coverage for the relationship management modules in both `do-memory-core` and `do-memory-storage-turso`. It introduces new tests for CRUD operations, global retrieval, cycle detection, and graph building, ensuring that recent regressions are addressed and the logic is stabilized.

Fixes #594

---
*PR created automatically by Jules for task [15046510184985316669](https://jules.google.com/task/15046510184985316669) started by @d-o-hub*