### PR TITLE
fix(deps): unify sysinfo to 0.39 across workspace, dedupe Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,7 +1483,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
- "sysinfo 0.38.4",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -1569,7 +1569,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sysinfo 0.38.4",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -1675,7 +1675,7 @@ dependencies = [
  "regex",
  "serde_json",
  "serial_test",
- "sysinfo 0.39.5",
+ "sysinfo",
  "tempfile",
  "tokio",
  "uuid",
@@ -5683,21 +5683,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.39.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "objc2-open-directory",
- "windows",
 ]
 
 [[package]]

--- a/memory-mcp/Cargo.toml
+++ b/memory-mcp/Cargo.toml
@@ -40,7 +40,7 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 chrono = { workspace = true }
 rand = { workspace = true }
 agentfs-sdk = "0.6.4"
-sysinfo = "0.38"
+sysinfo = "0.39"
 which = "4"
 regex = { workspace = true }
 


### PR DESCRIPTION
## Summary

Unifies the `sysinfo` dependency to `0.39` across all workspace crates and removes the duplicate `Cargo.lock` entry.

## Problem

`memory-mcp/Cargo.toml` pinned `sysinfo = "0.38"` while `memory-cli` and `tests` pinned `"0.39"`. Because `"0.38"` and `"0.39"` are incompatible caret ranges, `Cargo.lock` contained two duplicate `sysinfo 0.39.5` blocks plus dangling references to `sysinfo 0.38.4`. This caused CI failures on PRs with `error: package sysinfo is specified twice in the lockfile`.

## Fix

1. Set `memory-mcp/Cargo.toml` `sysinfo = "0.39"` to match the other crates.
2. Removed the duplicate `sysinfo` block from `Cargo.lock`.
3. Updated all dependency references from `sysinfo 0.38.4` → `sysinfo 0.39.5`.
4. Ran `cargo update -p sysinfo` to let Cargo properly verify the lockfile.
5. Verified with `cargo check --workspace` (passes) and `cargo metadata` (valid).

## Impact

- Unblocks PR #718 (CI failure from lockfile parse error).
- Prevents recurrence on future PRs.

## Verification

- [x] `cargo check --workspace` — passes
- [x] `cargo metadata` — lockfile valid
- [x] `cargo update -p sysinfo` — no errors, single entry remains
- [x] Only one `sysinfo` entry in `Cargo.lock`