### PR TITLE
Add ANN-backed semantic episode retrieval components

### DIFF
--- a/memory-core/src/embeddings/index.rs
+++ b/memory-core/src/embeddings/index.rs
@@ -1,0 +1,73 @@
+//! Vector index trait and implementations for semantic search
+
+use crate::Result;
+use std::collections::HashMap;
+
+/// Result of a vector search
+#[derive(Debug, Clone)]
+pub struct VectorHit {
+    /// ID of the item
+    pub id: String,
+    /// Similarity score (0.0 to 1.0)
+    pub score: f32,
+}
+
+/// Trait for vector indices supporting ANN or exact search
+pub trait VectorIndex: Send + Sync {
+    /// Add or update an item in the index
+    fn upsert(&mut self, id: &str, embedding: &[f32]) -> Result<()>;
+
+    /// Remove an item from the index
+    fn remove(&mut self, id: &str) -> Result<()>;
+
+    /// Search for the most similar items
+    fn search(&self, query: &[f32], top_k: usize) -> Result<Vec<VectorHit>>;
+}
+
+/// Simple in-memory vector index using linear scan
+#[derive(Default)]
+pub struct InMemoryVectorIndex {
+    embeddings: HashMap<String, Vec<f32>>,
+}
+
+impl InMemoryVectorIndex {
+    /// Create a new empty in-memory vector index
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            embeddings: HashMap::new(),
+        }
+    }
+}
+
+impl VectorIndex for InMemoryVectorIndex {
+    fn upsert(&mut self, id: &str, embedding: &[f32]) -> Result<()> {
+        self.embeddings.insert(id.to_string(), embedding.to_vec());
+        Ok(())
+    }
+
+    fn remove(&mut self, id: &str) -> Result<()> {
+        self.embeddings.remove(id);
+        Ok(())
+    }
+
+    fn search(&self, query: &[f32], top_k: usize) -> Result<Vec<VectorHit>> {
+        let mut hits: Vec<VectorHit> = self.embeddings.iter()
+            .map(|(id, embedding)| {
+                let score = crate::embeddings::cosine_similarity(query, embedding);
+                VectorHit {
+                    id: id.clone(),
+                    score,
+                }
+            })
+            .collect();
+
+        // Sort by score descending
+        hits.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+
+        // Take top K
+        hits.truncate(top_k);
+
+        Ok(hits)
+    }
+}

--- a/memory-core/src/embeddings/mod.rs
+++ b/memory-core/src/embeddings/mod.rs
@@ -39,6 +39,7 @@
 
 mod circuit_breaker;
 pub mod config;
+pub mod index;
 mod local;
 mod metrics;
 #[cfg(feature = "mistral")]
@@ -60,6 +61,7 @@ pub use config::{
     AzureOpenAIConfig, CustomConfig, EmbeddingConfig, LocalConfig, MistralConfig, OpenAIConfig,
     OptimizationConfig, ProviderConfig,
 };
+pub use index::{InMemoryVectorIndex, VectorHit, VectorIndex};
 pub use local::{
     LocalEmbeddingProvider, LocalModelUseCase, get_recommended_model, list_available_models,
 };

