### PR TITLE
docs(agents): add lessons #013-#014, update release/CI references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ Before task tool: skill? → script? → Skill+CLI? → task tool?
 ## Common Pitfalls
 
 - **Coderabbitai review loops**: Always `read_files` on the target file before acting on a finding. Trust current code, not conversation summaries or cached search results. Fix history may not match current tree.
+- **Feature-gated imports in tests**: When adding `#[cfg(feature = "X")]` tests, also gate ALL imports, structs, and impls used exclusively by those tests. CI runs clippy without features and will reject ungated dead code. One ungated import in `tests/` blocks all PRs.
 - Read patterns first; roadmap and status docs can lag real repo state.
 - Verify release/package reality with `gh release view` and `cargo metadata` before editing version plans.
 - Update `ROADMAP_ACTIVE.md`, `GOALS.md`, `ACTIONS.md`, `GOAP_STATE.md`, and `STATUS/CURRENT.md` together when sprint priorities change.

--- a/agent_docs/LESSONS.md
+++ b/agent_docs/LESSONS.md
@@ -83,3 +83,13 @@ Compact log for non-obvious workflow learnings. Pair each entry here with a shor
 - Root Cause: Ad-hoc scripts created during CI fixes were committed directly to root without considering long-term maintenance or placement conventions.
 - Solution: Place reusable scripts in `scripts/`, delete one-off scripts after use, and never commit `.py` or `.sh` files to the repository root. Use `plans/` for design notes, `target/` for build artifacts.
 - Reference: `AGENTS.md` "Disk Space" section — "No Temporary Files in Root" guard rail.
+
+## LESSON-015: Feature-gated test code requires matching cfg on ALL imports
+
+- Issue: `tests/hybrid_storage_recovery.rs` had `use std::sync::Arc`, `use async_trait::async_trait`, `struct FailingStorage` etc. defined unconditionally, but they were only used inside `#[cfg(feature = "redb")]` test functions. CI runs `cargo clippy --tests -- -D warnings` without features, causing unused-import and dead-code errors that block ALL open PRs.
+- Root Cause: When adding feature-gated tests, developers often gate only the `#[test]` function with `#[cfg(feature = "X")]` but forget to gate the imports, helper structs, and impl blocks that the test uses. Without the feature enabled, those become dead code.
+- Solution: Every import, struct, and impl block that is ONLY used inside feature-gated code must also carry matching `#[cfg(...)]` attributes. Use the same or broader cfg predicate as the most restrictive consumer.
+- 2026 best practice: Run clippy in CI both with `--tests` (no features) AND with `--all-features --tests` to catch both dead-code (no features) and missing-import (all features) errors. Consider `cargo-matrix` for comprehensive feature combination testing.
+- Key insight: A single ungated import in a test file can block the entire CI pipeline for all PRs, since the `e2e-tests` crate is checked as part of workspace clippy.
+- Location: `tests/hybrid_storage_recovery.rs`
+- Reference: Rust Reference §Conditional Compilation; <https://effective-rust.com/features.html>

--- a/tests/hybrid_storage_recovery.rs
+++ b/tests/hybrid_storage_recovery.rs
@@ -3,14 +3,19 @@
 //! Verifies that the hybrid storage system handles partial backend failures
 //! and correctly reconciles data when one backend is ahead of another.
 
+#[cfg(feature = "redb")]
 use async_trait::async_trait;
+#[cfg(feature = "redb")]
 use chrono::{DateTime, Utc};
+#[cfg(feature = "redb")]
 use do_memory_core::episode::{CleanupResult, EpisodeRetentionPolicy, PatternId};
 #[cfg(any(feature = "turso", feature = "redb"))]
 use do_memory_core::memory::SelfLearningMemory;
+#[cfg(feature = "redb")]
 use do_memory_core::memory::attribution::{
     RecommendationFeedback, RecommendationSession, RecommendationStats,
 };
+#[cfg(feature = "redb")]
 use do_memory_core::{Episode, Error, Heuristic, Pattern, Result, StorageBackend};
 #[cfg(any(feature = "turso", feature = "redb"))]
 use do_memory_core::{MemoryConfig, TaskContext, TaskOutcome, TaskType};
@@ -18,12 +23,16 @@ use do_memory_core::{MemoryConfig, TaskContext, TaskOutcome, TaskType};
 use do_memory_test_utils::in_memory_redb_storage;
 #[cfg(feature = "turso")]
 use do_memory_test_utils::temp_local_storage;
+#[cfg(feature = "redb")]
 use std::sync::Arc;
+#[cfg(feature = "redb")]
 use uuid::Uuid;
 
 /// A storage backend that fails on every operation
+#[cfg(feature = "redb")]
 struct FailingStorage;
 
+#[cfg(feature = "redb")]
 #[async_trait]
 impl StorageBackend for FailingStorage {
     async fn store_episode(&self, _episode: &Episode) -> Result<()> {


### PR DESCRIPTION
## Summary
Updates AGENTS.md and agent_docs/LESSONS.md with new learnings from the v0.1.34 sprint.

## Changes
- **agent_docs/LESSONS.md**: Added LESSON-013 (redb `:memory:` path fallback) and LESSON-014 (CI publish polling vs sleep)
- **AGENTS.md**: Added Trusted Publishing note in Release Process, publish pipeline subsection in CI Optimization, cross-reference for Trusted Publishing