### PR TITLE
security: add #![deny(unsafe_code)] to 4 crates (#701)

### DIFF
--- a/memory-cli/src/lib.rs
+++ b/memory-cli/src/lib.rs
@@ -1,3 +1,5 @@
+// Deny unsafe code in this crate — targeted exceptions via #[allow(unsafe_code)].
+#![deny(unsafe_code)]
 #![allow(clippy::empty_line_after_doc_comments)]
 #![allow(dead_code)]
 #![allow(unused_variables)]

--- a/memory-core/src/lib.rs
+++ b/memory-core/src/lib.rs
@@ -1,3 +1,5 @@
+// Deny unsafe code in this crate — no unsafe blocks required.
+#![deny(unsafe_code)]
 // Justified clippy suppressions for this crate (WG-113 audit)
 //
 // CAST-RELATED (necessary for embedding/similarity calculations):

--- a/memory-mcp/src/lib.rs
+++ b/memory-mcp/src/lib.rs
@@ -1,3 +1,5 @@
+// Deny unsafe code in this crate — targeted exceptions via #[allow(unsafe_code)].
+#![deny(unsafe_code)]
 // Clippy suppressions for memory-mcp
 #![allow(clippy::useless_attribute)]
 #![allow(clippy::excessive_nesting)]

--- a/memory-storage-redb/src/lib.rs
+++ b/memory-storage-redb/src/lib.rs
@@ -1,3 +1,5 @@
+// Deny unsafe code in this crate — no unsafe blocks required.
+#![deny(unsafe_code)]
 // Clippy suppressions for memory-storage-redb
 // Cast-related: necessary for persistence statistics and metrics
 #![allow(clippy::cast_precision_loss)]


### PR DESCRIPTION
Closes #701

Tightens the `unsafe_code` lint from implicit `warn` to explicit `deny` in crates that do not require unsafe code at the crate level.

## Changes

| Crate | Action | Reason |
|-------|--------|--------|
| `memory-core` | Add `#![deny(unsafe_code)]` | Only unsafe is `env::set_var` in tests (targeted allow) |
| `memory-storage-redb` | Add `#![deny(unsafe_code)]` | No unsafe code exists at all |
| `memory-mcp` | Add `#![deny(unsafe_code)]` | Sandbox libc + tests have targeted allows |
| `memory-cli` | Add `#![deny(unsafe_code)]` | Config `env::set_var` in tests has targeted allows |
| `memory-storage-turso` | **Excluded** | Legitimate unsafe in connection pooling (`unsafe impl Send/Sync`, pointer casts) |

## Design

- Crate-level `#![deny(unsafe_code)]` prevents new unsafe code from being introduced without explicit justification
- All existing unsafe blocks already have `#[allow(unsafe_code)]` annotations that override the crate-level deny
- `memory-storage-turso` is intentionally excluded with `#![allow(unsafe_code)]` for performance-critical connection pooling

## Validation

- [x] All 3,453 workspace tests pass
- [x] Clippy clean (`-D warnings`)
- [x] Formatting clean
- [x] Quality gate formatting passes