### PR TITLE
fix(mcp): resolve semver breaking change, bump to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ checksum = "2906d3628a885aa49a23b88e71f63e51ae8df41cd76652287f0a6179a11833a9"
 
 [[package]]
 name = "do-memory-benches"
-version = "0.1.34"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-cli"
-version = "0.1.34"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-core"
-version = "0.1.34"
+version = "0.2.0"
 dependencies = [
  "agentfs-sdk",
  "anyhow",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-examples"
-version = "0.1.34"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "do-memory-core",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-mcp"
-version = "0.1.34"
+version = "0.2.0"
 dependencies = [
  "agentfs-sdk",
  "anyhow",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-storage-redb"
-version = "0.1.34"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1655,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-storage-turso"
-version = "0.1.34"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-test-utils"
-version = "0.1.34"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1712,7 +1712,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "e2e-tests"
-version = "0.1.34"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.1.34"
+version = "0.2.0"
 edition = "2024"
 authors = ["Self-Learning Memory Contributors"]
 license = "MIT"

--- a/memory-mcp/Cargo.toml
+++ b/memory-mcp/Cargo.toml
@@ -27,9 +27,9 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 # Local dependencies
-do-memory-core = { path = "../memory-core", version = "0.1.34", features = ["agentfs"] }
-do-memory-storage-turso = { path = "../memory-storage-turso", version = "0.1.34" }
-do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.34" }
+do-memory-core = { path = "../memory-core", version = "0.2.0", features = ["agentfs"] }
+do-memory-storage-turso = { path = "../memory-storage-turso", version = "0.2.0" }
+do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.2.0" }
 
 # MCP-specific dependencies
 parking_lot = "0.12.5"

--- a/memory-storage-redb/Cargo.toml
+++ b/memory-storage-redb/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/do-memory-storage-redb"
 
 [dependencies]
 # Core dependencies
-do-memory-core = { path = "../memory-core", version = "0.1.34" }
+do-memory-core = { path = "../memory-core", version = "0.2.0" }
 
 # Async runtime
 tokio = { workspace = true, features = ["full"] }

--- a/memory-storage-turso/Cargo.toml
+++ b/memory-storage-turso/Cargo.toml
@@ -34,8 +34,8 @@ compression-gzip = ["flate2"]
 
 [dependencies]
 # Core dependencies
-do-memory-core = { path = "../memory-core", version = "0.1.34", features = ["hybrid_search"] }
-do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.34" }
+do-memory-core = { path = "../memory-core", version = "0.2.0", features = ["hybrid_search"] }
+do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.2.0" }
 
 # Async runtime
 tokio = { workspace = true, features = ["full"] }


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.1.34 to 0.2.0
- MCP semver check fails because `OAuthConfig.token_secret` and `EpisodeMetrics.total_episode_failures` are new fields on externally-constructible structs
- For pre-1.0 crates, this requires a minor version bump (0.1.x → 0.2.0)
- Update all dependency version constraints to 0.2.0

## Test Results

- 3517 tests pass, 0 failures
- Clippy clean, format clean

## Release Plan

After merge, will tag v0.2.0 and trigger release.yml → publish all 5 crates to crates.io.