### PR TITLE
fix(core,cli): resolve formatting and clippy failures in Quick Check

### DIFF
--- a/memory-cli/tests/relationship_command_tests.rs
+++ b/memory-cli/tests/relationship_command_tests.rs
@@ -203,9 +203,11 @@ fn test_relationship_full_cycle() {
         .get_output()
         .stdout
         .clone();
-    assert!(!extract_json(&out_val1)["has_cycle"]
-        .as_bool()
-        .expect("Missing has_cycle"));
+    assert!(
+        !extract_json(&out_val1)["has_cycle"]
+            .as_bool()
+            .expect("Missing has_cycle")
+    );
 
     // Create cycle
     harness
@@ -237,9 +239,11 @@ fn test_relationship_full_cycle() {
         .get_output()
         .stdout
         .clone();
-    assert!(extract_json(&out_val2)["has_cycle"]
-        .as_bool()
-        .expect("Missing has_cycle"));
+    assert!(
+        extract_json(&out_val2)["has_cycle"]
+            .as_bool()
+            .expect("Missing has_cycle")
+    );
 
     // Remove
     harness

--- a/memory-core/src/extraction/tests.rs
+++ b/memory-core/src/extraction/tests.rs
@@ -55,12 +55,10 @@ fn test_extract_from_complete_episode() {
         patterns
             .iter()
             .any(|p| matches!(p, Pattern::ToolSequence { tools, .. } if tools.len() == 3)),
-        "expected ToolSequence pattern with 3 tools, got {:?}",
-        patterns
+        "expected ToolSequence pattern with 3 tools, got {patterns:?}"
     );
 }
 
-#[cfg(test)]
 mod utils_tests {
     use super::*;
 


### PR DESCRIPTION
This commit addresses the failures in the "Quick PR Check (Format + Clippy)" workflow that were blocking the YAML Lint job.

Changes:
- Ran `cargo fmt --all` to fix formatting issues, notably in `memory-cli/tests/relationship_command_tests.rs`.
- Fixed a `clippy::uninlined_format_args` warning in `memory-core/src/extraction/tests.rs` by inlining variables into the format string.

These fixes allow the prerequisite Quick Check to pass, enabling downstream linting workflows to proceed.

---
*PR created automatically by Jules for task [13367127469841781086](https://jules.google.com/task/13367127469841781086) started by @d-o-hub*