--- a/memory-core/src/memory/core/struct_priv.rs
+++ b/memory-core/src/memory/core/struct_priv.rs
@@ -74,6 +74,10 @@ pub struct SelfLearningMemory {
     pub(super) diversity_maximizer: Option<crate::spatiotemporal::DiversityMaximizer>,
     /// Context-aware embeddings for task-specific similarity
     pub(super) context_aware_embeddings: Option<crate::spatiotemporal::ContextAwareEmbeddings>,
+    /// ANN-backed semantic retriever
+    pub(super) semantic_retriever: Option<crate::retrieval::SemanticRetriever>,
+    /// Hybrid ranker for multi-signal fusion
+    pub(super) hybrid_ranker: crate::search::HybridRanker,
     /// Semantic service for embedding generation and search
     semantic_service: Option<Arc<SemanticService>>,
     /// Configuration for semantic search

--- a/memory-core/src/retrieval/mod.rs
+++ b/memory-core/src/retrieval/mod.rs
@@ -13,6 +13,7 @@
 
 pub mod cache;
 pub mod cascade;
+pub mod semantic_retriever;
 pub mod gist;
 pub mod shard;
 pub mod signature;
@@ -31,6 +32,7 @@ pub use chaotic_semantic_memory::retrieval::{
 };
 
 pub use cache::{CacheKey, CacheMetrics, DEFAULT_CACHE_TTL, DEFAULT_MAX_ENTRIES, QueryCache};
+pub use semantic_retriever::SemanticRetriever;
 pub use cascade::{CascadeConfig, CascadeResult, CascadeRetriever};
 pub use gist::{EpisodeGist, GistExtractor, GistScoredItem, HierarchicalReranker, RerankConfig};
 pub use shard::{EpisodeMetadata, RoutingResult, ScopeFilter, ShardConfig, ShardRouter, TimeRange};

--- a/memory-core/src/retrieval/semantic_retriever.rs
+++ b/memory-core/src/retrieval/semantic_retriever.rs
@@ -1,0 +1,55 @@
+//! Semantic retriever for embedding-based episode lookup
+
+use crate::embeddings::{SemanticService, VectorIndex};
+use crate::Result;
+use parking_lot::RwLock;
+use std::sync::Arc;
+use uuid::Uuid;
+
+/// Retriever that uses semantic embeddings and a vector index
+pub struct SemanticRetriever {
+    semantic_service: Arc<SemanticService>,
+    index: Arc<RwLock<dyn VectorIndex>>,
+}
+
+impl SemanticRetriever {
+    /// Create a new semantic retriever
+    pub fn new(semantic_service: Arc<SemanticService>, index: Arc<RwLock<dyn VectorIndex>>) -> Self {
+        Self {
+            semantic_service,
+            index,
+        }
+    }
+
+    /// Retrieve episodes similar to the given text
+    pub async fn retrieve(&self, query_text: &str, top_k: usize) -> Result<Vec<(Uuid, f32)>> {
+        // 1. Generate embedding for query text
+        let embedding = self.semantic_service.provider.embed_text(query_text).await?;
+
+        // 2. Search index
+        let hits = self.index.read().search(&embedding, top_k)?;
+
+        // 3. Map to UUIDs
+        let mut results = Vec::new();
+        for hit in hits {
+            if let Ok(id) = Uuid::parse_str(&hit.id) {
+                results.push((id, hit.score));
+            }
+        }
+
+        Ok(results)
+    }
+
+    /// Add an episode to the semantic index
+    pub async fn index_episode(&self, episode_id: Uuid, text: &str) -> Result<()> {
+        let embedding = self.semantic_service.provider.embed_text(text).await?;
+        self.index.write().upsert(&episode_id.to_string(), &embedding)?;
+        Ok(())
+    }
+
+    /// Remove an episode from the semantic index
+    pub fn remove_episode(&self, episode_id: Uuid) -> Result<()> {
+        self.index.write().remove(&episode_id.to_string())?;
+        Ok(())
+    }
+}

--- a/memory-core/src/search/hybrid_ranker.rs
+++ b/memory-core/src/search/hybrid_ranker.rs
@@ -1,0 +1,122 @@
+//! Hybrid ranker for multi-signal fusion
+
+use crate::episode::Episode;
+use crate::types::TaskContext;
+use chrono::Utc;
+
+/// Signals used for ranking episodes
+pub struct RankingSignals {
+    /// Semantic similarity score (0.0 to 1.0)
+    pub semantic_score: f32,
+    /// Reward/Quality score (normalized, typically 0.0 to 1.0)
+    pub reward_score: f32,
+    /// Recency score (0.0 to 1.0, 1.0 is most recent)
+    pub recency_score: f32,
+    /// Context overlap score (0.0 to 1.0)
+    pub context_score: f32,
+}
+
+/// Configuration for hybrid ranking weights
+#[derive(Debug, Clone, Copy)]
+pub struct HybridRankingWeights {
+    pub semantic: f32,
+    pub reward: f32,
+    pub recency: f32,
+    pub context: f32,
+}
+
+impl Default for HybridRankingWeights {
+    fn default() -> Self {
+        Self {
+            semantic: 0.4,
+            reward: 0.3,
+            recency: 0.1,
+            context: 0.2,
+        }
+    }
+}
+
+/// Ranker that combines multiple signals into a final relevance score
+pub struct HybridRanker {
+    weights: HybridRankingWeights,
+}
+
+impl HybridRanker {
+    /// Create a new hybrid ranker with default weights
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            weights: HybridRankingWeights::default(),
+        }
+    }
+
+    /// Create a new hybrid ranker with custom weights
+    #[must_use]
+    pub fn with_weights(weights: HybridRankingWeights) -> Self {
+        Self { weights }
+    }
+
+    /// Rank episodes based on multiple signals
+    pub fn rank(&self, signals: &RankingSignals) -> f32 {
+        (signals.semantic_score * self.weights.semantic) +
+        (signals.reward_score * self.weights.reward) +
+        (signals.recency_score * self.weights.recency) +
+        (signals.context_score * self.weights.context)
+    }
+
+    /// Calculate recency score for an episode (1.0 = now, decays over time)
+    pub fn calculate_recency_score(&self, episode: &Episode) -> f32 {
+        let now = Utc::now();
+        let age = now.signed_duration_since(episode.start_time);
+        let age_days = age.num_days() as f32;
+
+        // Simple exponential decay: score = e^(-age_days / 30)
+        // 1.0 at 0 days, ~0.37 at 30 days, ~0.13 at 60 days
+        (-age_days / 30.0).exp()
+    }
+
+    /// Calculate context overlap score (domain, language, framework)
+    pub fn calculate_context_score(&self, episode: &Episode, query_context: &TaskContext) -> f32 {
+        let mut score = 0.0;
+        let mut total_weight = 0.0;
+
+        // Domain match (highest weight)
+        total_weight += 2.0;
+        if episode.context.domain == query_context.domain {
+            score += 2.0;
+        }
+
+        // Language match
+        total_weight += 1.0;
+        if let (Some(e_lang), Some(q_lang)) = (&episode.context.language, &query_context.language) {
+            if e_lang == q_lang {
+                score += 1.0;
+            }
+        }
+
+        // Framework match
+        total_weight += 1.0;
+        if let (Some(e_fw), Some(q_fw)) = (&episode.context.framework, &query_context.framework) {
+            if e_fw == q_fw {
+                score += 1.0;
+            }
+        }
+
+        // Tags overlap
+        if !query_context.tags.is_empty() {
+            total_weight += 1.0;
+            let query_tags: std::collections::HashSet<_> = query_context.tags.iter().collect();
+            let episode_tags: std::collections::HashSet<_> = episode.context.tags.iter().collect();
+            let common = query_tags.intersection(&episode_tags).count();
+            score += (common as f32 / query_tags.len() as f32).min(1.0);
+        }
+
+        score / total_weight
+    }
+}
+
+impl Default for HybridRanker {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/memory-core/src/search/mod.rs
+++ b/memory-core/src/search/mod.rs
@@ -4,6 +4,7 @@
 //! retrieving relevant episodes and patterns from memory.
 
 pub mod fuzzy;
+pub mod hybrid_ranker;
 pub mod metrics;
 pub mod ranking;
 pub mod regex;
@@ -30,3 +31,4 @@ pub use types::{FieldMatch, SearchField, SearchMode, SearchResult};
 
 #[cfg(feature = "hybrid_search")]
 pub use hybrid::{HybridSearch, HybridSearchConfig, HybridSearchResult};
+pub use hybrid_ranker::{HybridRanker, HybridRankingWeights, RankingSignals};

--- a/memory-core/src/types/config.rs
+++ b/memory-core/src/types/config.rs
@@ -176,6 +176,8 @@ pub struct MemoryConfig {
     /// - semantic-only: Use only semantic similarity for ranking
     /// - keyword-only: Use traditional keyword matching only
     pub semantic_search_mode: String,
+    /// Retrieval mode (Keyword, Semantic, Hybrid)
+    pub retrieval_mode: crate::types::enums::RetrievalMode,
     /// Enable query embedding caching (default: true)
     /// Caches query embeddings to avoid regenerating for identical queries
     pub enable_query_embedding_cache: bool,
@@ -220,6 +222,7 @@ impl Default for MemoryConfig {
 
             // Phase 3 (Enhanced) - Semantic search defaults
             semantic_search_mode: "hybrid".to_string(),
+            retrieval_mode: crate::types::enums::RetrievalMode::Hybrid,
             enable_query_embedding_cache: true,
             semantic_similarity_threshold: 0.6,
 
@@ -293,6 +296,21 @@ impl MemoryConfig {
                         policy
                     );
                     Some(crate::episode::EvictionPolicy::RelevanceWeighted)
+                }
+            };
+        }
+
+        if let Ok(mode) = std::env::var("MEMORY_RETRIEVAL_MODE") {
+            config.retrieval_mode = match mode.to_lowercase().as_str() {
+                "keyword" => crate::types::enums::RetrievalMode::Keyword,
+                "semantic" => crate::types::enums::RetrievalMode::Semantic,
+                "hybrid" => crate::types::enums::RetrievalMode::Hybrid,
+                _ => {
+                    tracing::warn!(
+                        "Invalid MEMORY_RETRIEVAL_MODE '{}', using default 'hybrid'",
+                        mode
+                    );
+                    crate::types::enums::RetrievalMode::Hybrid
                 }
             };
         }

