### PR TITLE
ci(publish): improve crates.io publish pipeline

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -40,7 +40,13 @@ jobs:
         run: cargo install --locked cargo-semver-checks
 
       - name: Semver Check
-        run: cargo semver-checks --package do-memory-core
+        id: semver
+        run: |
+          cargo semver-checks --package do-memory-core 2>&1 | tee semver-output.txt || true
+          echo '## Semver Check Results' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat semver-output.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
         continue-on-error: true  # Pre-1.0 may have breaking changes
 
       - name: Verify metadata
@@ -69,15 +75,29 @@ jobs:
         if: ${{ inputs.dry-run && steps.check-version.outputs.exists != 'true' }}
         run: |
           echo "exists output: ${{ steps.check-version.outputs.exists }}"
-          cargo publish --package do-memory-core --dry-run
+          cargo publish --package do-memory-core --locked --dry-run
 
       - name: Publish to crates.io
         if: ${{ (github.event_name == 'release' || !inputs.dry-run) && steps.check-version.outputs.exists != 'true' }}
         run: |
           echo "exists output: ${{ steps.check-version.outputs.exists }}"
-          cargo publish --package do-memory-core
+          cargo publish --package do-memory-core --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for crates.io propagation
+        if: ${{ (github.event_name == 'release' || !inputs.dry-run) && steps.check-version.outputs.exists != 'true' }}
+        run: |
+          VERSION="${{ steps.check-version.outputs.version }}"
+          CRATE_NAME="do-memory-core"
+          for i in $(seq 1 20); do
+            PUBLISHED=$(curl -s -H "User-Agent: rust-self-learning-memory-ci" \
+              "https://crates.io/api/v1/crates/$CRATE_NAME/versions" | \
+              jq -r '.versions[0].num // empty')
+            [ "$PUBLISHED" = "$VERSION" ] && echo "✓ Propagated!" && break
+            echo "Waiting for propagation... attempt $i/20"
+            sleep 15
+          done
 
   # Publish do-memory-storage-redb after core (no internal dependencies)
   publish-redb:
@@ -99,11 +119,14 @@ jobs:
       - name: Install cargo-semver-checks
         run: cargo install --locked cargo-semver-checks
 
-      - name: Wait for crates.io propagation
-        run: sleep 30
-
       - name: Semver Check
-        run: cargo semver-checks --package do-memory-storage-redb
+        id: semver
+        run: |
+          cargo semver-checks --package do-memory-storage-redb 2>&1 | tee semver-output.txt || true
+          echo '## Semver Check Results' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat semver-output.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
         continue-on-error: true  # Pre-1.0 may have breaking changes
 
       - name: Verify metadata
@@ -130,21 +153,35 @@ jobs:
         if: ${{ inputs.dry-run && steps.check-version.outputs.exists != 'true' }}
         run: |
           echo "exists output: ${{ steps.check-version.outputs.exists }}"
-          cargo publish --package do-memory-storage-redb --dry-run
+          cargo publish --package do-memory-storage-redb --locked --dry-run
 
       - name: Publish to crates.io
         if: ${{ (github.event_name == 'release' || !inputs.dry-run) && steps.check-version.outputs.exists != 'true' }}
         run: |
           echo "exists output: ${{ steps.check-version.outputs.exists }}"
-          cargo publish --package do-memory-storage-redb
+          cargo publish --package do-memory-storage-redb --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-  # Publish do-memory-storage-turso after redb (depends on redb)
+      - name: Wait for crates.io propagation
+        if: ${{ (github.event_name == 'release' || !inputs.dry-run) && steps.check-version.outputs.exists != 'true' }}
+        run: |
+          VERSION="${{ steps.check-version.outputs.version }}"
+          CRATE_NAME="do-memory-storage-redb"
+          for i in $(seq 1 20); do
+            PUBLISHED=$(curl -s -H "User-Agent: rust-self-learning-memory-ci" \
+              "https://crates.io/api/v1/crates/$CRATE_NAME/versions" | \
+              jq -r '.versions[0].num // empty')
+            [ "$PUBLISHED" = "$VERSION" ] && echo "✓ Propagated!" && break
+            echo "Waiting for propagation... attempt $i/20"
+            sleep 15
+          done
+
+  # Publish do-memory-storage-turso after core and redb (depends on both)
   publish-turso:
     name: Publish do-memory-storage-turso
     runs-on: ubuntu-latest
