### PR TITLE
docs(spatiotemporal): add usage guide and executable examples

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -50,7 +50,7 @@ jobs:
           mkdir -p _site
           cp -r book/book/* _site/
           mkdir -p _site/api
-          cp -r target/doc/* _site/api/
+          cp -r ${CARGO_TARGET_DIR:-target}/doc/* _site/api/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -6,7 +6,7 @@
 - [Episodes](#episodes) <!-- TODO: create book/src/episodes.md -->
 - [Patterns](#patterns) <!-- TODO: create book/src/patterns.md -->
 - [Memory Retrieval](#retrieval) <!-- TODO: create book/src/retrieval.md -->
-    - [Spatiotemporal Retrieval](./spatiotemporal-retrieval.md)
+- [Spatiotemporal Retrieval](./spatiotemporal-retrieval.md)
 - [MCP Server](#mcp-server) <!-- TODO: create book/src/mcp-server.md -->
 - [CLI Reference](#cli-reference) <!-- TODO: create book/src/cli.md -->
 - [API Reference](#api-reference) <!-- TODO: create book/src/api.md -->

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -6,6 +6,7 @@
 - [Episodes](#episodes) <!-- TODO: create book/src/episodes.md -->
 - [Patterns](#patterns) <!-- TODO: create book/src/patterns.md -->
 - [Memory Retrieval](#retrieval) <!-- TODO: create book/src/retrieval.md -->
+    - [Spatiotemporal Retrieval](./spatiotemporal-retrieval.md)
 - [MCP Server](#mcp-server) <!-- TODO: create book/src/mcp-server.md -->
 - [CLI Reference](#cli-reference) <!-- TODO: create book/src/cli.md -->
 - [API Reference](#api-reference) <!-- TODO: create book/src/api.md -->

--- a/book/src/spatiotemporal-retrieval.md
+++ b/book/src/spatiotemporal-retrieval.md
@@ -35,6 +35,18 @@ let matches = retriever.retrieve(&query, &history).await?;
 
 If you're working within a specific domain, you can restrict search to that domain to avoid "cross-talk" from unrelated areas that might share similar keywords but different implementations.
 
+```rust
+let query = RetrievalQuery {
+    query_text: "Load configuration".to_string(),
+    domain: Some("api-gateway".to_string()),
+    limit: 5,
+    ..Default::default()
+};
+
+// Only 'api-gateway' episodes will be considered in Level 1
+let matches = retriever.retrieve(&query, &history).await?;
+```
+
 ### 3. Time-Window Constrained Retrieval
 
 You can use the `SpatiotemporalIndex` directly to find all episodes in a specific domain within a time range.

--- a/book/src/spatiotemporal-retrieval.md
+++ b/book/src/spatiotemporal-retrieval.md
@@ -1,0 +1,60 @@
+# Spatiotemporal Retrieval Cookbook
+
+Spatiotemporal retrieval is a structured approach to finding relevant episodic memories by leveraging domain knowledge, task classification, and temporal context.
+
+## Core Concepts
+
+Unlike traditional flat semantic search, spatiotemporal retrieval uses a 4-level hierarchy to filter and rank memories:
+
+1.  **Domain**: Filters by high-level logical context (e.g., `web-api`, `infrastructure`).
+2.  **Task Type**: Filters by the nature of the work (e.g., `CodeGeneration`, `Debugging`).
+3.  **Temporal Clusters**: Prioritizes recent episodes using time-based bucketing.
+4.  **Semantic Similarity**: Performs fine-grained vector comparison on the remaining candidates.
+
+## Common Patterns
+
+### 1. Recent Similar Task Lookup
+
+When starting a new task, it's often useful to see how similar tasks were handled recently.
+
+```rust
+let query = RetrievalQuery {
+    query_text: "Implement OAuth2 flow".to_string(),
+    domain: Some("auth-service".to_string()),
+    task_type: Some(TaskType::CodeGeneration),
+    limit: 3,
+    ..Default::default()
+};
+
+// HierarchicalRetriever will prioritize 'auth-service' and 'CodeGeneration'
+// from the last few weeks.
+let matches = retriever.retrieve(&query, &history).await?;
+```
+
+### 2. Locality-Aware Recall
+
+If you're working within a specific domain, you can restrict search to that domain to avoid "cross-talk" from unrelated areas that might share similar keywords but different implementations.
+
+### 3. Time-Window Constrained Retrieval
+
+You can use the `SpatiotemporalIndex` directly to find all episodes in a specific domain within a time range.
+
+```rust
+let start = Utc::now() - Duration::days(7);
+let end = Utc::now();
+let episode_ids = index.query("frontend", Some(TaskType::Testing), Some(start), Some(end), 10);
+```
+
+## Ranking Composition
+
+The final relevance score is calculated as follows:
+
+`Relevance = 0.3 * DomainMatch + 0.3 * TaskTypeMatch + W * Recency + (0.4 - W) * Similarity`
+
+*   **DomainMatch**: 1.0 if domain matches exactly, 0.0 otherwise (0.5 if no domain specified).
+*   **TaskTypeMatch**: 1.0 if task type matches exactly, 0.0 otherwise (0.5 if no task type specified).
+*   **Recency**: A score from 1.0 (brand new) to 0.0 (older than 30 days).
+*   **Similarity**: Cosine similarity of embeddings or word-overlap score.
+*   **W**: The `temporal_bias_weight` (default 0.3).
+
+> **Note on Reward**: While reward scores are used in capacity management and eviction policies, they are not currently part of the core hierarchical retrieval scoring. This ensures that even "failed" tasks can be retrieved for guidance (to avoid repeating mistakes), provided they are contextually relevant.

--- a/memory-core/examples/spatiotemporal_basic.rs
+++ b/memory-core/examples/spatiotemporal_basic.rs
@@ -1,0 +1,123 @@
+//! Basic example of spatiotemporal indexing and hierarchical retrieval.
+//!
+//! This example demonstrates how to:
+//! 1. Create a `SpatiotemporalIndex` and insert episodes.
+//! 2. Use `HierarchicalRetriever` to search for episodes.
+//! 3. Observe how domain, task type, and recency affect the results.
+
+use chrono::{Duration, Utc};
+use do_memory_core::episode::Episode;
+use do_memory_core::spatiotemporal::{HierarchicalRetriever, RetrievalQuery, SpatiotemporalIndex};
+use do_memory_core::types::{TaskContext, TaskType};
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Initialize tracing
+    tracing_subscriber::fmt()
+        .with_env_filter("info,do_memory_core::spatiotemporal=debug")
+        .init();
+
+    println!("--- Spatiotemporal Retrieval Basic Example ---");
+
+    // 1. Create some sample episodes
+    let now = Utc::now();
+    let mut episodes = Vec::new();
+
+    // Episode 1: Web API / Code Generation (Recent)
+    let ep1 = create_episode(
+        "Implement JWT authentication",
+        "web-api",
+        TaskType::CodeGeneration,
+        now - Duration::hours(2),
+    );
+    episodes.push(Arc::new(ep1));
+
+    // Episode 2: Web API / Debugging (Yesterday)
+    let ep2 = create_episode(
+        "Fix database connection leak",
+        "web-api",
+        TaskType::Debugging,
+        now - Duration::days(1),
+    );
+    episodes.push(Arc::new(ep2));
+
+    // Episode 3: Frontend / Code Generation (Last Week)
+    let ep3 = create_episode(
+        "Create React login component",
+        "frontend",
+        TaskType::CodeGeneration,
+        now - Duration::days(7),
+    );
+    episodes.push(Arc::new(ep3));
+
+    // 2. Build the Spatiotemporal Index
+    let mut index = SpatiotemporalIndex::new();
+    for ep in &episodes {
+        index.insert(ep);
+    }
+
+    println!(
+        "Indexed {} episodes across {} domains.",
+        index.total_episodes,
+        index.num_domains()
+    );
+
+    // 3. Setup the Hierarchical Retriever
+    // Weight recency heavily (0.5)
+    let retriever = HierarchicalRetriever::with_config(0.5, 5);
+
+    // 4. Perform a query
+    println!("\nQuerying for: 'authentication' in 'web-api' domain...");
+
+    let query = RetrievalQuery {
+        query_text: "authentication".to_string(),
+        domain: Some("web-api".to_string()),
+        task_type: Some(TaskType::CodeGeneration),
+        limit: 5,
+        ..Default::default()
+    };
+
+    let results = retriever.retrieve(&query, &episodes).await?;
+
+    println!("Found {} results:", results.len());
+    for (i, score) in results.iter().enumerate() {
+        let ep = episodes
+            .iter()
+            .find(|e| e.episode_id == score.episode_id)
+            .unwrap();
+        println!(
+            "{}. [{:.2}] {} (Domain: {}, Type: {:?}, Created: {})",
+            i + 1,
+            score.relevance_score,
+            ep.task_description,
+            ep.context.domain,
+            ep.task_type,
+            ep.start_time.format("%Y-%m-%d %H:%M")
+        );
+        println!(
+            "   Scores: Domain: {:.2}, TaskType: {:.2}, Temporal: {:.2}, Similarity: {:.2}",
+            score.level_1_score,
+            score.level_2_score,
+            score.level_3_score,
+            score.level_4_score
+        );
+    }
+
+    Ok(())
+}
+
+fn create_episode(
+    description: &str,
+    domain: &str,
+    task_type: TaskType,
+    start_time: chrono::DateTime<Utc>,
+) -> Episode {
+    let context = TaskContext {
+        domain: domain.to_string(),
+        ..Default::default()
+    };
+    let mut ep = Episode::new(description.to_string(), context, task_type);
+    ep.start_time = start_time;
+    ep
+}

--- a/memory-core/examples/spatiotemporal_basic.rs
+++ b/memory-core/examples/spatiotemporal_basic.rs
@@ -59,7 +59,7 @@ async fn main() -> anyhow::Result<()> {
 
     println!(
         "Indexed {} episodes across {} domains.",
-        index.total_episodes,
+        index.len(),
         index.num_domains()
     );
 
@@ -103,6 +103,8 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Helper to create an episode with a specific start time.
+/// NOTE: duplicate of `spatiotemporal_task_replay` — consider a shared examples/utils
 fn create_episode(
     description: &str,
     domain: &str,

--- a/memory-core/examples/spatiotemporal_basic.rs
+++ b/memory-core/examples/spatiotemporal_basic.rs
@@ -82,10 +82,9 @@ async fn main() -> anyhow::Result<()> {
 
     println!("Found {} results:", results.len());
     for (i, score) in results.iter().enumerate() {
-        let ep = episodes
-            .iter()
-            .find(|e| e.episode_id == score.episode_id)
-            .unwrap();
+        let Some(ep) = episodes.iter().find(|e| e.episode_id == score.episode_id) else {
+            continue;
+        };
         println!(
             "{}. [{:.2}] {} (Domain: {}, Type: {:?}, Created: {})",
             i + 1,
@@ -97,10 +96,7 @@ async fn main() -> anyhow::Result<()> {
         );
         println!(
             "   Scores: Domain: {:.2}, TaskType: {:.2}, Temporal: {:.2}, Similarity: {:.2}",
-            score.level_1_score,
-            score.level_2_score,
-            score.level_3_score,
-            score.level_4_score
+            score.level_1_score, score.level_2_score, score.level_3_score, score.level_4_score
         );
     }
 

--- a/memory-core/examples/spatiotemporal_task_replay.rs
+++ b/memory-core/examples/spatiotemporal_task_replay.rs
@@ -99,6 +99,8 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Helper to create an episode with a specific start time.
+/// NOTE: duplicate of `spatiotemporal_basic` — consider a shared examples/utils
 fn create_episode(
     description: &str,
     domain: &str,

--- a/memory-core/examples/spatiotemporal_task_replay.rs
+++ b/memory-core/examples/spatiotemporal_task_replay.rs
@@ -1,0 +1,113 @@
+//! Example of using spatiotemporal retrieval for task replay/guidance.
+//!
+//! This example shows how an agent can look up similar past tasks
+//! to retrieve successful execution patterns and avoid past mistakes.
+
+use chrono::{Duration, Utc};
+use do_memory_core::episode::Episode;
+use do_memory_core::spatiotemporal::{HierarchicalRetriever, RetrievalQuery};
+use do_memory_core::types::{TaskContext, TaskOutcome, TaskType};
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Initialize tracing
+    tracing_subscriber::fmt().with_env_filter("info").init();
+
+    println!("--- Task Replay & Guidance Example ---");
+
+    // 1. Setup past memories (some successful, some failed)
+    let now = Utc::now();
+    let mut history = Vec::new();
+
+    // Successful past task
+    let mut ep1 = create_episode(
+        "Deploy to production environment",
+        "devops",
+        TaskType::Other,
+        now - Duration::days(30),
+    );
+    ep1.outcome = Some(TaskOutcome::Success {
+        verdict: "Deployed successfully after setting correct env vars".to_string(),
+        artifacts: vec!["deploy-log.txt".to_string()],
+    });
+    history.push(Arc::new(ep1));
+
+    // Failed past task (same domain)
+    let mut ep2 = create_episode(
+        "Deploy to production environment",
+        "devops",
+        TaskType::Other,
+        now - Duration::days(45),
+    );
+    ep2.outcome = Some(TaskOutcome::Failure {
+        reason: "Database migration failed: missing permissions".to_string(),
+        error_details: Some("Tried to run migrations with read-only user".to_string()),
+    });
+    history.push(Arc::new(ep2));
+
+    // 2. Current task we need guidance for
+    let current_task = "Deploying the new analytics service to prod";
+    println!("Current Task: {current_task}");
+
+    // 3. Use spatiotemporal retrieval to find relevant guidance
+    let retriever = HierarchicalRetriever::new();
+
+    let query = RetrievalQuery {
+        query_text: current_task.to_string(),
+        domain: Some("devops".to_string()),
+        task_type: Some(TaskType::Other),
+        limit: 2,
+        ..Default::default()
+    };
+
+    println!("Searching for relevant past experiences...");
+    let matches = retriever.retrieve(&query, &history).await?;
+
+    // 4. Extract guidance from the top match
+    if let Some(best_match) = matches.first() {
+        let ep = history
+            .iter()
+            .find(|e| e.episode_id == best_match.episode_id)
+            .unwrap();
+        println!("\nFound relevant past episode: {}", ep.task_description);
+        println!("Relevance Score: {:.2}", best_match.relevance_score);
+
+        match &ep.outcome {
+            Some(TaskOutcome::Success { verdict, .. }) => {
+                println!("Outcome: SUCCESS ✅");
+                println!("Guidance: {verdict}");
+            }
+            Some(TaskOutcome::Failure {
+                reason,
+                error_details,
+            }) => {
+                println!("Outcome: FAILURE ❌");
+                println!("Warning: Last time this was tried, it failed because: {reason}");
+                if let Some(details) = error_details {
+                    println!("Details: {details}");
+                }
+            }
+            _ => println!("Outcome: Unknown"),
+        }
+    } else {
+        println!("No relevant past experiences found.");
+    }
+
+    Ok(())
+}
+
+fn create_episode(
+    description: &str,
+    domain: &str,
+    task_type: TaskType,
+    start_time: chrono::DateTime<Utc>,
+) -> Episode {
+    let context = TaskContext {
+        domain: domain.to_string(),
+        ..Default::default()
+    };
+    let mut ep = Episode::new(description.to_string(), context, task_type);
+    ep.start_time = start_time;
+    ep
+}

--- a/memory-core/examples/spatiotemporal_task_replay.rs
+++ b/memory-core/examples/spatiotemporal_task_replay.rs
@@ -66,10 +66,12 @@ async fn main() -> anyhow::Result<()> {
 
     // 4. Extract guidance from the top match
     if let Some(best_match) = matches.first() {
-        let ep = history
+        let Some(ep) = history
             .iter()
             .find(|e| e.episode_id == best_match.episode_id)
-            .unwrap();
+        else {
+            return Ok(());
+        };
         println!("\nFound relevant past episode: {}", ep.task_description);
         println!("Relevance Score: {:.2}", best_match.relevance_score);
 

--- a/memory-core/src/spatiotemporal/index/mod.rs
+++ b/memory-core/src/spatiotemporal/index/mod.rs
@@ -218,6 +218,18 @@ impl SpatiotemporalIndex {
     pub fn num_domains(&self) -> usize {
         self.domain_indices.len()
     }
+
+    /// Get the total number of episodes in the index.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.total_episodes
+    }
+
+    /// Check if the index is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.total_episodes == 0
+    }
 }
 
 #[cfg(test)]

--- a/memory-core/src/spatiotemporal/index/mod.rs
+++ b/memory-core/src/spatiotemporal/index/mod.rs
@@ -282,8 +282,10 @@ mod tests {
         let episode = create_test_episode("test-domain", TaskType::Debugging);
         let episode_id = episode.episode_id;
 
+        assert!(index.is_empty());
         index.insert(&episode);
-        assert_eq!(index.total_episodes, 1);
+        assert_eq!(index.len(), 1);
+        assert!(!index.is_empty());
 
         let removed = index.remove(episode_id);
         assert!(removed);

--- a/memory-core/src/spatiotemporal/mod.rs
+++ b/memory-core/src/spatiotemporal/mod.rs
@@ -1,26 +1,59 @@
-//! Spatiotemporal memory organization for efficient episodic retrieval
+//! Spatiotemporal memory organization for efficient episodic retrieval.
 //!
-//! This module implements Phase 3 (Spatiotemporal Memory Organization) features
-//! from the research integration plan, including:
+//! This module provides a sophisticated hierarchical approach to organizing and retrieving
+//! episodic memories. Unlike pure semantic retrieval which treats all memories as a flat
+//! collection of vectors, spatiotemporal retrieval uses the natural structure of tasks
+//! to progressively narrow the search space.
 //!
-//! - Context-aware embeddings with task-specific adaptation
-//! - Hierarchical spatiotemporal indexing (future)
-//! - Coarse-to-fine retrieval strategy (future)
-//! - MMR-based diversity maximization (future)
+//! # Why Spatiotemporal?
 //!
-//! # Phase 3 Goals
+//! Pure semantic retrieval often suffers from:
+//! - **Context drift**: Finding semantically similar but contextually irrelevant tasks.
+//! - **Recency neglect**: Older, less relevant tasks may outrank newer, more pertinent ones.
+//! - **Scalability**: Scanning all embeddings becomes slow as memory grows.
 //!
-//! - **Hierarchical Indexing**: Domain → Task Type → Temporal clusters
-//! - **Coarse-to-Fine Retrieval**: Multi-level search for speed and accuracy
-//! - **Diversity Maximization**: MMR algorithm to avoid redundant results
-//! - **Context-Aware Embeddings**: Task-specific embedding adaptation
+//! Spatiotemporal organization solves these by introducing a 4-level hierarchy:
+//! 1. **Domain**: High-level logical grouping (e.g., "web-api", "frontend", "infrastructure").
+//! 2. **Task Type**: Functional classification (e.g., `CodeGeneration`, `Debugging`, `Analysis`).
+//! 3. **Temporal Clusters**: Time-based buckets (Weekly, Monthly, Quarterly) that favor recent patterns.
+//! 4. **Semantic Similarity**: Fine-grained vector comparison within the filtered subset.
 //!
-//! # Current Status
+//! # Key Components
 //!
-//! - ✅ Context-aware embeddings (Task 4.1, 4.2, 4.3)
-//! - ✅ Diversity maximization (Task 3.1, 3.2) - **COMPLETE**
-//! - ⏳ Hierarchical indexing (Task 1.1, 1.2, 1.3)
-//! - ⏳ Coarse-to-fine retrieval (Task 2.1, 2.2, 2.3)
+//! - [`SpatiotemporalIndex`]: A 3-level index structure (Domain -> TaskType -> Temporal).
+//! - [`HierarchicalRetriever`]: Executes the coarse-to-fine retrieval strategy.
+//! - [`DiversityMaximizer`]: Applies MMR (Maximal Marginal Relevance) to ensure result variety.
+//! - [`ContextAwareEmbeddings`]: Task-specific embedding adaptation via contrastive learning.
+//!
+//! # Example: Basic Retrieval
+//!
+//! ```no_run
+//! use do_memory_core::spatiotemporal::{HierarchicalRetriever, RetrievalQuery};
+//! use do_memory_core::TaskType;
+//! use std::collections::HashMap;
+//!
+//! # async fn example() -> anyhow::Result<()> {
+//! let retriever = HierarchicalRetriever::with_config(0.4, 5);
+//!
+//! let query = RetrievalQuery {
+//!     query_text: "Fix authentication bug".to_string(),
+//!     query_embedding: None, // Will fallback to text similarity if None
+//!     domain: Some("identity-service".to_string()),
+//!     task_type: Some(TaskType::Debugging),
+//!     limit: 3,
+//!     episode_embeddings: HashMap::new(),
+//! };
+//!
+//! // let results = retriever.retrieve(&query, &all_episodes).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Scoring Composition
+//!
+//! The final relevance score is a weighted combination:
+//! `Score = 0.3*Domain + 0.3*TaskType + W*Recency + (0.4-W)*Similarity`
+//! where `W` is the `temporal_bias_weight` (default 0.3).
 
 pub mod diversity;
 pub mod embeddings;

--- a/memory-core/src/spatiotemporal/mod.rs
+++ b/memory-core/src/spatiotemporal/mod.rs
@@ -30,18 +30,16 @@
 //! ```no_run
 //! use do_memory_core::spatiotemporal::{HierarchicalRetriever, RetrievalQuery};
 //! use do_memory_core::TaskType;
-//! use std::collections::HashMap;
 //!
 //! # async fn example() -> anyhow::Result<()> {
 //! let retriever = HierarchicalRetriever::with_config(0.4, 5);
 //!
 //! let query = RetrievalQuery {
 //!     query_text: "Fix authentication bug".to_string(),
-//!     query_embedding: None, // Will fallback to text similarity if None
 //!     domain: Some("identity-service".to_string()),
 //!     task_type: Some(TaskType::Debugging),
 //!     limit: 3,
-//!     episode_embeddings: HashMap::new(),
+//!     ..Default::default()
 //! };
 //!
 //! // let results = retriever.retrieve(&query, &all_episodes).await?;

--- a/memory-core/src/spatiotemporal/retriever/types.rs
+++ b/memory-core/src/spatiotemporal/retriever/types.rs
@@ -36,7 +36,7 @@ use uuid::Uuid;
 ///     episode_embeddings: HashMap::new(),
 /// };
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct RetrievalQuery {
     /// Text description of the query task
     pub query_text: String,


### PR DESCRIPTION
This PR adds comprehensive documentation and runnable examples for the spatiotemporal module in `do-memory-core`. It includes:
- Module-level documentation explaining the 4-level hierarchical retrieval strategy.
- Two new examples: `spatiotemporal_basic` for general usage and `spatiotemporal_task_replay` for guidance/replay patterns.
- A new cookbook page in the documentation book covering core concepts and common patterns.
- Implementation of `Default` for `RetrievalQuery`.
- Verification that all tests pass and examples work as intended.

Fixes #754

---
*PR created automatically by Jules for task [10558599754520469185](https://jules.google.com/task/10558599754520469185) started by @d-o-hub*