### PR TITLE
fix(deps): update yanked spin crate 0.9.8 → 0.9.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5671,9 +5671,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spinning_top"


### PR DESCRIPTION
## Summary

Update yanked `spin` crate from 0.9.8 to 0.9.9 to fix Supply Chain Security and Security CI failures.

The `spin` 0.9.8 was yanked from crates.io, causing cargo-deny advisory checks to fail.