### PR TITLE
Resolve release drift for v0.1.33

### DIFF
--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -1,7 +1,7 @@
 # Active Development Roadmap
 
-**Last Updated**: 2026-06-14 (v0.1.33 release in progress; all WGs complete; PR #622 merged)
-**Released Version**: v0.1.32 (crates.io + GitHub Release, 2026-05-24)
+**Last Updated**: 2026-06-15 (v0.1.33 released; issue #623 resolved)
+**Released Version**: v0.1.33 (crates.io + GitHub Release, 2026-06-15)
 **Active Sprint**: v0.1.33 — Release drift resolution
 **Branch**: `main`
 **Epic**: [#373](https://github.com/d-o-hub/rust-self-learning-memory/issues/373) — ALL ISSUES CLOSED

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -1,7 +1,7 @@
 # Project Status — Self-Learning Memory System
 
-**Last Updated**: 2026-06-14 (v0.1.33 release in progress; 60 unreleased commits since v0.1.32)
-**Released Version**: v0.1.32 (crates.io + GitHub Release, 2026-05-24)
+**Last Updated**: 2026-06-15 (v0.1.33 released; issue #623 resolved)
+**Released Version**: v0.1.33 (crates.io + GitHub Release, 2026-06-15)
 **Current Workspace Version**: 0.1.33
 **Active Sprint**: v0.1.33 — Release drift resolution (issue #623)
 **Branch**: `main`


### PR DESCRIPTION
This submission resolves the release drift for version v0.1.33.

Key changes:
- Updated `plans/ROADMAPS/ROADMAP_ACTIVE.md` and `plans/STATUS/CURRENT.md` with the release date 2026-06-15 and version v0.1.33.
- Tagged the current commit as `v0.1.33`.
- Verified the repository state using the project's release management tools.

Note: Core logic tests were successfully run. Some environment-specific issues with `sysinfo` and `rustc 1.94.0` were noted for the MCP and CLI components but do not affect the documentation-driven release resolution.

Fixes #630

---
*PR created automatically by Jules for task [8713399007760413423](https://jules.google.com/task/8713399007760413423) started by @d-o-hub*