### PR TITLE
docs: add missing abstention_score field to RewardScore doctest example

### DIFF
--- a/memory-core/src/types/structs.rs
+++ b/memory-core/src/types/structs.rs
@@ -97,6 +97,7 @@ impl Default for TaskContext {
 ///     complexity_bonus: 1.2,  // Handled complex task well
 ///     quality_multiplier: 1.1, // High quality output
 ///     learning_bonus: 0.3,    // Discovered new pattern
+///     abstention_score: 0.0,  // No abstention
 /// };
 /// ```
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
The RewardScore struct gained an `abstention_score` field in #718 but the doctest example in `types/structs.rs` was not updated. This caused doctests to fail.

**Fix:** Added `abstention_score: 0.0` to the RewardScore example in the doc comment.

**Verification:** `cargo test --doc` passes (37/37).