### PR TITLE
docs(plans): mark PR remediation campaign complete + fix stale metrics

### DIFF
--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1,11 +1,35 @@
 # GOAP State Snapshot
 
-- **Last Updated**: 2026-06-30 (v0.1.33 release still pending; dependency updates + CI quality merged; issue #674 active)
+- **Last Updated**: 2026-07-02 (PR remediation campaign complete; all 7 PRs merged; 0 open PRs; v0.1.33 release still pending)
 - **Version**: `0.1.33` (workspace — **no git tag exists**; ~100 unreleased commits per #674)
 - **Branch**: `main`
 - **Validation**: `plans/STATUS/VALIDATION_LATEST.md`
 - **Gap Analysis**: `plans/STATUS/GAP_ANALYSIS_LATEST.md`
 - **Primary ADRs**: ADR-052 (v0.1.29), ADR-037 (CSM workflow adoption), ADR-053 (Accepted), **ADR-055 (Accepted — v0.1.32 missing-impl remediation; resolved)**, **ADR-056 (Accepted — Local Storage No Connection Pooling)**, **ADR-057 (Accepted — CI Health: PR #616 merged; slow test bounded by PR #620)**, **ADR-058 (Accepted — Scheduled gitleaks false positives, release drift)**
+
+---
+
+## PR Remediation Campaign (2026-07-02) ✅ COMPLETE
+
+**Task**: Resolve all open PRs from `plans/OPEN_PR_REMEDIATION_2026-07-02.md`.
+
+**PRs Merged** (in recommended order):
+1. **PR #719** — `fix(deps): unify sysinfo to 0.39` → Merged (sysinfo workspace dedup)
+2. **PR #711** — `docs: align documentation with architecture` → Merged (rebase only)
+3. **PR #715** — `refactor(mcp): remove deprecated handle_shutdown (ADR-060)` → Merged (add/add conflict resolved)
+4. **PR #718** — `feat(patterns): AbstentionPattern extractor + abstention_score` → Merged (9 missing fields fixed)
+5. **PR #709** — `Resolve flat file conflicts / consolidate modules` → Merged (3 rebase conflicts, dangling mods, 6 import renames)
+6. **PR #727** — `docs: fix RewardScore doctest` → Merged (follow-up fix)
+7. **PR #729** — `fix: sandbox test + wire up dead types_tests` → Merged (JS runtime error type + dead code)
+
+**Key outcomes**:
+- 0 open PRs, 3,453 tests pass (0 failures), clippy + fmt clean
+- 0 dependency duplicates (down from 127)
+- 23 stale local branches cleaned, 8 worktrees pruned
+- `target/` reduced from 43G to 13G (30G freed)
+- All quality gates pass
+
+**Plan document**: `plans/OPEN_PR_REMEDIATION_2026-07-02.md`
 
 ---
 

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -536,8 +536,8 @@ Impact analysis of `d-o-hub/github-template-ai-agents` and `d-o-hub/chaotic_sema
 
 | Metric | Value | Target |
 |--------|-------|--------|
-| Workspace version | 0.1.31 | — |
-| Latest GitHub release | v0.1.31 | verified 2026-04-30 |
+| Workspace version | 0.1.33 | — |
+| Latest GitHub release | v0.1.32 | verified 2026-07-02 |
 | Publishable workspace crates | 6 | all at 0.1.31 |
 | Total tests | 3,282 | — |
 | Ignored tests | 164 skipped | ceiling ≤165 |

--- a/plans/OPEN_PR_REMEDIATION_2026-07-02.md
+++ b/plans/OPEN_PR_REMEDIATION_2026-07-02.md
@@ -1,9 +1,10 @@
 # Open PR Remediation Plan — 2026-07-02
 
+> **STATUS: ✅ COMPLETE** — All 7 PRs merged to `main` by 2026-07-02.
+> See [Completion Summary](#completion-summary) below.
+
 Analysis of all open GitHub PRs, their review comments, merge conflicts, and CI
-failures, with a concrete resolution for each. Scope of this document is
-**analysis + solution design only** (per request, only `plans/` was modified;
-no source code was changed).
+failures, with a concrete resolution for each.
 
 Base of analysis: `origin/main` @ `91839c2f` ("Strict JSON-RPC Content-Length
 validation (#708)").
@@ -234,6 +235,38 @@ Rationale:
 - **#718** only needs the `sysinfo` fix + rebase.
 - **#709** is a sweeping rename; landing it last means it rebases once over the
   final tree instead of forcing every other PR to re-resolve rename conflicts.
+
+---
+
+## Completion Summary
+
+**All 7 PRs merged to `main` by 2026-07-02.**
+
+| PR | Title | Result |
+|----|-------|--------|
+| **#719** | fix(deps): unify sysinfo to 0.39 | ✅ Merged — resolved `sysinfo` duplication on `main` |
+| **#711** | docs: align documentation with architecture | ✅ Merged — rebase only, no conflicts |
+| **#715** | refactor(mcp): remove deprecated `handle_shutdown` (ADR-060) | ✅ Merged — resolved add/add conflict on `jsonrpc_shutdown_integration_test.rs` |
+| **#718** | feat(patterns): AbstentionPattern extractor + `abstention_score` | ✅ Merged — fixed 9 `abstention_score` fields + fmt + `Cargo.lock` dedup |
+| **#709** | Resolve flat file conflicts / consolidate modules | ✅ Merged — 3 rebase conflicts, dangling `mod` declarations, `pattern`→`patterns`/`episodic`→`episode` imports |
+| **#727** | docs: fix RewardScore doctest (found during QA) | ✅ Merged — follow-up fix for missed `abstention_score` in doc example |
+| **#729** | fix: sandbox syntax test + wire up dead types_tests | ✅ Merged — JS runtime error type change + dead code module wiring |
+
+**Post-merge QA:**
+- `cargo test --doc`: 37/37 passed
+- `cargo nextest run --all`: 3,453 passed, 0 failed, 181 skipped
+- `cargo clippy --workspace --all-targets`: clean
+- `cargo fmt --check`: clean
+- Quality gates: all 11 passed
+- `cargo doc --no-deps --document-private-items`: clean
+- 0 dependency duplicates (down from 127)
+- 23 stale local branches cleaned, 8 worktrees pruned
+- `target/` reduced from 43G → 13G (30G freed)
+- `main` branch: only branch remaining locally
+
+**Merge order followed:** #719 (sysinfo fix on main) → #711 + #715 (small docs/mcp) → #718 (feature) → #709 (refactor, last) → #727 (doctest fixup) → #729 (test fix + dead code)
+
+---
 
 ## Verification checklist (apply to each PR before merge)
 

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -1,6 +1,6 @@
 # Project Status — Self-Learning Memory System
 
-**Last Updated**: 2026-06-30 (WG-176..182 complete; dependency maintenance done; release v0.1.33 pending)
+**Last Updated**: 2026-07-02 (PR remediation complete; 7 PRs merged; 0 open PRs; release v0.1.33 pending)
 **Released Version**: v0.1.32 (crates.io + GitHub Release, 2026-05-24)
 **Workspace Version**: 0.1.33 (no tag — release drift)
 **Active Sprint**: v0.1.33 — Release + CI Health + Quality
@@ -51,7 +51,7 @@
 | Fuzzing | Green | Green | ✅ |
 | Security audit (`cargo deny`) | Clean | Clean | ✅ Fixed in PR #682 |
 | Open issues | 3 | 0 | 🟡 (#674, #652, #653) |
-| Open PRs | 0-1 | 0 | 🟡 (#678 auto-merging) |
+| Open PRs | 0 | 0 | ✅ All merged (PR remediation 2026-07-02) |
 | Fuzz harness | Present | Present | ✅ |
 | Property test files | 17 | ≥13 | ✅ |
 | MSRV | Rust 2024 / stable 1.95.0 | — | ✅ |

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -196,6 +196,20 @@ All research/implementation phases are complete:
 | 4 | API embedding (fallback) | OpenAI/Cohere/Ollama | 1 | Existing |
 | Pipeline | Cascade orchestrator | New `CascadeRetriever` | 0-1 | ✅ WG-131 Complete (732 LOC, 20+ tests) |
 
+---
+
+## CI Health (Post-Remediation 2026-07-02)
+
+| Workflow | Status | Notes |
+|----------|--------|-------|
+| Push CI (main) | ✅ Green | — |
+| Security (scheduled) | ✅ Fixed | WG-176 done (PR #675) |
+| Nightly Full Tests | ✅ Fixed | WG-177 done (PR #675 disk cleanup) |
+| Mutation Testing | ✅ Fixed | WG-178 done (scoped to memory-core) |
+| Fuzzing | ✅ Green | — |
+
+---
+
 ## Critical Issues for v0.1.22 Tag — ALL RESOLVED
 
 | Issue | Priority | Status |


### PR DESCRIPTION
Updates planning documents to reflect the completed PR remediation campaign.

**Changes:**
- plans/OPEN_PR_REMEDIATION_2026-07-02.md: Added completion banner and summary section listing all 7 merged PRs with QA results
- plans/GOAP_STATE.md: Added PR Remediation Campaign section, fixed stale version numbers (0.1.31->0.1.33, v0.1.31->v0.1.32)
- plans/STATUS/CURRENT.md: Updated date, Open PRs count, and CI Health table to reflect post-PR675 reality

**Key metrics updated:**
- 0 open PRs, 0 dependency duplicates (down from 127)
- 3,453 tests pass, all quality gates green
- 23 stale branches cleaned, 30G disk freed