-    needs: [publish-redb]
+    needs: [publish-core, publish-redb]
     if: ${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch') && (inputs.crate == '' || inputs.crate == 'do-memory-storage-turso') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -160,11 +197,14 @@ jobs:
       - name: Install cargo-semver-checks
         run: cargo install --locked cargo-semver-checks
 
-      - name: Wait for crates.io propagation
-        run: sleep 30
-
       - name: Semver Check
-        run: cargo semver-checks --package do-memory-storage-turso
+        id: semver
+        run: |
+          cargo semver-checks --package do-memory-storage-turso 2>&1 | tee semver-output.txt || true
+          echo '## Semver Check Results' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat semver-output.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
         continue-on-error: true  # Pre-1.0 may have breaking changes
 
       - name: Verify metadata
@@ -191,15 +231,29 @@ jobs:
         if: ${{ inputs.dry-run && steps.check-version.outputs.exists != 'true' }}
         run: |
           echo "exists output: ${{ steps.check-version.outputs.exists }}"
-          cargo publish --package do-memory-storage-turso --dry-run
+          cargo publish --package do-memory-storage-turso --locked --dry-run
 
       - name: Publish to crates.io
         if: ${{ (github.event_name == 'release' || !inputs.dry-run) && steps.check-version.outputs.exists != 'true' }}
         run: |
           echo "exists output: ${{ steps.check-version.outputs.exists }}"
-          cargo publish --package do-memory-storage-turso
+          cargo publish --package do-memory-storage-turso --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for crates.io propagation
+        if: ${{ (github.event_name == 'release' || !inputs.dry-run) && steps.check-version.outputs.exists != 'true' }}
+        run: |
+          VERSION="${{ steps.check-version.outputs.version }}"
+          CRATE_NAME="do-memory-storage-turso"
+          for i in $(seq 1 20); do
+            PUBLISHED=$(curl -s -H "User-Agent: rust-self-learning-memory-ci" \
+              "https://crates.io/api/v1/crates/$CRATE_NAME/versions" | \
+              jq -r '.versions[0].num // empty')
+            [ "$PUBLISHED" = "$VERSION" ] && echo "✓ Propagated!" && break
+            echo "Waiting for propagation... attempt $i/20"
+            sleep 15
+          done
 
   # Publish MCP crate after all storage crates
   publish-mcp:
@@ -221,11 +275,14 @@ jobs:
       - name: Install cargo-semver-checks
         run: cargo install --locked cargo-semver-checks
 
-      - name: Wait for crates.io propagation
-        run: sleep 30
-
       - name: Semver Check
-        run: cargo semver-checks --package do-memory-mcp
+        id: semver
+        run: |
+          cargo semver-checks --package do-memory-mcp 2>&1 | tee semver-output.txt || true
+          echo '## Semver Check Results' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat semver-output.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
         continue-on-error: true  # Pre-1.0 may have breaking changes
 
       - name: Verify metadata
@@ -252,12 +309,12 @@ jobs:
         if: ${{ inputs.dry-run && steps.check-version.outputs.exists != 'true' }}
         run: |
           echo "exists output: ${{ steps.check-version.outputs.exists }}"
-          cargo publish --package do-memory-mcp --dry-run
+          cargo publish --package do-memory-mcp --locked --dry-run
 
       - name: Publish to crates.io
         if: ${{ (github.event_name == 'release' || !inputs.dry-run) && steps.check-version.outputs.exists != 'true' }}
         run: |
           echo "exists output: ${{ steps.check-version.outputs.exists }}"
-          cargo publish --package do-memory-mcp
+          cargo publish --package do-memory-mcp --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/tests/hybrid_storage_recovery.rs
+++ b/tests/hybrid_storage_recovery.rs
@@ -3,14 +3,19 @@
 //! Verifies that the hybrid storage system handles partial backend failures
 //! and correctly reconciles data when one backend is ahead of another.
 
+#[cfg(feature = "redb")]
 use async_trait::async_trait;
+#[cfg(feature = "redb")]
 use chrono::{DateTime, Utc};
+#[cfg(feature = "redb")]
 use do_memory_core::episode::{CleanupResult, EpisodeRetentionPolicy, PatternId};
 #[cfg(any(feature = "turso", feature = "redb"))]
 use do_memory_core::memory::SelfLearningMemory;
+#[cfg(feature = "redb")]
 use do_memory_core::memory::attribution::{
     RecommendationFeedback, RecommendationSession, RecommendationStats,
 };
+#[cfg(feature = "redb")]
 use do_memory_core::{Episode, Error, Heuristic, Pattern, Result, StorageBackend};
 #[cfg(any(feature = "turso", feature = "redb"))]
 use do_memory_core::{MemoryConfig, TaskContext, TaskOutcome, TaskType};
@@ -18,12 +23,16 @@ use do_memory_core::{MemoryConfig, TaskContext, TaskOutcome, TaskType};
 use do_memory_test_utils::in_memory_redb_storage;
 #[cfg(feature = "turso")]
 use do_memory_test_utils::temp_local_storage;
+#[cfg(feature = "redb")]
 use std::sync::Arc;
+#[cfg(feature = "redb")]
 use uuid::Uuid;
 
 /// A storage backend that fails on every operation
+#[cfg(feature = "redb")]
 struct FailingStorage;
 
+#[cfg(feature = "redb")]
 #[async_trait]
 impl StorageBackend for FailingStorage {
     async fn store_episode(&self, _episode: &Episode) -> Result<()> {


### PR DESCRIPTION
## Summary
Fixes #772 - CI/CD & crates.io publish pipeline improvements.

## Changes
1. **Replace sleep 30 with polling**: Crates.io propagation now uses polling (20 attempts × 15s) instead of hardcoded sleep
2. **Add --locked flag**: All cargo publish commands use `--locked` for reproducible builds
3. **Fix dependency chain**: `publish-turso` now correctly declares `needs: [publish-core, publish-redb]`
4. **Surface semver-checks**: Output is written to `$GITHUB_STEP_SUMMARY` instead of being silently swallowed

## 2026 Best Practices Applied
- `cargo publish --locked` per Cargo best practices
- Sparse-index polling pattern (vs sleep) per crates.io recommendations
- Step summary for visibility per GitHub Actions best practices