### PR TITLE
docs(release): enforce ALWAYS use release.yml workflow, never bypass

### DIFF
--- a/.agents/skills/release-guard/SKILL.md
+++ b/.agents/skills/release-guard/SKILL.md
@@ -14,6 +14,7 @@ allowed-tools: Read, Bash(gh *:*), Bash(git *:*)
 - **NEVER use `--admin` or `--force`** to bypass branch protection or merge checks.
 - **NEVER merge when `mergeStateStatus` is `UNSTABLE` or `BLOCKED`** — wait for `CLEAN`.
 - **NEVER skip the pr-readiness skill** — load it before any merge action.
+- **ALWAYS use the `release.yml` workflow** — push a git tag, let the workflow handle everything. NEVER use `gh release create` manually. NEVER bypass the release pipeline.
 
 ## Activation Steps
 1. **PR Check**: Ask for PR# if needed. Run `gh pr view $PR_NUM --json state,baseRefName`. Must: state=CLOSED, baseRefName=main.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,8 @@ Before ANY merge action, ALL of these must be true:
 4. `release.yml` workflow triggers automatically (preflight → build → create release)
 5. Do NOT use `gh release create` manually — the workflow handles everything
 
+**NEVER bypass the release pipeline.** The `release.yml` workflow runs preflight checks, builds artifacts, and creates the GitHub release. Skipping steps, creating releases manually, or using `--admin` to force a release bypasses critical safety checks (version validation, build verification, artifact signing).
+
 **Before tagging a release**, ALL of these must be true:
 ```
 □ All PRs merged to main with CLEAN merge state


### PR DESCRIPTION
## Summary

Adds explicit rule: ALWAYS use the `release.yml` workflow for releases. NEVER bypass the release pipeline manually.

## Changes

| File | Change |
|------|--------|
| `AGENTS.md` | Added "NEVER bypass the release pipeline" rule to Release Process section |
| `.agents/skills/release-guard/SKILL.md` | Added "ALWAYS use release.yml workflow" to Core Rules |

## The Rule

Push a git tag, let the workflow handle everything:
```bash
git tag v<VERSION> && git push origin v<VERSION>
```

NEVER use `gh release create` manually. NEVER use `--admin` to force a release. The workflow runs preflight checks, builds artifacts, and creates the GitHub release.