--- a/memory-core/src/types/enums.rs
+++ b/memory-core/src/types/enums.rs
@@ -75,6 +75,33 @@ impl std::fmt::Display for TaskType {
     }
 }
 
+/// Mode for episode retrieval
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RetrievalMode {
+    /// Traditional keyword-based search
+    Keyword,
+    /// Semantic embedding-based search
+    Semantic,
+    /// Hybrid search combining keyword, semantic, and other signals
+    Hybrid,
+}
+
+impl Default for RetrievalMode {
+    fn default() -> Self {
+        Self::Hybrid
+    }
+}
+
+impl std::fmt::Display for RetrievalMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RetrievalMode::Keyword => write!(f, "keyword"),
+            RetrievalMode::Semantic => write!(f, "semantic"),
+            RetrievalMode::Hybrid => write!(f, "hybrid"),
+        }
+    }
+}
+
 impl std::str::FromStr for TaskType {
     type Err = String;
 


### PR DESCRIPTION
Implemented the core components for ANN-backed semantic episode retrieval, including a vector index abstraction, a semantic retriever, and a hybrid ranker for multi-signal fusion. Updated configuration types to support these new retrieval modes.

Fixes #744

---
*PR created automatically by Jules for task [13453850703839040699](https://jules.google.com/task/13453850703839040699) started by @d-o-hub*