### PR TITLE
Remove .trigger-ci.txt anti-pattern and use workflow_dispatch

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ permissions:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual trigger'
+        required: false
+        default: 'Manual CI run'
 
 env:
   RUST_BACKTRACE: 1

--- a/.github/workflows/file-structure.yml
+++ b/.github/workflows/file-structure.yml
@@ -12,6 +12,7 @@ concurrency:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  workflow_dispatch:
 
 jobs:
   # Wait for quick-check to pass before running file structure validation

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -6,6 +6,12 @@ name: Quick Check
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual trigger'
+        required: false
+        default: 'Manual Quick Check run'
 
 # Cancel outdated runs when new commits are pushed
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ permissions:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
   schedule:
     - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -8,6 +8,7 @@ name: YAML Lint
       - '**.yml'
       - '**.yaml'
       - '.github/workflows/**'
+  workflow_dispatch:
   pull_request:
     branches: [main, develop]
     paths:

--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ debug_config
 
 # Generated full LLM context (artifact only; compact llms.txt is tracked)
 /llms-full.txt
+
+# Prevent re-introduction of CI trigger file anti-pattern
+.trigger-ci.txt

--- a/.trigger-ci.txt
+++ b/.trigger-ci.txt
@@ -1,1 +1,0 @@
-trigger-ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,13 +40,24 @@
 
    **Note**: The pre-commit hook automatically runs these checks, but you can run them manually too.
 
-6. **Commit & Push**
+6. **Manual CI Triggers**
+   If you need to manually re-run CI without pushing a new commit (e.g., to retry a flaky test or after a dependency update), use the GitHub CLI:
+   ```bash
+   # Trigger the main CI workflow
+   gh workflow run ci.yml --ref your-branch-name -f reason="Retrying after flaky failure"
+
+   # Trigger quick checks
+   gh workflow run quick-check.yml --ref your-branch-name
+   ```
+   You can also trigger workflows from the "Actions" tab in the GitHub UI.
+
+7. **Commit & Push**
    ```bash
    git commit -m "feat: add episode pattern recognition"
    git push origin feat/your-feature-name
    ```
 
-7. **Create Pull Request**
+8. **Create Pull Request**
    - Target `main` branch
    - Fill out PR template
    - Link related issues


### PR DESCRIPTION
This change removes the .trigger-ci.txt file used for forcing CI re-runs and replaces it with the native GitHub Actions workflow_dispatch trigger. It also updates documentation and the .gitignore file to prevent re-introduction of the anti-pattern. Instructions for manual triggers using the GitHub CLI or UI are added to CONTRIBUTING.md.

Fixes #703

---
*PR created automatically by Jules for task [6639011082851978391](https://jules.google.com/task/6639011082851978391) started by @d-o-hub*