### PR TITLE
docs(guard-rails): enforce CI wait before merge, never use --admin

### DIFF
--- a/.agents/skills/pr-readiness/SKILL.md
+++ b/.agents/skills/pr-readiness/SKILL.md
@@ -22,6 +22,16 @@ Verify that a Pull Request is truly ready to merge — not just that CI is green
 3. All required checks passed (not just non-required ones)
 4. No stale CANCELLED checks that should have run
 
+## Hard Blockers (NEVER BYPASS)
+
+These rules have NO exceptions. Do not use `--admin`, `--force`, or any bypass mechanism:
+
+1. **NEVER merge when `mergeStateStatus` is `UNSTABLE`** — Wait for all checks to complete.
+2. **NEVER merge when checks are `pending`** — Wait for ALL checks to reach a terminal state.
+3. **NEVER use `gh pr merge --admin` to bypass branch protection** — Fix the code, don't bypass the gate.
+4. **NEVER merge a PR you haven't personally verified** — Run the full check and confirm ALL conditions.
+5. **NEVER skip loading this skill** — Load this skill before any merge recommendation.
+
 ## Full Procedure
 
 ### 1. Query All PR State
@@ -147,6 +157,17 @@ This ignores merge conflicts and behind-main state.
 ### ✅ Correct: Investigate CANCELLED
 ```
 "Coverage check CANCELLED — was it because Quick Check failed? Or stale from old push?"
+```
+
+### ❌ Wrong: Use --admin to bypass protection
+```
+"gh pr merge --admin" when checks are failing/pending
+```
+This is NEVER acceptable. Fix the code, don't bypass the gate.
+
+### ✅ Correct: Fix the underlying issue
+```
+"Checks failing → diagnose → fix code → push → wait for green → merge normally"
 ```
 
 ## Output Format

--- a/.agents/skills/release-guard/SKILL.md
+++ b/.agents/skills/release-guard/SKILL.md
@@ -8,9 +8,12 @@ allowed-tools: Read, Bash(gh *:*), Bash(git *:*)
 
 ## Core Rules (NEVER VIOLATE)
 - Releases **ONLY** from **main** after PR merge.
-- **ALL** CI jobs must COMPLETE + SUCCESS. NO queued jobs.
+- **ALL** CI jobs must COMPLETE + SUCCESS. NO queued jobs. NO partial passes.
 - Verify branch protection requires status checks.
 - **Version MUST match tag** before creating release (cargo-dist requirement).
+- **NEVER use `--admin` or `--force`** to bypass branch protection or merge checks.
+- **NEVER merge when `mergeStateStatus` is `UNSTABLE` or `BLOCKED`** — wait for `CLEAN`.
+- **NEVER skip the pr-readiness skill** — load it before any merge action.
 
 ## Activation Steps
 1. **PR Check**: Ask for PR# if needed. Run `gh pr view $PR_NUM --json state,baseRefName`. Must: state=CLOSED, baseRefName=main.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,52 @@ A PR is NOT ready to merge unless ALL of:
 
 CI checks run against the branch HEAD, not against the merge result. A PR can have green CI but be unmergeable due to conflicts with main.
 
