### PR TITLE
fix(deps): remove stale advisory ignores and update anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"

--- a/deny.toml
+++ b/deny.toml
@@ -33,28 +33,7 @@ ignore = [
     # Date: 2026-04-22
     # Mitigation: Applications that do not use CRLs are not affected
     "RUSTSEC-2026-0104",
-    # RUSTSEC-2026-0097: rand is unsound with a custom logger using rand::rng()
-    # Dependency chain: multiple (tokio, libsql, etc) -> rand 0.8/0.9
-    # Fix: rand >=0.8.6 (semver-compatible with 0.8.x) or >=0.9.x
-    # Upstream: Waiting for transitive dependency updates
-    # Mitigation: Unsoundness only affects custom loggers using rand::rng()
-    "RUSTSEC-2026-0097",
-    # RUSTSEC-2025-0141: bincode is unmaintained
-    # Dependency chain: libsql 0.9.30 -> bincode 1.3.3
-    # Mitigation: Awaiting libsql update, bincode usage in libsql is for internal state
-    "RUSTSEC-2025-0141",
-    # RUSTSEC-2024-0384: instant is unmaintained
-    # Dependency chain: augurs-changepoint 0.10.2 -> ... -> instant 0.1.13
-    # Mitigation: Awaiting augurs updates
-    "RUSTSEC-2024-0384",
-    # RUSTSEC-2024-0436: paste is unmaintained
-    # Dependency chain: tokenizers 0.22.2 -> paste 1.0.15
-    # Mitigation: Awaiting tokenizers updates
-    "RUSTSEC-2024-0436",
-    # RUSTSEC-2025-0134: rustls-pemfile 2.2.0 is unmaintained
-    "RUSTSEC-2025-0134",
-    # RUSTSEC-2026-0002: lru has unsound IterMut implementation
-    "RUSTSEC-2026-0002",
+
     # RUSTSEC-2023-0071: rsa vulnerability (Marvin Attack)
     # Dependency chain: jsonwebtoken 10.3.0 -> rsa 0.9.10
     # Mitigation: do-memory-mcp uses HMAC (HS256) exclusively, not RSA.


### PR DESCRIPTION
## Summary
- Remove 6 stale advisory ignore entries from deny.toml that no longer match any crates in the dependency tree
- Update anyhow 1.0.102 → 1.0.103 (fixes RUSTSEC-2026-0190: unsoundness in Error::downcast_mut())
- `cargo deny check` now passes cleanly

## Removed advisories (resolved by recent dependency updates)
- RUSTSEC-2026-0097 (rand unsound with custom logger)
- RUSTSEC-2025-0141 (bincode unmaintained)
- RUSTSEC-2024-0384 (instant unmaintained)
- RUSTSEC-2024-0436 (paste unmaintained)
- RUSTSEC-2025-0134 (rustls-pemfile unmaintained)
- RUSTSEC-2026-0002 (lru unsound IterMut)

## Testing
- `cargo deny check` passes locally