### PR TITLE
docs(release): update CHANGELOG and STATUS for v0.1.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - **Build maintenance script** — `scripts/build-maintenance.sh` verifies `.cargo/config.toml` optimizations and target/ size
 - **Mutation testing workflow** — Focused mutation testing for core modules (PR #793)
 - **File-level lint allows** — `#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]` added to 25 test/bench/example files
+- **Retry budgets and backpressure** (PR #806) — `RetryBudget` (sliding window token bucket) and `ConcurrencyLimiter` (tokio semaphore) for retry backpressure (#753)
+- **WASM compile-check** (PR #806) — `wasm32` feature flag and CI compile-check job for `memory-core` WASM builds (#746)
+- **Pre-built binary installation** (PR #806) — Added platform matrix and download links to README (#770)
 
 ### Fixed
 
@@ -14,13 +17,16 @@
 - **Edit distance performance** — Optimized space complexity and row transitions with swap (PR #796)
 - **CLI local storage** — Persist episodes in local storage mode (PR #787)
 - **Reconciliation cache** — Made backfill synchronous instead of fire-and-forget (PR #781)
-- **Benchmark timeouts** — Reduced `phase3_cache_performance` and `compression_benchmark` timeouts from 600s to 300s
+- **Benchmark timeouts** — Increased step timeout to 55min, MAX_TOTAL_TIME to 50min for grown benchmark suite (PR #806)
+- **Sandbox test assertion** — Relaxed `test_security_bypass_attempts` to accept any `Error` variant for Node.js version compatibility (PR #806)
+- **Broken doc link** — Fixed unresolved `[acquire]` link in `retry/limiter.rs` (PR #806)
 
 ### Changed
 
-- **Publish pipeline** — Improved crates.io publish pipeline with sparse-index polling (PR #789)
+- **Publish pipeline** — Improved crates.io publish pipeline with sparse-index polling, added CLI publish job (PR #789, #806)
 - **CI workflows** — Added required check anchors to Coverage, File Structure, Security, YAML Lint workflows
-- **Documentation** — Added build dependencies section to README (PR #788), agent lessons #013-#014 (PR #791)
+- **Documentation** — Added build dependencies section to README (PR #788), agent lessons #013-#014 (PR #791), storage module pipeline docs (#743)
+- **Turso connection pool** — Enhanced with atomic `PoolMetrics`, `min_connections`, `acquire_timeout_ms`, `idle_timeout_ms`, ADR-056 compliance verified (PR #806, #749)
 
 ## [0.1.33] - 2026-06-15
 

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -1,24 +1,27 @@
 # Project Status — Self-Learning Memory System
 
-**Last Updated**: 2026-07-09 (v0.1.34 released)
-**Released Version**: v0.1.34 (GitHub Release tag exists, 2026-07-09)
+**Last Updated**: 2026-07-11 (v0.1.34 PR merged, pending release)
+**Released Version**: v0.1.33 (GitHub Release tag exists, 2026-07-04)
 **Workspace Version**: 0.1.34
-**Active Sprint**: v0.1.34 — CI Health + Benchmark Fixes + Lint Hygiene
+**Active Sprint**: v0.1.34 — CI Fixes + All Open Issues Resolved
 **Branch**: `main`
-**Epic**: [#373](https://github.com/d-o-hub/rust-self-learning-memory/issues/373) — ALL ISSUES CLOSED
+**PR**: [#806](https://github.com/d-o-hub/rust-self-learning-memory/pull/806) — MERGED
 **Edition**: Rust 2024
 
-## v0.1.34 Sprint — IN PROGRESS
+## v0.1.34 Sprint — PR MERGED, PENDING RELEASE
 
 | Phase | Issue | Description | Status |
 |-------|-------|-------------|--------|
-| P1 — Bug Fix | #773 | Local storage episodes not persisting | 🟡 PR #787 open |
-| P2 — Docs | #771 | Add build dependencies to README | 🟡 PR #788 open |
-| P3 — CI | #772 | Publish pipeline improvements | 🟡 PR #789 open |
-| P4 — Release | #784 | Release drift (30+ unreleased commits) | ⏳ Blocked on P1-P3 |
-| P5 — Publish | #770 | crates.io availability | ⏳ Blocked on P3+P4 |
+| CI Fix | — | `test_security_bypass_attempts` assertion relaxed | ✅ Merged (PR #806) |
+| CI Fix | — | Benchmark timeout increased to 55min | ✅ Merged (PR #806) |
+| Docs | #770 | Pre-built binary installation section in README | ✅ Merged (PR #806) |
+| Docs | #743 | Storage module pipeline documentation | ✅ Merged (PR #806) |
+| Feature | #753 | Retry budgets and backpressure controls | ✅ Merged (PR #806) |
+| Feature | #749 | Turso connection pool enhancements + ADR-056 | ✅ Merged (PR #806) |
+| Feature | #746 | WASM compile-check CI job | ✅ Merged (PR #806) |
+| Publish | #770 | CLI crates.io publish prep | ✅ Merged (PR #806) |
 
-**Blocking**: P4 and P5 depend on P1-P3 merging first.
+**All 6 open issues resolved.** Release tag v0.1.34 pending.
 
 ## v0.1.33 Sprint — COMPLETE ✅ (Released)
 


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md with all v0.1.34 changes from PR #806
- Update STATUS/CURRENT.md to reflect PR #806 merged and all 6 issues resolved

## Changes

- **CHANGELOG.md**: Added entries for retry budgets, WASM compile-check, pre-built binary docs, benchmark timeout fix, sandbox test fix, broken doc link fix, storage module docs, Turso pool enhancements, CLI publish prep
- **STATUS/CURRENT.md**: Updated sprint status to show all phases complete, PR #806 merged, pending release tag

## Closes

No new issues — documentation update only.