+### Hard Blockers (NEVER BYPASS)
+
+These rules have NO exceptions. Do not use `--admin`, `--force`, or any bypass mechanism:
+
+1. **NEVER merge when `mergeStateStatus` is `UNSTABLE`** — Wait for all checks to complete. `UNSTABLE` means non-required checks are failing/pending. Investigate before merging.
+2. **NEVER merge when checks are `pending`** — Wait for ALL checks to reach a terminal state (`SUCCESS`, `FAILURE`, `SKIPPED`).
+3. **NEVER use `gh pr merge --admin` to bypass branch protection** — Branch protection exists for a reason. If checks fail, fix the code, don't bypass the gate.
+4. **NEVER merge a PR you haven't personally verified** — Run the full PR readiness check (`gh pr view {n} --json mergeable,mergeStateStatus,statusCheckRollup`) and confirm ALL conditions before merging.
+5. **NEVER skip the `pr-readiness` skill** — Load `.agents/skills/pr-readiness/SKILL.md` before any merge recommendation. The skill defines the exact verification procedure.
+
+### Mandatory Pre-Merge Checklist
+
+Before ANY merge action, ALL of these must be true:
+
+```
+□ Loaded pr-readiness skill
+□ Ran: gh pr view {n} --json mergeable,mergeStateStatus,statusCheckRollup
+□ mergeable = MERGEABLE
+□ mergeStateStatus = CLEAN
+□ All required checks = SUCCESS (not pending, not FAILURE)
+□ No CANCELLED checks that should have run
+□ No pre-existing failures from base branch
+□ Verified locally: cargo nextest run --all passes
+□ Verified locally: cargo clippy --workspace -- -D warnings passes
+```
+
+## Release Process (MANDATORY)
+**NEVER manually create GitHub releases.** Always use the automated workflow:
+1. Bump version in `Cargo.toml`
+2. Commit + push to `main`
+3. Push git tag: `git tag v<VERSION> && git push origin v<VERSION>`
+4. `release.yml` workflow triggers automatically (preflight → build → create release)
+5. Do NOT use `gh release create` manually — the workflow handles everything
+
+**Before tagging a release**, ALL of these must be true:
+```
+□ All PRs merged to main with CLEAN merge state
+□ All CI workflows on main pass (no failures, no pending)
+□ Pre-existing failures investigated and fixed (not ignored)
+□ CHANGELOG.md updated with all changes
+□ STATUS/CURRENT.md updated
+□ GOAP_STATE.md updated
+□ Local verification: cargo nextest run --all passes
+□ Local verification: cargo clippy --workspace -- -D warnings passes
+```
+
 Feature flags: `openai`, `local-embeddings`, `turso`, `redb`, `embeddings-full`, `full`, `csm`
 
 ## CSM Integration

--- a/agent_docs/LESSONS.md
+++ b/agent_docs/LESSONS.md
@@ -2,6 +2,17 @@
 
 Compact log for non-obvious workflow learnings. Pair each entry here with a short distilled note in the nearest `AGENTS.md`.
 
+## LESSON-011: NEVER rush merges — wait for ALL CI, never use --admin
+
+- Issue: PR #806 merged when `mergeStateStatus` was `UNSTABLE` (not `CLEAN`) using `gh pr merge --admin`. This bypassed branch protection and caused pre-existing CI failures to ship to main. Required follow-up PRs (#810, #811) to fix the failures.
+- Root Cause: Agent rushed to "complete the task" instead of following the mandatory PR health check procedure. The pr-readiness skill was never loaded. The `--admin` flag was used as a shortcut instead of fixing the underlying issues.
+- Solution: 
+  1. ALWAYS load `.agents/skills/pr-readiness/SKILL.md` before any merge action
+  2. NEVER use `--admin` or `--force` — fix the code, don't bypass the gate
+  3. NEVER merge when `mergeStateStatus` is anything other than `CLEAN`
+  4. Wait for ALL checks to reach terminal state before merging
+  5. Follow the Mandatory Pre-Merge Checklist in AGENTS.md
+
 ## LESSON-010: Coderabbitai review loop — verify each finding against current code
 
 - Issue: Conversation summaries implied fixes were already applied, but code still had the original unfixed patterns (e.g., `_min_sequence_len` in `with_thresholds`, `contributing_tiers` hardcoding `api_fallback_needed`).


### PR DESCRIPTION
## Summary

Adds guard rails to prevent rushing merges before all CI passes. Inspired by the PR #806 incident where `--admin` was used to bypass branch protection while `mergeStateStatus` was `UNSTABLE`.

## Changes

| File | Change |
|------|--------|
| `AGENTS.md` | Added "Hard Blockers" section with 5 never-bypass rules, mandatory pre-merge checklist, release process section |
| `.agents/skills/pr-readiness/SKILL.md` | Added hard blockers and `--admin` anti-pattern |
| `.agents/skills/release-guard/SKILL.md` | Added never-use-admin and never-skip-pr-readiness rules |
| `agent_docs/LESSONS.md` | Added LESSON-011 about rush merges |

## The 5 Hard Blockers

1. NEVER merge when `mergeStateStatus` is `UNSTABLE`
2. NEVER merge when checks are `pending`
3. NEVER use `gh pr merge --admin` to bypass branch protection
4. NEVER merge a PR you haven't personally verified
5. NEVER skip the `pr-readiness` skill

## Lesson Learned

PR #806 was merged with `--admin` when state was `UNSTABLE`. This caused pre-existing CI failures (flaky test, nightly config) to ship to main, requiring follow-up PRs #810 and #811 to fix. The fix is simple: wait for `CLEAN`, fix code instead of bypassing gates.