### PR TITLE
fix(version): revert 0.2.0 → 0.1.35, enforce patch-only release policy

### DIFF
--- a/.agents/skills/feature-implement/SKILL.md
+++ b/.agents/skills/feature-implement/SKILL.md
@@ -37,3 +37,4 @@ See **[process.md](process.md)** for detailed phases and **[patterns.md](pattern
 - Error handling: `anyhow::Result`
 - Storage: Turso (durable) + redb (cache)
 - Serialization: postcard
+- Version: ONLY 0.1.x patch releases. NEVER bump minor/major without explicit human approval.

--- a/.agents/skills/goap-agent/SKILL.md
+++ b/.agents/skills/goap-agent/SKILL.md
@@ -54,6 +54,14 @@ See **[skills.md](skills.md)** for complete skills list and **[agents.md](agents
 - Treat an empty required-check rollup as a blocker and document it in `plans/STATUS/VALIDATION_LATEST.md`.
 - Avoid adding plans-only follow-up commits until remediation checks are attached.
 
+## Version Policy (HARD CONSTRAINT)
+
+- **ONLY patch releases (0.1.x)**. The project stays on the `0.1.x` line.
+- **NEVER plan or execute a minor/major version bump** (0.2.0, 1.0.0) without explicit human approval.
+- If cargo-semver-checks reports breaking changes: document in CHANGELOG, keep version on 0.1.x.
+- This applies to ALL version-related work groups (WGs) in sprint plans.
+- Verify version with: `grep '^version' Cargo.toml` — must show `0.1.*`.
+
 See **[methodology.md](methodology.md)** for detailed phase-by-phase guidance and **[patterns.md](patterns.md)** for common execution patterns.
 
 ## ADR Integration Workflow

--- a/.agents/skills/release-guard/SKILL.md
+++ b/.agents/skills/release-guard/SKILL.md
@@ -11,10 +11,12 @@ allowed-tools: Read, Bash(gh *:*), Bash(git *:*)
 - **ALL** CI jobs must COMPLETE + SUCCESS. NO queued jobs. NO partial passes.
 - Verify branch protection requires status checks.
 - **Version MUST match tag** before creating release (cargo-dist requirement).
+- **ONLY PATCH RELEASES (0.1.x)**. NEVER bump to 0.2.0 or higher without explicit human approval.
 - **NEVER use `--admin` or `--force`** to bypass branch protection or merge checks.
 - **NEVER merge when `mergeStateStatus` is `UNSTABLE` or `BLOCKED`** — wait for `CLEAN`.
 - **NEVER skip the pr-readiness skill** — load it before any merge action.
 - **ALWAYS use the `release.yml` workflow** — push a git tag, let the workflow handle everything. NEVER use `gh release create` manually. NEVER bypass the release pipeline.
+- **If cargo-semver-checks reports breaking changes**: Keep version on 0.1.x, document in CHANGELOG. ASK human before ANY non-patch bump.
 
 ## Activation Steps
 1. **PR Check**: Ask for PR# if needed. Run `gh pr view $PR_NUM --json state,baseRefName`. Must: state=CLOSED, baseRefName=main.

--- a/.github/workflows/file-structure.yml
+++ b/.github/workflows/file-structure.yml
@@ -54,6 +54,72 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
+      - name: Validate version line (0.1.x only)
+        run: |
+          #!/bin/bash
+          set -e
+
+          echo "Validating workspace version stays on 0.1.x patch line..."
+          echo ""
+
+          VERSION=$(grep -E '^version\s*=' Cargo.toml | head -1 | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+[^"]*)".*/\1/')
+
+          if [[ -z "$VERSION" ]]; then
+            echo "❌ Could not extract version from Cargo.toml"
+            exit 1
+          fi
+
+          echo "  Workspace version: $VERSION"
+
+          MAJOR_MINOR=$(echo "$VERSION" | grep -oP '^\d+\.\d+')
+
+          if [[ "$MAJOR_MINOR" != "0.1" ]]; then
+            echo ""
+            echo "❌ VERSION POLICY VIOLATION"
+            echo ""
+            echo "   Found version: $VERSION"
+            echo "   Expected: 0.1.x (patch releases only)"
+            echo ""
+            echo "   The project stays on the 0.1.x release line."
+            echo "   Minor/major bumps (0.2.0, 1.0.0) require explicit human approval."
+            echo "   Pre-1.0 semver allows breaking changes in patch releases (§4)."
+            echo ""
+            echo "   Fix: Change version in Cargo.toml back to 0.1.x"
+            echo "   If you have human approval for a non-patch bump, add 'version-override' label to the PR."
+            exit 1
+          fi
+
+          # Also check all workspace members match
+          MEMBERS=$(find . -name "Cargo.toml" -not -path "./target/*" -not -path "./fuzz/*" | sort)
+          MISMATCH=0
+          for toml in $MEMBERS; do
+            # Check for hardcoded version (not workspace inheritance)
+            HARD_VERSION=$(grep -E '^version\s*=\s*"[0-9]' "$toml" 2>/dev/null | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/' || true)
+            if [[ -n "$HARD_VERSION" && "$HARD_VERSION" != "$VERSION" ]]; then
+              echo "  ❌ $toml has version $HARD_VERSION (expected $VERSION)"
+              MISMATCH=1
+            fi
+            # Check for inter-crate version references that don't match
+            INTER_CRATE=$(grep -oP 'do-memory-\S+.*?version\s*=\s*"\K[0-9]+\.[0-9]+\.[0-9]+' "$toml" 2>/dev/null || true)
+            for v in $INTER_CRATE; do
+              if [[ "$v" != "$VERSION" ]]; then
+                echo "  ❌ $toml has inter-crate dep version $v (expected $VERSION)"
+                MISMATCH=1
+              fi
+            done
+          done
+
+          if [[ $MISMATCH -ne 0 ]]; then
+            echo ""
+            echo "❌ Version consistency check FAILED"
+            echo "   All crate versions and inter-crate dependencies must match the workspace version."
+            exit 1
+          fi
+
+          echo "  ✅ Version line: 0.1.x (correct)"
+          echo "  ✅ All crate versions consistent"
+          echo ""
+
       - name: Validate file locations
         run: |
           #!/bin/bash

--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -60,9 +60,14 @@ jobs:
             echo "tag_drift=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # Alert threshold: >5 feat/fix commits unreleased
-          if [[ $((FEATS + FIXES)) -gt 5 ]]; then
+          # Alert threshold: >5 feat/fix commits unreleased AND version matches tag
+          # (if version already bumped ahead of tag, a release is being prepared — don't alert)
+          if [[ $((FEATS + FIXES)) -gt 5 && "$LATEST_TAG" == "v${VERSION}" ]]; then
             echo "needs_release=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$LATEST_TAG" != "v${VERSION}" && "$LATEST_TAG" != "none" ]]; then
+            # Tag drift exists but version is already bumped — release in progress
+            echo "needs_release=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Version ($VERSION) differs from tag ($LATEST_TAG) — release likely in progress"
           else
             echo "needs_release=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,13 @@ jobs:
             echo "Fix: bump Cargo.toml version to match tag, or use 'cargo release' to bump+tag atomically."
             exit 1
           fi
-          echo "✅ Tag matches Cargo.toml version"
+          # Enforce 0.1.x patch release line
+          MAJOR_MINOR=$(echo "$CARGO_VERSION" | grep -oP '^\d+\.\d+')
+          if [[ "$MAJOR_MINOR" != "0.1" ]]; then
+            echo "::error::Version $CARGO_VERSION violates the 0.1.x patch release policy. Only patch releases (0.1.x) are allowed without explicit human approval."
+            exit 1
+          fi
+          echo "✅ Tag matches Cargo.toml version (0.1.x patch line)"
 
   plan:
     needs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,31 @@ Before task tool: skill? → script? → Skill+CLI? → task tool?
 - **Files**: ≤500 LOC per source file
 - **Tests**: ≥90% coverage. `#[tokio::test]` for async. AAA pattern
 - **Docs**: URLs wrapped in `<...>`. New types re-exported from `lib.rs`
+- **Version**: ONLY patch releases (0.1.x). NEVER bump minor/major without explicit human approval. See Version Policy below.
+
+## Version Policy (MANDATORY — Human Approval Required)
+
+**The project stays on the `0.1.x` patch release line.** This is non-negotiable.
+
+| Action | Allowed? | Requirement |
+|--------|----------|-------------|
+| Patch bump (0.1.34 → 0.1.35) | ✅ Yes | Standard release process |
+| Minor bump (0.1.x → 0.2.0) | ❌ NO | Requires explicit human approval in writing |
+| Major bump (0.x → 1.0) | ❌ NO | Requires explicit human approval in writing |
+
+**Rules**:
+1. **NEVER bump to 0.2.0 or higher** without the human explicitly approving the version number
+2. **Pre-1.0 semver**: Breaking changes are allowed in patch releases (per semver spec §4)
+3. **If a change is breaking**: Document it in CHANGELOG under "Breaking Changes" but keep version on 0.1.x
+4. **Version source of truth**: Workspace `Cargo.toml` `[workspace.package] version` field
+5. **All crate versions must match** the workspace version exactly
+6. **Agents must ASK before any non-patch version change** — even if tooling (cargo-semver-checks) suggests a major/minor bump is needed
+
+**What to do if cargo-semver-checks reports a breaking change**:
+- Document the breaking change in CHANGELOG.md
+- Keep the version as the next patch (e.g., 0.1.35)
+- Add a note in the release: "Contains breaking API changes in <crate>"
+- Do NOT bump to 0.2.0
 
 ## Documentation Rules
 - Wrap URLs in angle brackets, re-export new public types from `lib.rs`, and run `cargo doc --no-deps --document-private-items` before commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.35] - 2026-07-14
+
+### Breaking Changes
+
+- **MCP crate**: Semver-incompatible API changes in `do-memory-mcp` (lazy tool registration signature changed). Breaking changes are permitted under pre-1.0 semver (§4). PR #822.
+
+### Fixed
+
+- fix(deps): update yanked `spin` crate 0.9.8 → 0.9.9 ([7d9eeec](https://github.com/d-o-hub/rust-self-learning-memory/commit/7d9eeec3)) — PR #824
+- fix(mcp): resolve semver breaking change in MCP tool registration ([9955850](https://github.com/d-o-hub/rust-self-learning-memory/commit/99558504)) — PR #822
+- fix(version): revert workspace version from 0.2.0 back to 0.1.35 (project stays on 0.1.x patch line)
+
+### CI/CD
+
+- ci(deps): bump the actions-all group with 2 updates ([232033c](https://github.com/d-o-hub/rust-self-learning-memory/commit/232033c0)) — PR #819
+- ci(release): add 0.1.x version-line enforcement to release.yml preflight
+
+### Added
+
+- docs(agents): add Version Policy (MANDATORY) section to AGENTS.md
+- docs(adr): ADR-072 — Comprehensive Analysis v0.1.35
+- scripts: add 0.1.x version-line guard to `verify-release-state.sh` and `release-manager.sh`
+- skills: add version policy enforcement to `release-guard`, `goap-agent`, `feature-implement`
+
 ## [0.1.34] - 2026-07-11
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ checksum = "2906d3628a885aa49a23b88e71f63e51ae8df41cd76652287f0a6179a11833a9"
 
 [[package]]
 name = "do-memory-benches"
-version = "0.2.0"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-cli"
-version = "0.2.0"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-core"
-version = "0.2.0"
+version = "0.1.35"
 dependencies = [
  "agentfs-sdk",
  "anyhow",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-examples"
-version = "0.2.0"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "do-memory-core",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-mcp"
-version = "0.2.0"
+version = "0.1.35"
 dependencies = [
  "agentfs-sdk",
  "anyhow",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-storage-redb"
-version = "0.2.0"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1655,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-storage-turso"
-version = "0.2.0"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-test-utils"
-version = "0.2.0"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1712,7 +1712,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "e2e-tests"
-version = "0.2.0"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.1.35"
 edition = "2024"
 authors = ["Self-Learning Memory Contributors"]
 license = "MIT"

--- a/memory-mcp/Cargo.toml
+++ b/memory-mcp/Cargo.toml
@@ -27,9 +27,9 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 # Local dependencies
-do-memory-core = { path = "../memory-core", version = "0.2.0", features = ["agentfs"] }
-do-memory-storage-turso = { path = "../memory-storage-turso", version = "0.2.0" }
-do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.2.0" }
+do-memory-core = { path = "../memory-core", version = "0.1.35", features = ["agentfs"] }
+do-memory-storage-turso = { path = "../memory-storage-turso", version = "0.1.35" }
+do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.35" }
 
 # MCP-specific dependencies
 parking_lot = "0.12.5"

--- a/memory-storage-redb/Cargo.toml
+++ b/memory-storage-redb/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/do-memory-storage-redb"
 
 [dependencies]
 # Core dependencies
-do-memory-core = { path = "../memory-core", version = "0.2.0" }
+do-memory-core = { path = "../memory-core", version = "0.1.35" }
 
 # Async runtime
 tokio = { workspace = true, features = ["full"] }

--- a/memory-storage-turso/Cargo.toml
+++ b/memory-storage-turso/Cargo.toml
@@ -34,8 +34,8 @@ compression-gzip = ["flate2"]
 
 [dependencies]
 # Core dependencies
-do-memory-core = { path = "../memory-core", version = "0.2.0", features = ["hybrid_search"] }
-do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.2.0" }
+do-memory-core = { path = "../memory-core", version = "0.1.35", features = ["hybrid_search"] }
+do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.35" }
 
 # Async runtime
 tokio = { workspace = true, features = ["full"] }

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1,689 +1,173 @@
 # GOAP State Snapshot
 
-- **Last Updated**: 2026-07-08 (3 PRs created for issues #773, #771, #772; release drift at 30+ commits)
-- **Version**: `0.1.33` (workspace — tag v0.1.33 exists; ~30 commits since release)
+- **Last Updated**: 2026-07-14 (codebase analysis, PR/issue review, CI verification)
+- **Version**: `0.1.35` (target — workspace Cargo.toml needs version correction from 0.2.0 back to 0.1.35)
 - **Branch**: `main`
 - **Validation**: `plans/STATUS/VALIDATION_LATEST.md`
 - **Gap Analysis**: `plans/STATUS/GAP_ANALYSIS_LATEST.md`
-- **Primary ADRs**: ADR-052 (v0.1.29), ADR-037 (CSM workflow adoption), ADR-053 (Accepted), **ADR-055 (Accepted — v0.1.32 missing-impl remediation; resolved)**, **ADR-056 (Accepted — Local Storage No Connection Pooling)**, **ADR-057 (Accepted — CI Health: PR #616 merged; slow test bounded by PR #620)**, **ADR-058 (Accepted — Scheduled gitleaks false positives, release drift)**
+- **Primary ADRs**: ADR-072 (Accepted — v0.1.35 Comprehensive Analysis, this session), ADR-071 (Auto-Checkpoint on Abstained), ADR-060 (handle_shutdown deprecation), ADR-058 (CI Health), ADR-057 (CI Health PR616)
 
 ---
 
-## Sprint 2026-07-08: PR Batch Merge & Mutation Testing
+## Sprint 2026-07-14: Supply Chain Fix & Patch Release v0.1.35
 
-**Task**: Merge 5 open PRs, implement mutation testing (#747), update skills canonical path
+**Task**: Fix yanked spin crate blocking CI, merge dependency PRs, correct version to 0.1.35, cut patch release
 
-**PRs Merged** (auto-merge enabled):
-| PR | Title | Fixes |
-|----|-------|-------|
-| #787 | fix(cli): persist episodes in local storage mode | #773 |
-| #788 | docs(readme): add build dependencies section | #771 |
-| #789 | ci(publish): improve crates.io publish pipeline | #772 |
-| #790 | docs(plans): update status for v0.1.34 sprint | - |
-| #791 | docs(agents): add lessons #013-#014 | - |
+**World State**:
+- Local quality: ✅ Build, Clippy, Fmt all pass
+- Main branch CI: ⚠️ `Supply Chain Security` and `Security` workflows FAILING (yanked `spin 0.9.8`)
+- PR #824 (fix/yanked-spin): ✅ **CLEAN — Ready to merge** (all checks pass)
+- PR #820 (dependabot patch-minor): ⚠️ UNSTABLE (blocked by yanked spin, will fix after #824)
+- PR #821 (dependabot sysinfo major): ⚠️ UNSTABLE (blocked by yanked spin, will fix after #824)
+- Issue #823: Release drift — 7 unreleased commits since v0.1.34
+- Version issue: Cargo.toml shows 0.2.0 (PR #822 over-bumped); must revert to 0.1.35 for patch release
 
-**Issues Implemented**:
-- #747: Mutation testing workflow added (non-blocking, weekly schedule)
+**Immediate Actions (Priority Order)**:
 
-**Remaining Open Issues**:
+| # | Action | Owner Skill | Priority | Status |
+|---|--------|-------------|----------|--------|
+| 1 | Merge PR #824 (fix yanked spin 0.9.8 → 0.9.9) | `pr-readiness` | 🔴 Critical | Ready |
+| 2 | Fix workspace version: 0.2.0 → 0.1.35 | `feature-implement` | 🔴 Critical | TODO |
+| 3 | Rebase/update PR #820 against main | `ci-fix` | High | Blocked on #1 |
+| 4 | Rebase/update PR #821 against main | `ci-fix` | High | Blocked on #1 |
+| 5 | Merge #820 and #821 after CI green | `pr-readiness` | High | Blocked on #3, #4 |
+| 6 | Cut v0.1.35 release (close #823) | `release-guard` | High | Blocked on #2, #5 |
+
+---
+
+## Open Issues
+
 | # | Title | Priority | Notes |
 |---|-------|----------|-------|
-| #786 | Release drift | High | Cut release after merges |
-| #770 | crates.io availability | Medium | Partially by #789 |
-| #753 | Retry budgets | Backlog | Large feature |
-| #749 | Turso connection pooling | Backlog | Large feature |
-| #746 | WASM build path | Backlog | Large feature |
-| #743 | Storage refactor | Backlog | Large refactor |
+| #823 | Release drift: 7 unreleased commits since v0.1.34 | 🔴 High | Auto-generated; resolve with v0.1.35 release |
+
+**Backlog** (from previous sprints, still relevant):
+| # | Title | Priority | Notes |
+|---|-------|----------|-------|
+| #753 | Retry budgets | Backlog | Large feature; not blocking |
+| #749 | Turso connection pooling | Backlog | Large feature; not blocking |
+| #746 | WASM build path | Backlog | Large feature; not blocking |
+| #743 | Storage refactor | Backlog | Large refactor; not blocking |
 
 ---
 
-## PR Remediation — 2026-07-08
+## Open PRs Status
 
-**Task**: Resolve open PRs #769, #774, #775.
-
-**Current Status**:
-| PR | Title | Status | Action |
-|----|-------|--------|--------|
-| **#775** | feat(retrieval): add ANN-backed semantic episode retrieval | ✅ MERGEABLE, CI green | Ready to merge (macOS pending) |
-| **#774** | Add ANN-backed semantic episode retrieval components | ❌ CLOSED | Superseded by #775 |
-| **#769** | Add Turso + redb hybrid storage integration tests | 🔧 FIXED | Merge conflict resolved, CI workflow fixed, review comments addressed |
-
-### PR #769 Changes
-- Resolved merge conflict in `memory-core/src/types/structs.rs` (RewardScore doc comment conflict from `feat(reward): implement statistical normalization and temporal decay`)
-- Fixed CI workflow: replaced `--all-features` with explicit `--features turso,redb` in hybrid storage-matrix mode
-- Review feedback: typo already fixed, `assert_episode_parity` already compares values, TempDir warning documented, reconciliation confirmed
-- Local verification: `cargo check` ✅, `cargo fmt` ✅, `cargo clippy` ✅, 22 hybrid tests pass
-
-### PR #774
-- Closed as superseded by #775 (same feature: ANN-backed semantic retrieval)
-- #774 had 305 additions, CI failing (Quick PR Check, Semver Check)
-- #775 has 1503 additions, CI green (all checks passing)
-
-### Next Actions
-- Merge #775 once macOS + benchmarks complete
-- Merge #769 once CI re-runs green
-- WG-175: Cut v0.1.33 release (urgent — additional commits accumulated)
+| PR | Title | Merge State | CI | Action |
+|----|-------|-------------|----|----|
+| **#824** | fix(deps): update yanked spin 0.9.8 → 0.9.9 | ✅ CLEAN | ✅ All pass | **Merge immediately** |
+| #821 | chore(deps): bump sysinfo 0.38.4 → 0.39.6 | ⚠️ UNSTABLE | ❌ cargo-deny (spin) | Wait for #824 merge, then rebase |
+| #820 | chore(deps): bump rust-patch-minor (3 updates) | ⚠️ UNSTABLE | ❌ cargo-deny (spin) | Wait for #824 merge, then rebase |
 
 ---
 
-## PR Remediation Campaign (2026-07-02) ✅ COMPLETE
+## CI Health (Main Branch)
 
-**Task**: Resolve all open PRs from `plans/OPEN_PR_REMEDIATION_2026-07-02.md`.
+| Workflow | Status | Notes |
+|----------|--------|-------|
+| Quick Check | ✅ Pass | Format + Clippy clean |
+| CI (Tests, Semver, MCP, Multi-Platform) | ✅ Pass | All jobs green |
+| Storage Matrix Tests | ✅ Pass | redb, turso, hybrid |
+| Performance Benchmarks | ✅ Pass | No regressions |
+| Coverage | ✅ Pass | |
+| File Structure Validation | ✅ Pass | |
+| Release Drift Check | ✅ Pass | (created #823) |
+| **Supply Chain Security** | ❌ FAIL | `cargo-deny`: yanked spin 0.9.8 |
+| **Security** | ❌ FAIL | `cargo-deny`: yanked spin 0.9.8 |
 
-**PRs Merged** (in recommended order):
-1. **PR #719** — `fix(deps): unify sysinfo to 0.39` → Merged (sysinfo workspace dedup)
-2. **PR #711** — `docs: align documentation with architecture` → Merged (rebase only)
-3. **PR #715** — `refactor(mcp): remove deprecated handle_shutdown (ADR-060)` → Merged (add/add conflict resolved)
-4. **PR #718** — `feat(patterns): AbstentionPattern extractor + abstention_score` → Merged (9 missing fields fixed)
-5. **PR #709** — `Resolve flat file conflicts / consolidate modules` → Merged (3 rebase conflicts, dangling mods, 6 import renames)
-6. **PR #727** — `docs: fix RewardScore doctest` → Merged (follow-up fix)
-7. **PR #729** — `fix: sandbox test + wire up dead types_tests` → Merged (JS runtime error type + dead code)
-
-**Key outcomes**:
-- 0 open PRs, 3,453 tests pass (0 failures), clippy + fmt clean
-- 0 dependency duplicates (down from 127)
-- 23 stale local branches cleaned, 8 worktrees pruned
-- `target/` reduced from 43G to 13G (30G freed)
-- All quality gates pass
-
-**Plan document**: `plans/OPEN_PR_REMEDIATION_2026-07-02.md`
+**Root Cause**: `spin` crate version 0.9.8 was yanked from crates.io. PR #824 updates to 0.9.9.
 
 ---
 
-## Dependency & CI Maintenance (2026-06-30)
+## Version Correction Required
 
-**Task**: Merge all open PRs (4 Dependabot + 1 CI/quality) in correct dependency order.
+PR #822 bumped workspace to `0.2.0` citing a "semver breaking change" in MCP. However, the project follows `0.1.x` patch releases. The correct action is:
 
-**PRs Merged** (in order):
-1. **PR #675** — `fix(ci,quality): WG-176..182 CI health + code quality` → Merged 2026-06-30T09:43:27Z
-   - Fixed gitleaks fingerprints, clippy --all-features lints, cache/wrapper.rs split, cascade tracing
-   - Workflow fixes: disk cleanup, mutation scoping, upload-artifact bump
-   - **Completes**: WG-176, WG-177, WG-178, WG-179, WG-180, WG-181, WG-182
-2. **PR #682** — `fix(deps): remove stale advisory ignores and update anyhow` → Merged 2026-06-30T10:10:58Z
-   - Removed 6 stale RUSTSEC advisory ignores from deny.toml
-   - Updated anyhow 1.0.102 → 1.0.103 (fixes RUSTSEC-2026-0190)
-   - `cargo deny check` now passes cleanly
-3. **PR #681** — `ci(deps): bump the actions-all group across 1 directory with 13 updates` → Merged 2026-06-30T11:10:33Z
-   - Bumped actions/checkout, actions/github-script, peter-evans/create-pull-request, etc.
-   - Resolves Node.js 20 deprecation warnings
-4. **PR #684** — `chore(deps): bump the rust-patch-minor group across 1 directory with 2 updates` → Merged 2026-06-30T11:14:54Z
-5. **PR #678** — `chore(deps): bump sysinfo from 0.38.4 to 0.39.5 in the rust-major group` → Auto-merge enabled, pending CI
+1. Revert workspace version in `Cargo.toml` from `0.2.0` → `0.1.35`
+2. If the MCP change was truly breaking, document it in CHANGELOG but keep on patch line (pre-1.0 semver allows breaking changes in minor/patch)
+3. Tag release as `v0.1.35`
 
-**Key outcomes**:
-- All GitHub Actions checks pass (Codacy, Quick PR Check, Dependency Audit, CodeQL, etc.)
-- `cargo deny check` passes cleanly (6 stale advisories removed, anyhow advisory fixed)
-- GitHub Actions updated to latest versions (Node 24 compatible)
-- Dependency audit clean: no outstanding advisories require ignoring (except existing rustls-webpki transitive)
-
-**Follow-up tasks**:
-- WG-175: Cut v0.1.33 release (now more urgent — additional commits since analysis)
-- ✅ WG-183: llms.txt generator (issue #652) — DONE (`scripts/generate-llms-txt.sh`)
-- WG-184: ADR for VERSION file decision (issue #653)
-- Monitor PR #678 auto-merge completion
-
----
-
-## WG-185 + WG-183 Execution (2026-07-01)
-
-**Branch**: `feat/wg185-loc-splits-llms-generator`
-**Plan**: `plans/GOAP_COMPREHENSIVE_ANALYSIS_2026-06-30.md`
-
-**WG-185 — LOC boundary splits** (both files were at exactly 500 LOC, the gate limit):
-- `memory-core/src/retrieval/cascade/mod.rs`: 500 → 420 LOC. Extracted
-  `CascadeConfig`/`TierResult`/`CascadeResult` into new `cascade/types.rs` (re-exported).
-- `memory-cli/src/commands/tag/core.rs`: 500 → 382 LOC. Extracted `search_by_tags`
-  into new `core/search_ops.rs`.
-- Fixed pre-existing unused-variable warning in `cascade/weights.rs` tests (`cg` → `_cg`).
-
-**WG-183 — llms.txt generator (closes #652)**:
-- Added `scripts/generate-llms-txt.sh` (compact `llms.txt` tracked + regenerated;
-  `--full` emits git-ignored `llms-full.txt` artifact; `--check` for CI freshness).
-- Version sourced from `Cargo.toml`; crate map from `cargo metadata`.
-- Regenerated `llms.txt` (was stale at v0.1.30 → now v0.1.33).
-- Documented in `agent_docs/token_efficiency.md`; `.gitignore` excludes `llms-full.txt`.
-
-**Verification**: clippy clean (core+cli default; core `--features csm`), fmt clean,
-2009 tests pass, 165 doctests pass, `cargo doc` clean, docs-integrity unchanged
-(only pre-existing archive-only broken links remain).
-
----
-
-## Comprehensive Analysis (2026-06-28)
-
-**Task**: Analyze codebase for improvements; document in `plans/` (GOAP orchestrated).
-
-**Findings**:
-- **Open Issues**: 3 — **#674** (release drift: 94 unreleased commits since v0.1.32), **#652** (llms.txt automation), **#653** (VERSION file evaluation).
-- **Open PRs**: 0.
-- **Push CI (main)**: ✅ Green (latest: `850bf69d` 2026-06-26).
-- **Scheduled Security**: ❌ — Gitleaks still detects 3 false positives (`.gitleaksignore` has 81 entries but misses these 3). Same root cause as ADR-058.
-- **Nightly Full Tests**: ❌ — Disk exit-95 (runner infra). Node.js 20 deprecation warnings on checkout/upload-artifact actions.
-- **Mutation Testing**: ❌ Cancelled — 6h ceiling always hit (scope too broad).
-- **Clippy `--all-features`**: ❌ 5 findings in `memory-core/src/embeddings/mistral/client.rs` (4 excessive_nesting + 1 unnecessary_wraps).
-- **File size gate**: 1 violation — `cache/wrapper.rs` at 537 LOC.
-- **Architecture**: Non-CSM cascade fallback returns empty result silently.
-- **Security audit**: 2 allowed git2 warnings (transitive via agentfs-sdk).
-
-**Recent improvements since last analysis (2026-06-14 → 2026-06-28)**:
-- Fuzz harness added (`14d756bd`) — parser/serialization boundaries
-- Agent harness map + eval/sensor workflow (`1884f300`)
-- Edit distance space complexity optimized (`14173bbd`)
-- GitHub Actions pinned to stable SHAs (`1b234d11`, `d828cc90`)
-- MCP input bounds hardened (multiple commits)
-- actions/checkout bumped from v6→v7 (`a6c20fc4`)
-- Codacy script injection in mutants.yml fixed (`19a17257`)
-- Root one-off scripts cleaned (`850bf69d`)
-
-**Plan Document**: `plans/GOAP_COMPREHENSIVE_ANALYSIS_2026-06-28.md` — 10 work groups (WG-175..WG-184) across 5 phases.
-
-**Next actions**: WG-175 cut v0.1.33 release → WG-176 gitleaks fingerprints → WG-177-179 CI fixes → WG-180-181 clippy/LOC → WG-182-184 arch/DevX.
-
----
-
-## Comprehensive Analysis (2026-06-14)
-
-**Task**: Analyze codebase for improvements + check open GitHub issues; document in `plans/` (GOAP + ADR).
-
-**Findings**:
-- **Open Issues**: 1 — **#619** (release drift: 54 unreleased commits since v0.1.32; 2 feat, 8 fix). Real/actionable.
-- **Open PRs**: 0. PR #616 (cosine-similarity perf) **merged** 2026-06-12 with the ADR-057 A1/A2 fix (`tokio::sync::Mutex` + plans restore); push CI green.
-- **Scheduled Security**: ❌ — Gitleaks "Leaks detected" on the **full-history schedule scan**. 3 findings, all **confirmed false positives** (doc/example/historical placeholder keys), none matched by `.gitleaksignore` (stale fingerprints after `.claude`→`.agents` move + commit/rule drift).
-- **Nightly Full Tests**: ❌ — `should_scale_processing_with_different_worker_counts` slow-test still times out (ADR-057 **A3 never applied**); plus disk exit-95 + mutation 2h ceiling (infra).
-- **Backlog**: WG-158/160/161/162 implemented (`6a43deae`); `query_hits: 0` now only in test fixtures. WG-156/157 residuals to re-audit.
-
-**Plan Documents**:
-- `plans/GOAP_COMPREHENSIVE_ANALYSIS_2026-06-14.md` — GOAP action plan (B1–B5)
-- `plans/adr/ADR-058-CI-Health-Gitleaks-Release-Drift-2026-06-14.md` — decision record
-
-**Next actions**: B1 add 3 gitleaks fingerprints → B2 cut release (#619) → B3 bound slow test (ADR-057 A3) → B4 WG-156/157 re-audit → B5 nightly infra watch.
-
----
-
-## CI Health Sweep (2026-06-11)
-
-**Task**: Analyze failing CI, open PRs/issues, and missing implementation; document GOAP + ADR.
-
-**Findings**:
-- **Open PRs**: 1 — PR #616 (`perf(encoder): optimize cosine similarity`, Jules bot). ❌ CI red.
-  - Root cause: `clippy::await_holding_lock` — PR holds a `parking_lot::Mutex` guard across `.await` in `memory-mcp/src/bin/server_impl/storage.rs` tests. Cascades to CI/Coverage/Security/Perf via `wait-on-check`. `main` is clean.
-  - PR is cut from a stale base and deletes recent `plans/*` files (would regress docs).
-- **Open Issues**: none.
-- **Nightly Full Tests (main)**: ❌ — `should_scale_processing_with_different_worker_counts` TIMEOUT (120s, `#[ignore]` slow test); regular-tests exit-95 = runner disk-space (infra); mutation testing = 2h ceiling.
-- **Missing impl**: WG-156–162 stubs still present (e.g. `query_hits: 0 // Not yet implemented`); tracked in `GOAP_PRE_EXISTING_ISSUES_FOLLOWUP_2026-06-09.md`.
-
-**Plan Documents**:
-- `plans/GOAP_CI_ANALYSIS_2026-06-11.md` — GOAP action plan (A1–A5)
-- `plans/adr/ADR-057-CI-Health-PR616-Nightly-Timeout.md` — decision record
-- `plans/CODE_CHANGES_CI_REMEDIATION_2026-06-11.md` — detailed before/after code changes
-
----
-
-## Remote Repository Analysis (2026-06-10)
-
-**Task**: Analyze remote repository (d-o-hub/rust-self-learning-memory) for workflow impacts
-
-**Strategy**: Parallel Swarm (3 agents)
-
-**Status**: ✅ COMPLETE — No adaptations required
-
-**Key Findings**:
-- Remote repository is IDENTICAL to local codebase (same project)
-- Workflow configurations match exactly
-- No feature gaps identified
-- Build check passed successfully
-
-**Conclusion**: The local codebase is a complete working copy of the remote repository. Continue development using existing workflow patterns.
-
-**Plan Documents**:
-- `plans/remote-repo-analysis-2026-06-10.md` - Initial analysis plan
-- `plans/remote-repo-synthesis-2026-06-10.md` - Synthesis findings
-- `plans/GOAP_REMOTE_ANALYSIS_2026-06-10.md` - Execution summary
-
----
-
-## Optional Maintenance Complete (2026-06-10)
-
-**Task**: Perform all optional maintenance from remote repository analysis
-
-**Strategy**: Parallel Swarm (3 agents)
-
-**Status**: ✅ **ALL MAINTENANCE COMPLETE**
-
-### Maintenance Results
-
-| Task | Agent | Status | Key Finding |
-|------|-------|--------|-------------|
-| Documentation sync | documentation | ✅ Complete | All docs identical to remote |
-| Release monitoring | github-release-best-practices | ✅ Complete | v0.1.32 latest, 33 unreleased commits |
-| Feature verification | explore | ✅ Complete | Full feature parity confirmed |
-
-### Summary
-- **Documentation**: Zero drift detected, all files current
-- **Releases**: v0.1.32 is latest release, 33 commits unreleased
-- **Features**: Full parity across core, MCP, and CLI modules
-- **Local Codebase**: Complete working copy of remote repository
-
-**Plan Document**: `plans/GOAP_MAINTENANCE_2026-06-10.md`
-
----
-
-## v0.1.33 Sprint — Release Drift Resolution (In Flight)
-
-- **Issue**: [#623](https://github.com/d-o-hub/rust-self-learning-memory/issues/623) — 60 unreleased commits since v0.1.32
-- **ADR**: ADR-058 (CI Health), ADR-055 (Missing Implementation Remediation)
-- **Strategy**: Sequential — gitleaks fix (B1 ✅) → slow test fix (B3 ✅) → WG-156/162 re-audit (B4 ✅) → release v0.1.33
-
-### Progress
-
-| Action | Description | Status |
-|--------|-------------|--------|
-| B1 | Add 3 gitleaks false-positive fingerprints | ✅ Done (PR #620) |
-| B3 | Bound slow test; stop worker pools between iterations | ✅ Done (PR #620) |
-| B4 | Re-audit WG-156–162 stubs | ✅ Done (PR #620) |
-| B2 | Cut v0.1.33 release (close #623) | 🔧 In progress |
-
----
-
-## v0.1.32 Sprint — COMPLETE ✅ (Released 2026-05-24)
-
-### v0.1.32 Feature Addition — PR #611 (2026-06-06)
-
-**Issue**: [#610](https://github.com/d-o-hub/rust-self-learning-memory/issues/610) — feat(turso): expose local/offline mode  
-**PR**: [#611](https://github.com/d-o-hub/rust-self-learning-memory/pull/611) — Expose local/offline mode as a first-class config path  
-**ADR**: ADR-056 — Local Storage No Connection Pooling  
-**Branch**: `feat/turso-local-mode-12832947082971821257`  
-**CI Status (2026-06-08)**: 🔴 4 checks failing
-
-| Check | Status | Root Cause |
-|-------|--------|------------|
-| Tests | ❌ FAILURE | SIGSEGV in turso relationship tests with `keepalive-pool` feature enabled |
-| Multi-Platform (ubuntu) | ❌ FAILURE | Same SIGSEGV |
-| Multi-Platform (macos) | ❌ FAILURE | Same SIGSEGV |
-| Code Coverage Analysis | ❌ FAILURE | CLI `test_cli_help_output` snapshot mismatch |
-
-**Root cause** (documented in `GOAP_PR611_CI_FIX_2026-06-09.md`):
-- `new_local`/`new_in_memory` routed through `TursoConfig::default()` which has `enable_pooling=true` + `enable_keepalive=true`
-- Background task holding libsql connections drops outside `#[tokio::test]` runtime → SIGSEGV
-- Fix: `local_config()` with `enable_pooling=false`, `enable_keepalive=false`
-- Snapshot mismatch: clap trailing whitespace stripped from hand-edited `.snap` file; fix via `cargo insta accept`
-
-**Fix status**: Documented (2026-06-09), not yet applied to branch.
-
-**Next action**: Apply fixes from `plans/GOAP_PR611_CI_FIX_2026-06-09.md` to `feat/turso-local-mode-12832947082971821257` and push.
-
-### Phase 1 — User Contract (P1)
-
-| WG | Gap | Owner Skill | Status | Evidence |
-|----|-----|-------------|--------|----------|
-| WG-150 | `relationship show <id>` (CLI bails) | `feature-implement` | ✅ Complete | `get_relationship_by_id` in storage trait + Turso/redb + CLI (`memory-cli/src/commands/relationships/core.rs:286`) |
-| WG-151 | Global cycle validation (CLI bails) | `feature-implement` | ✅ Complete | DFS helper at `memory-cli/src/commands/relationships/core.rs:450` + `all_relationships` in core |
-| WG-152 | `eval --custom-thresholds` no-op | `feature-implement` | ✅ Resolved-by-typed-error | `eval.rs:412` returns explicit `anyhow::bail!` instead of silent no-op (ADR-055 accepted resolution) |
-| WG-153 | Cohere silent fallback to Local | `analysis-swarm` → `feature-implement` | ✅ Resolved-by-typed-error | `embeddings/tool/execute/configure.rs:30` returns "not implemented" rather than substituting Local |
-| WG-154 | Mistral binary dequantization bails | `feature-implement` | ✅ Complete | Bit-unpacking implemented at `embeddings/mistral/client.rs:158` + unit tests |
-| WG-155 | AgentFS test_connection always stub | `external-signal-provider` | ✅ Complete | Multiple commits (55fc1869, 4831a6dc, abe53ced) — real SDK + config-derived status |
-
-### Phase 2 — Telemetry Truthfulness (P2)
-
-| WG | Gap | Owner Skill | Status | Evidence |
-|----|-----|-------------|--------|----------|
-| WG-156 | `pattern_match_score` hard-coded 0.8 | `feature-implement` | ✅ Complete | `time_series.rs` computes from `applied_patterns` success ratio + pattern density fallback |
-| WG-157 | `memory_usage_mb` hard-coded 50.0 | `feature-implement` | ✅ Complete | `time_series.rs` uses `sysinfo` for actual process memory; 50.0 is fallback on sysinfo failure |
-| WG-158 | `episode_success_rate` hard-coded 99.0 | `feature-implement` | ✅ Complete | `monitoring/types.rs` `record_episode_creation` computes from `total_episodes_created` / `total_episode_failures` |
-| WG-159 | `uptime_seconds` returns `process::id()` | `feature-implement` | ✅ Complete | `OnceLock<Instant>` at `memory-cli/src/commands/health.rs:10`; captured in `main.rs:207` |
-| WG-160 | Turso cache query_hits/evictions = 0 | `feature-implement` | ✅ Complete | `query_hits: 0` now only in test fixtures (commit `6a43deae`) |
-
-### Phase 3 — Internal Debt (P3)
-
-| WG | Gap | Owner Skill | Status | Evidence |
-|----|-----|-------------|--------|----------|
-| WG-161 | Cascade `analyze_query` stub | `feature-implement` | ✅ Complete | `retrieval/cascade/mod.rs` `estimate_api_call_probability` uses real heuristics (length, keyword density, code tokens) |
-| WG-162 | `generate_simple_embedding` prod placeholder | `code-quality` | ✅ Complete | `memory/retrieval/helpers.rs` implements 10-dim feature hashing (domain, task type, complexity, etc.) |
-| WG-163 | WG-149 `emit_event` not wired to lifecycle | `feature-implement` | ✅ Complete | `memory/episode.rs:120` + `memory/completion.rs:400` invoke `emit_event_with_cloud` |
-| WG-164 | Stale "extraction not implemented" comment | `code-quality` | ✅ Complete | `extraction/tests.rs` assertion is real (no stale comment) |
-
-### Phase 4 — Validation & Release
-
-| WG | Step | Status |
-|----|------|--------|
-| WG-165 | `cargo nextest run --all` | 🟡 Queued |
-| WG-166 | `cargo test --doc` | 🟡 Queued |
-| WG-167 | `./scripts/quality-gates.sh` (≥90%) | 🟡 Queued |
-| WG-168 | Sprint-exit `rg` audit (0 matches) | 🟡 Queued |
-| WG-169 | Bump workspace to `0.1.32` + CHANGELOG | 🟡 Queued |
-| WG-170 | `gh release create v0.1.32` (release-guard) | 🟡 Queued |
-
----
-
-## v0.1.31 Sprint (Released ✅)
-
-### GOAP Analysis (2026-04-20)
-
-**Primary Goal**: Reduce CPU usage and prompt/token usage via CPU-local retrieval tiers (CSM integration), cascading query pipeline, and skills consolidation — while keeping release/package truth sources accurate ahead of the `0.1.31` version bump.
-
-**Constraints**:
-- Time: Normal
-- Resources: All agents available
-- Dependencies: Release/package truth must stay aligned before the `0.1.31` bump
-
-**Complexity Level**: Complex (4+ agents, mixed execution)
-
-**Strategy**: Hybrid (Phase 0 sequential → CPU/token work parallelized → research follow-up deferred)
-
-### GOAP Skill Stack
-
-- **Planning/coordination**: `goap-agent`, `agent-coordination`
-- **CPU work**: `performance`, `feature-implement`, `debug-troubleshoot`
-- **CSM integration**: `feature-implement`, `performance`, `test-runner`
-- **Token/docs work**: `agents-update`, `memory-context`, `learn`
-- **Validation**: `code-quality`, `test-runner`, `architecture-validation`
-
-### Execution Pattern
-
-- **Analyze**: verify release/package truth, cache hot paths, token-heavy context assembly
-- **Decompose**: split work into release/package, CPU efficiency, token efficiency, and deferred research upgrades
-- **Coordinate**: run CPU and token tasks in parallel after truth-source alignment
-- **Validate**: require benchmarks or measurable budget reductions before version bump
-
-### Phase 0: Release & Package Truth (Sequential)
-
-| Task | WG | Status | Owner |
-|------|----|--------|-------|
-| Verify v0.1.30 release/package parity | WG-111 | ✅ Complete | github-release-best-practices |
-| Bump to 0.1.31 | WG-112 | ✅ Complete | feature-implement |
-| Refresh stale truth sources | WG-113 | ✅ Complete | agents-update |
-
-### Phase 1: CPU Efficiency (Parallel)
-
-| Task | WG | Status | Owner | Notes |
-|------|----|--------|-------|-------|
-| Reduce QueryCache contention | WG-114 | ✅ Complete | performance | `parking_lot::RwLock` already implemented in `memory-core/src/retrieval/cache/lru.rs` |
-| Replace placeholder cached retrieval | WG-115 | ✅ Complete | feature-implement | Verified: QueryCache fully implemented (273 LOC LRU+TTL+metrics), no placeholders |
-| Tune compression/cache CPU budget | WG-116 | ✅ Complete | performance | Verified: Constants in `memory-core/src/constants.rs` (CACHE_SIZE=1000, TTL=3600s, MAX_EPISODES=10000, SIMILARITY_THRESHOLD=0.7) |
-
-### Phase 1.5: CSM Integration ✅ Complete (crate dependency)
-
-**Implementation**: Added `chaotic_semantic_memory = "0.3.2"` as optional dependency with `csm` feature flag. Re-exports in `memory-core/src/retrieval/mod.rs`.
-
-| Task | WG | Status | Owner |
-|------|----|--------|-------|
-| BM25 keyword index from CSM | WG-128 | ✅ Complete | crate dependency |
-| HDC local embedding fallback | WG-129 | ✅ Complete | crate dependency |
-| ConceptGraph ontology expansion | WG-130 | ✅ Complete | crate dependency |
-| Cascading retrieval pipeline | WG-131 | ✅ Complete | feature-implement | 732 LOC, 20+ tests, full 4-tier cascade implementation |
-
-### Phase 2: Token Efficiency (Parallel with Phase 1)
-
-| Task | WG | Status | Owner | Notes |
-|------|----|--------|-------|-------|
-| Implement BundleAccumulator window | WG-117 | ✅ Complete | feature-implement | Fully implemented in `memory-core/src/context/accumulator.rs` with 20+ tests |
-| Add hierarchical/gist reranking | WG-118 | ✅ Complete | feature-implement | |
-| Compact high-frequency skills/docs | WG-119 | ✅ Complete | agents-update | 4 skills compacted: web-doc-resolver (187→84), test-patterns (161→86), build-rust (143→84), code-quality (137→74) |
-
-### Phase 3: Research-Inspired Retrieval Upgrades (P2 Priority)
-
-| Task | WG | Status | Owner | Paper |
-|------|----|--------|-------|-------|
-| Reconstructive retrieval windows | WG-120 | ✅ Complete | feature-implement | E-mem (arXiv:2601.21714) - 462 LOC, 30+ tests |
-| Execution-signature retrieval | WG-121 | ✅ Complete | feature-implement | APEX-EM (arXiv:2603.29093) - 593 LOC, 30+ tests |
-| Scope-before-search shard routing | WG-122 | ✅ Complete | feature-implement | ShardMemo (arXiv:2601.21545) - 635 LOC, 27 tests |
-| Procedural memory type | WG-124 | ✅ Complete (PR #569) | feature-implement | ParamAgent |
-| LottaLoRA local classifier | WG-132 | ✅ Complete (evaluation doc) | feature-implement | LottaLoRA |
-| Agentic memory taxonomy alignment | WG-133 | ✅ Complete (evaluation doc) | agents-update | Anatomy of Agentic Memory |
-| DAG-based state management | WG-134 | ✅ Complete | feature-implement | arXiv:2602.22398 — ~1,320 LOC in `context/dag/`, 24 tests, ~86% token reduction |
-| Temporal graph edges | WG-123 | ✅ Complete (PR #570) | feature-implement | REMem (ICLR 2026, arXiv:2602.13530) — weighted traversal, pattern edges, significance weights |
-| MemCollab cross-agent memory | WG-126 | ✅ Complete (PR #572) | feature-implement | MemCollab (arXiv:2603.23234) — trajectory distillation, contrastive adapter, collaborative prototypes |
-| Federated HDC multi-agent memory | WG-135 | 🔵 Evaluated (evaluation doc) | feature-implement | arXiv:2603.20037 |
-| CloudEvents EventEmitter | WG-149 | ✅ Complete | feature-implement | ADR-054 — CloudEvents 1.0 spec
-
-### Phase 5: CI Optimization (2026-04-28)
-
-| Task | WG | Status | Owner | Notes |
-|------|----|--------|-------|-------|
-| Update benchmarks.yml paths trigger | WG-150 | ✅ Complete | feature-implement | PRs use `paths` only, push uses `paths-ignore` |
-| Add skip-benchmarks label support | WG-151 | ✅ Complete | feature-implement | Label check in benchmark job condition |
-| Make benchmark informational (not required) | WG-152 | ✅ Complete | feature-implement | `regression-check` uses `continue-on-error` |
-| Update AGENTS.md with CI guidelines | WG-153 | ✅ Complete | agents-update | CI optimization section in AGENTS.md |
-| Create ci-optimization skill | WG-154 | 🔵 Deferred (optional) | skill-creator | Not needed; covered by ci-fix + github-workflows skills |
-
-**CI Optimization Result**: PR CI time reduced from ~50+ min to ~15-18 min for non-perf PRs. Benchmarks (~54 min) only run when perf-critical paths change or `skip-benchmarks` label is absent. See `plans/FIX_CI_AND_RELEASE_STATE.md` for 2026-05-21 analysis.
-
-### WG-131 CascadeRetriever Status (Updated 2026-05-01)
-
-The CascadeRetriever has a full CSM implementation behind the `csm` feature flag
-(BM25 Tier 1, HDC Tier 2, ConceptGraph Tier 3 with curated ontology, API fallback Tier 4).
-All 4 tiers are now implemented and tested.
-
-**Status**: ✅ Complete — CSM path complete with ConceptGraph ontology, 30 tests passing.
-
-### Phase 4: Housekeeping (Parallel)
-
-| Task | WG | Status | Owner |
-|------|----|--------|-------|
-| Create `performance` skill | WG-136 | ✅ Complete | skill-creator |
-| Prune skills 40 → ≤35 | WG-137 | ✅ Complete | agents-update |
-| Fix CURRENT.md contradictions | WG-138 | ✅ Complete | agents-update |
-| Refresh CODEBASE_ANALYSIS_LATEST.md | WG-139 | ✅ Complete | agents-update |
-
-### Quality Gates
-- **Gate 1** (after Phase 0): release/package/version truth sources all agree
-- **Gate 1.5** (after Phase 1.5): BM25+HDC retrieval tested, cascading pipeline passes integration tests, API call count reduced
-- **Gate 2** (after Phase 1-2): CPU hot paths benchmarked, token budget reduced, all tests pass
-- **Gate 3** (after Phase 3): retrieval upgrades validated without coverage regressions
-
-### Recommended Skill Invocation Order
-
-1. `goap-agent`
-2. `agent-coordination`
-3. `performance` or `feature-implement` depending on work item
-4. `agents-update` for high-frequency doc/skill compaction
-5. `code-quality` and `test-runner` before closing a work group
-
-## v0.1.30 Sprint (Complete ✅)
-
-### Cross-Repo Impact Analysis (2026-04-09)
-
-Impact analysis of `d-o-hub/github-template-ai-agents` and `d-o-hub/chaotic_semantic_memory` identified unadopted patterns and integration opportunities. All P1/P2 items adopted.
-
-### P1: Runtime Patterns from `chaotic_semantic_memory`
-
-| Task | WG | Status | Details |
-|------|----|--------|---------|
-| `MemoryEvent` broadcast channel | WG-103 | ✅ Complete | `tokio::broadcast` channel + subscribe() method + emit_event() helper |
-| `select_nth_unstable_by` for top-k | WG-104 | ✅ Complete | `search::top_k` module with O(n) partial sort utilities |
-| Idempotent cargo publish | WG-105 | ✅ Already exists | Version check step in `publish-crates.yml` |
-
-### P2: Agent Harness Patterns from `github-template-ai-agents`
-
-| Task | WG | Status | Details |
-|------|----|--------|---------|
-| Add `memory-context` skill | WG-106 | ✅ Complete | `.agents/skills/memory-context/SKILL.md` using do-memory-cli |
-| Add `learn` skill (dual-write learning) | WG-107 | ✅ Complete | `.agents/skills/learn/SKILL.md` with dual-write pattern |
-
-### P3: Future Backlog from CSM
-
-| Task | WG | Status | Details |
-|------|----|--------|---------|
-| Version-retained persistence | WG-108 | 🔵 Backlog | Track concept drift across episode versions |
-| `BundleAccumulator` sliding window | WG-109 | ✅ Complete (WG-117) | Recency-weighted context for pattern retrieval |
-| SIMD-accelerated similarity | WG-110 | 🔵 Backlog | Marginal perf gain — defer until benchmarks justify |
-
-## v0.1.29 Sprint (Complete ✅)
-
-| Task | WG | Status | Details |
-|------|----|--------|---------|
-| Version bump to 0.1.29 | WG-094 | ✅ Complete | Workspace + inter-crate deps updated |
-| Archive stale GOAP plans | WG-095 | ✅ Complete | Already archived in v0.1.28 sprint |
-| Remove WASM sandbox | WG-096 | ✅ Complete | -6,982 LOC, 11 files removed |
-| Remove wasmtime/rquickjs deps | WG-097 | ✅ Complete | Cargo.toml cleanup |
-| Implement vector_top_k search | WG-098 | ✅ Complete | Native DiskANN queries |
-| Embedding format migration | WG-099 | ✅ Complete | JSON → F32_BLOB |
-| Integration tests | WG-100 | ✅ Complete | Vector search tests |
-| Split >500 LOC files | WG-101 | ✅ Complete | 6 files split |
-| Dead code audit | WG-102 | ✅ Complete | 31 → target ≤25 |
-
-## v0.1.28 Sprint (Complete ✅)
-
-| Task | WG | Status |
-|------|----|--------|
-| DyMoE routing-drift protection | WG-089 | ✅ Affinity gating |
-| Dual reward scoring | WG-090 | ✅ Stability + novelty signals |
-| Merge AI spam detector PR #406 | WG-091 | ✅ Merged |
-| Dependabot alerts | WG-092 | ✅ Tracked (transitive) |
-| CodeQL cleartext logging | WG-093 | ✅ Fixed |
-| Plans consolidation | ACT-096 | ✅ 87% noise reduction |
-
-## v0.1.27 Sprint (Complete ✅)
-
-| Task | WG | Status |
-|------|----|--------|
-| Bayesian ranking | WG-073 | ✅ Wilson score from attribution data |
-| Diversity retrieval | WG-077 | ✅ MMR reranking |
-| Episode GC/TTL | WG-075 | ✅ Retention policy |
-| MCP Server Card | WG-078 | ✅ `.well-known/mcp.json` |
-| spawn_blocking audit | WG-079 | ✅ CPU-heavy async paths |
-| GitHub Pages | WG-084 | ✅ mdBook + cargo doc |
-| llms.txt | WG-085 | ✅ LLM context file |
-
-## v0.1.26 Release (Complete ✅)
-
-| Task | Status |
-|------|--------|
-| Crate renaming (`memory-*` → `do-memory-*`) | ✅ |
-| Version bump `0.1.25` → `0.1.26` | ✅ |
-| crates.io publish (all 4 crates) | ✅ |
-| Binary names (`do-memory-mcp-server`, `do-memory-cli`) | ✅ |
-| GitHub Release (tag v0.1.26, multi-platform) | ✅ |
-
----
-
-## Release Process (MANDATORY)
-
-**NEVER manually create GitHub releases.** Always use the automated workflow.
-
-### How releases work
-1. Bump version in `Cargo.toml` (workspace)
-2. Update `CHANGELOG.md` / `ROADMAP_ACTIVE.md` / `STATUS/CURRENT.md`
-3. Commit + push to `main`
-4. Push a git tag: `git tag v<VERSION> && git push origin v<VERSION>`
-5. The `release.yml` workflow triggers automatically on tag push:
-   - Preflight: verifies tag matches `Cargo.toml` version
-   - Builds multi-platform artifacts via `cargo-dist`
-   - Creates GitHub Release with changelog + artifacts
-6. The `release-drift.yml` monitors unreleased commits and auto-creates drift issues
-
-### What NOT to do
-- Do NOT use `gh release create` manually
-- Do NOT create releases from non-main branches
-- Do NOT skip the preflight tag-version check
-- Do NOT bypass the workflow for "quick releases"
-
-### Release readiness checklist
-- [ ] All required CI checks green on `main`
-- [ ] `cargo nextest run --all` passes
-- [ ] `cargo test --doc` passes
-- [ ] `./scripts/quality-gates.sh` passes (≥90% coverage)
-- [ ] `./scripts/code-quality.sh clippy --workspace` clean
-- [ ] Version bumped in `Cargo.toml`
-- [ ] Changelog updated
-- [ ] Tag pushed (triggers workflow)
+**Rationale**: Pre-1.0 semver (0.x.y) does not require major bumps for breaking changes. The project has consistently released as 0.1.x and should continue until a deliberate 1.0 decision is made.
 
 ---
 
 ## Key Metrics
 
-| Metric | Value | Target |
-|--------|-------|--------|
-| Workspace version | 0.1.33 | — |
-| Latest GitHub release | v0.1.32 | verified 2026-07-02 |
-| Publishable workspace crates | 6 | all at 0.1.31 |
-| Total tests | 3,282 | — |
-| Ignored tests | 164 skipped | ceiling ≤165 |
-| `allow(dead_code)` (prod) | 0 | ≤25 — ✅ Met (all 38 dead_code warnings eliminated, verified 2026-05-16) |
-| Clippy | Clean | 0 warnings |
-| Doctests | 0 failures | 0 |
-| Skills count | 31 | ✅ target ≤35 met |
-| Skills LOC | re-audit | minimize high-frequency prompt load |
-| Clippy suppressions (lib.rs) | 64 | ≤20 |
-| Files >500 LOC | 0 | 0 |
-| Cargo audit | 3 unmaintained warnings | transitive |
-| Dependabot alerts | 3 open | all transitive, tracked |
-| CodeQL alerts | 0 open | ✅ fixed |
-| CSM integration | Not started | BM25+HDC+ConceptGraph cascade |
+| Metric | Value | Target | Status |
+|--------|-------|--------|--------|
+| Workspace version (current) | 0.2.0 | 0.1.35 | ⚠️ Needs fix |
+| Latest GitHub release | v0.1.34 | — | ⚠️ Drift |
+| Open issues | 1 | 0 | Release drift |
+| Open PRs | 3 | 0 | 1 ready, 2 blocked |
+| Local build | ✅ Pass | Pass | ✅ |
+| Local clippy | ✅ 0 warnings | 0 | ✅ |
+| Local fmt | ✅ Clean | Clean | ✅ |
+| Skills count | 33 | ≤35 | ✅ |
+| Files >500 LOC | 0 | 0 | ✅ |
+| ADRs | 42 → 43 | — | +ADR-072 |
 
 ---
 
-## Active Issues / Blockers
+## Recommended Next Sprint: v0.1.35 Patch Release
 
-| Issue | Status | Notes |
-|-------|--------|-------|
-| CLI_TURSO_SEGFAULT | Known | libsql upstream memory corruption; 71 Turso tests `#[ignore]` (ADR-027) |
-| Dependabot alerts (3) | Tracked | All transitive deps, documented in `audit.toml` / `deny.toml` |
-| CodeQL alert #60 | ✅ Fixed | PR #420 merged; CodeQL reports `fixed` |
-| Issue #401 | Pending | Auto-closes when PR #406 merges |
+**Goal**: Fix CI, correct version, merge deps, cut v0.1.35 patch release.
 
----
+**Work Groups**:
 
-## DyMoE Feature Impact Analysis (Issue #419)
+| WG | Task | Owner Skill | Effort | Priority |
+|----|------|-------------|--------|----------|
+| WG-186 | Merge PR #824 (spin fix) | `pr-readiness` | 5 min | 🔴 Critical |
+| WG-187 | Revert version 0.2.0 → 0.1.35 in Cargo.toml | `feature-implement` | 10 min | 🔴 Critical |
+| WG-188 | Rebase + merge PRs #820, #821 | `ci-fix` + `pr-readiness` | 30 min | High |
+| WG-189 | Update CHANGELOG.md for v0.1.35 | `agents-update` | 15 min | High |
+| WG-190 | Update STATUS/CURRENT.md | `agents-update` | 10 min | High |
+| WG-191 | Tag + push v0.1.35 release | `release-guard` | 10 min | High |
+| WG-192 | Verify release workflow completes | `ci-poll` | 20 min | High |
+| WG-193 | Close issue #823 (auto-closes on release) | — | Auto | — |
 
-### Architecture Touchpoints
-
-| Component | File | Current Behavior | DyMoE Change |
-|-----------|------|------------------|-------------|
-| Pattern extraction | `memory/learning.rs` | Extracts & stores all patterns unconditionally | Add affinity gate before `store_pattern` |
-| Effectiveness tracker | `patterns/effectiveness/calculator.rs` | Uniform decay by min_effectiveness (0.3) | Add `affinity_clarity` as second gating dimension |
-| Reward scoring | `reward/mod.rs` | Single composite `RewardScore` (total/base/efficiency/etc.) | Add `stability_score` + `novelty_score` fields |
-| Pattern types | `pattern/types.rs` | `PatternEffectiveness` tracks success_rate + avg_reward_delta | No schema change needed |
-| Hybrid extractor | `patterns/extractors/hybrid.rs` | Runs 4 extractors, clusters, deduplicates | Insert affinity classifier before clustering |
-| Cosine similarity | `embeddings/similarity.rs` | `cosine_similarity(a, b) -> f32` | Reuse existing — no new dependency |
-| Recommendation | `memory/pattern_search/recommendation.rs` | Multi-signal scoring (semantic + recency + success) | Wire `EpisodeAssignmentGuard` into scoring |
-
-### Impact Assessment
-
-| Change | LOC Estimate | Risk | Files Modified | New Files |
-|--------|-------------|------|---------------|-----------|
-| `EpisodeAssignmentGuard` (WG-089 part 2) | ~50 | Low | `effectiveness/calculator.rs` | 0 |
-| `PatternAffinityClassifier` (WG-089 part 1) | ~80 | Medium | `learning.rs`, `hybrid.rs` | `patterns/affinity.rs` |
-| `DualRewardScore` (WG-090) | ~60 | Low | `reward/mod.rs` | 0 |
-| DB schema migration | ~20 | Low | turso schema | 0 |
-| Tests | ~200 | None | — | `tests/dymoe_*.rs` |
-| **Total** | **~410** | **Medium** | **4–5** | **1–2** |
-
-### Recommended Execution Order (from issue #419)
-1. `EpisodeAssignmentGuard` — smallest diff, highest leverage
-2. `PatternAffinityClassifier` — depends on cosine_similarity infra (already exists)
-3. `DualRewardScore` — extends existing `RewardScore`, backward-compatible
-
-### Key Finding
-The existing `cosine_similarity` function in `embeddings/similarity.rs` can be reused directly for `compute_drel()`. No new embedding infrastructure needed. The `PatternEffectiveness` already tracks `success_rate` which maps to the `success_rate` dimension of the `EpisodeAssignmentGuard`.
+**Quality Gates**:
+- Gate 1 (after WG-186): Main branch `Supply Chain Security` + `Security` workflows pass
+- Gate 2 (after WG-187): `cargo metadata` shows version 0.1.35
+- Gate 3 (after WG-188): All open PRs merged, 0 open PRs
+- Gate 4 (after WG-191): v0.1.35 release created via workflow, 0 open issues
 
 ---
 
-## Self-Learnings (Consolidated)
+## Future Backlog (Post-v0.1.35)
 
-Patterns extracted from v0.1.17–v0.1.27 sprint history (34 sessions, 234 msgs, 97 commits):
+| Priority | Item | Notes |
+|----------|------|-------|
+| Medium | Trusted Publishing (OIDC) for crates.io | Eliminate CARGO_REGISTRY_TOKEN; see ADR-045 |
+| Medium | Code coverage improvement (61% → 70%) | ADR-042 Phase 1 target |
+| Backlog | Retry budgets (#753) | Large feature |
+| Backlog | Turso connection pooling (#749) | Large feature |
+| Backlog | WASM build path (#746) | Large feature |
+| Backlog | Storage refactor (#743) | Large refactor |
+| Backlog | Federated HDC multi-agent (WG-135) | Research feature |
 
-### API / Dependency Changes
-- **redb 3.x**: `begin_read()` is on the `ReadableDatabase` trait — import accordingly
-- **rand 0.10**: `thread_rng()` → `rand::rng()`, `gen()` → `random()`, `gen_range()` → `random_range()`
+---
 
-### Development Workflow
-- **Turso local dev**: Use `turso dev` — no auth token needed
-- **Doctest quality**: New features must have tested doctests before merge
-- **File size invariant**: Templates extraction prevents LOC growth (≤500 LOC per file)
-- **Integration tests**: Feature implementation without integration tests leaves gaps
-- **Documentation sync**: ROADMAP / CURRENT must stay in sync with releases
-- **Plan document drift**: Always verify metrics by running actual commands, not trusting stale docs
+## GOAP Skill Stack (This Sprint)
 
-### CI / GitHub
-- **PR supersession**: Track supersession chains (e.g., #388 → #389 → #391) to avoid referencing stale PRs
-- **codecov/patch**: Not a required CI check — configure thresholds in `codecov.yml`, don't block merges
-- **Jules PRs**: Reconcile external agent PRs before planning more work — they may implement "pending" items
+| Phase | Skills | Strategy |
+|-------|--------|----------|
+| Fix CI | `ci-fix`, `pr-readiness` | Sequential (merge #824 first) |
+| Fix version | `feature-implement` | Sequential (Cargo.toml edit) |
+| Merge deps | `pr-readiness`, `ci-poll` | Sequential (rebase, wait for CI) |
+| Release | `release-guard`, `agents-update` | Sequential (docs → tag → verify) |
+| Validate | `code-quality`, `test-runner` | Parallel (local checks) |
 
-### Quality Gates
-- **Ignored test ceiling**: Monitor the 125 ceiling metric; actual count can creep close
-- **Tool selection**: Target Bash:Grep ratio of 2:1 (historical 17:1 indicates over-reliance on shell)
-- **Atomic commits**: One change per commit — 5 excessive_changes instances in early sprints
-- **Wrong approach**: Read 3+ source files before implementing — 8 instances of proceeding without patterns
+---
+
+## Release Process (MANDATORY)
+
+**NEVER manually create GitHub releases.** Always use the automated workflow:
+1. Bump version in `Cargo.toml` to `0.1.35`
+2. Update `CHANGELOG.md` / `ROADMAP_ACTIVE.md` / `STATUS/CURRENT.md`
+3. Commit + push to `main`
+4. Push git tag: `git tag v0.1.35 && git push origin v0.1.35`
+5. The `release.yml` workflow triggers automatically on tag push
+6. The `release-drift.yml` monitors unreleased commits and auto-creates drift issues
 
 ---
 
@@ -691,8 +175,9 @@ Patterns extracted from v0.1.17–v0.1.27 sprint history (34 sessions, 234 msgs,
 
 | Document | Location |
 |----------|----------|
-| Archived Execution Plans | `plans/archive/2026-03-consolidation/` |
+| ADR-072 (this analysis) | `plans/adr/ADR-072-Comprehensive-Analysis-v0.1.35.md` |
 | Active Roadmap | `plans/ROADMAPS/ROADMAP_ACTIVE.md` |
 | Latest Validation | `plans/STATUS/VALIDATION_LATEST.md` |
 | Latest Gap Analysis | `plans/STATUS/GAP_ANALYSIS_LATEST.md` |
 | ADR Index | `plans/adr/` |
+| Skills | `.agents/skills/` (33 skills) |

--- a/plans/adr/ADR-072-Comprehensive-Analysis-v0.1.35.md
+++ b/plans/adr/ADR-072-Comprehensive-Analysis-v0.1.35.md
@@ -1,0 +1,175 @@
+# ADR-072: Comprehensive Analysis v0.1.35 — Supply Chain Fix & Patch Release
+
+- **Status**: Accepted
+- **Date**: 2026-07-14
+- **Context**: Sprint planning analysis after v0.1.34 release; version correction and patch release
+- **Skill**: `goap-agent` → `codebase-analyzer` → `pr-readiness`
+
+---
+
+## Context
+
+Following the v0.1.34 release (2026-07-09), PR #822 incorrectly bumped the workspace to v0.2.0 citing a "semver breaking change" in the MCP crate. However, the project is pre-1.0 and follows `0.1.x` patch releases exclusively. The version must be corrected to `0.1.35`.
+
+Additionally, the `spin` crate v0.9.8 was yanked from crates.io, causing `cargo-deny` failures in both the `Supply Chain Security` and `Security` CI workflows on main and all open PRs.
+
+### Current State (2026-07-14)
+
+| Aspect | Status |
+|--------|--------|
+| Workspace version (Cargo.toml) | 0.2.0 (INCORRECT — must be 0.1.35) |
+| Latest release | v0.1.34 |
+| Local quality (build/clippy/fmt) | ✅ All pass |
+| Main CI (tests, semver, MCP) | ✅ Pass |
+| Main CI (supply chain, security) | ❌ Fail (yanked spin 0.9.8) |
+| Open issues | 1 (#823 — release drift) |
+| Open PRs | 3 (#824 ready, #820/#821 blocked) |
+
+---
+
+## Decision
+
+### D1: Revert workspace version to 0.1.35
+
+The project is pre-1.0. Under [semver pre-1.0 rules](https://semver.org/#spec-item-4), breaking changes are permitted in any 0.x.y release. There is no need to jump to 0.2.0. The consistent release line is `0.1.x` and the next patch is `0.1.35`.
+
+**Action**: Change `version = "0.2.0"` → `version = "0.1.35"` in workspace `Cargo.toml` and all member crates.
+
+### D2: Merge PR #824 immediately (spin fix)
+
+PR #824 updates `spin` from yanked 0.9.8 to 0.9.9. It is:
+- `mergeable: MERGEABLE`
+- `mergeStateStatus: CLEAN`
+- All CI checks: `SUCCESS`
+
+This is the critical-path fix that unblocks all other work.
+
+### D3: Sequential dependency PR merge after #824
+
+After #824 merges to main, PRs #820 and #821 need rebasing to pick up the spin fix. Merge order:
+1. #824 (spin fix)
+2. #820 (rust-patch-minor: 3 dep updates)
+3. #821 (sysinfo 0.38.4 → 0.39.6 — major bump, but pre-1.0 allows this)
+
+### D4: Cut v0.1.35 patch release
+
+After all PRs merged and version corrected, tag `v0.1.35` to resolve issue #823 (release drift).
+
+### D5: No new features in this sprint
+
+This sprint is purely maintenance: fix supply chain, correct version, merge deps, release.
+
+### D6: Enforce version policy across all agent docs and skills
+
+Added `Version Policy (MANDATORY)` section to:
+- `AGENTS.md` — Core Invariants + dedicated section
+- `.agents/skills/release-guard/SKILL.md` — Core Rules
+- `.agents/skills/goap-agent/SKILL.md` — Hard Constraint section
+- `.agents/skills/feature-implement/SKILL.md` — Project Standards
+- `scripts/verify-release-state.sh` — Automated enforcement check
+
+This prevents future accidental version over-bumps by tooling (e.g., cargo-semver-checks suggesting 0.2.0).
+
+---
+
+## Consequences
+
+### Positive
+- Version line stays consistent (0.1.x)
+- Main branch CI fully green (all 10+ workflows)
+- Zero open PRs after sprint
+- Zero open issues (drift auto-closes on release)
+- Clean patch release state for v0.1.35
+
+### Negative / Risks
+- The "semver breaking change" from PR #822 (MCP crate) is now released as a patch. Since the project is pre-1.0, this is acceptable per semver spec, but consumers should be aware of API changes in the MCP crate.
+- sysinfo 0.38 → 0.39 is a major bump in that dependency; tests already pass.
+
+### Neutral
+- Release drift monitoring continues via `release-drift.yml`
+- Backlog items (#743, #746, #749, #753) remain unchanged
+
+---
+
+## Work Groups
+
+| WG | Task | Effort | Priority | Dependencies |
+|----|------|--------|----------|--------------|
+| WG-186 | Merge PR #824 (spin fix) | 5 min | Critical | None |
+| WG-187 | Revert version 0.2.0 → 0.1.35 | 10 min | Critical | None |
+| WG-188 | Rebase + merge #820, #821 | 30 min | High | WG-186 |
+| WG-189 | Update CHANGELOG.md for v0.1.35 | 15 min | High | WG-187, WG-188 |
+| WG-190 | Update STATUS/CURRENT.md | 10 min | High | WG-188 |
+| WG-191 | Tag v0.1.35 release | 10 min | High | WG-189, WG-190 |
+| WG-192 | Verify release workflow | 20 min | High | WG-191 |
+| WG-193 | Confirm #823 auto-closed | 2 min | Low | WG-192 |
+
+---
+
+## Quality Gates
+
+| Gate | Trigger | Verification |
+|------|---------|--------------|
+| Gate 1 | After WG-186 | `gh run list --branch main --limit 5` shows Security + Supply Chain = success |
+| Gate 2 | After WG-187 | `cargo metadata --format-version 1 \| jq '.packages[].version'` all show 0.1.35 |
+| Gate 3 | After WG-188 | `gh pr list --state open` returns empty |
+| Gate 4 | After WG-192 | `gh release view v0.1.35` succeeds; `gh issue list --state open` returns empty |
+
+---
+
+## Skill Invocation Order
+
+1. `pr-readiness` — verify #824 merge state, execute merge
+2. `ci-poll` — wait for main CI to go green
+3. `feature-implement` — version correction in Cargo.toml
+4. `ci-fix` — rebase #820/#821 if conflicts arise
+5. `pr-readiness` — merge #820, #821
+6. `agents-update` — update CHANGELOG, STATUS, ROADMAP
+7. `release-guard` — tag and push v0.1.35
+8. `ci-poll` — verify release workflow completes
+
+---
+
+## Recommendations (Post-Sprint)
+
+### R1: Trusted Publishing Migration (Medium Priority)
+
+Migrate crates.io publishing from `CARGO_REGISTRY_TOKEN` to OIDC-based Trusted Publishing. This eliminates secret rotation burden and reduces supply chain attack surface. See <https://crates.io/docs/trusted-publishing>.
+
+**Effort**: ~2 hours
+**Tracking**: Future ADR (referenced in ADR-045)
+
+### R2: Code Coverage Push to 70% (Medium Priority)
+
+Current coverage is 61.22%. ADR-042 Phase 1 target is 70%. Focus areas:
+- `memory-core/src/retrieval/` — cascade tiers
+- `memory-mcp/src/bin/` — server integration paths
+- `memory-cli/src/commands/` — CLI handlers
+
+**Effort**: ~1 sprint
+**Tracking**: ADR-042
+
+### R3: Stale Branch Cleanup (Low Priority)
+
+42 remote branches exist. Many are from merged PRs. Run `git fetch --prune` and delete merged branches.
+
+### R4: Dependabot Auto-Merge for Patch Updates (Low Priority)
+
+Enable auto-merge for dependabot PRs that only bump patch versions and pass all CI.
+
+### R5: Prevent Future Version Over-Bumps
+
+Add a CI check or pre-commit hook that validates the workspace version stays on the `0.1.x` line until a deliberate 1.0 decision is documented via ADR.
+
+---
+
+## Related Documents
+
+| Document | Purpose |
+|----------|---------|
+| `plans/GOAP_STATE.md` | Updated GOAP state (this sprint) |
+| `plans/ROADMAPS/ROADMAP_ACTIVE.md` | Active roadmap (update after release) |
+| `plans/adr/ADR-071-Auto-Checkpoint-on-Abstained.md` | Previous ADR |
+| `.agents/skills/pr-readiness/SKILL.md` | PR merge verification skill |
+| `.agents/skills/release-guard/SKILL.md` | Release process skill |
+| `.agents/skills/ci-fix/SKILL.md` | CI failure diagnosis skill |

--- a/scripts/release-manager.sh
+++ b/scripts/release-manager.sh
@@ -71,6 +71,23 @@ if [[ "$RELEASE_LEVEL" != "patch" && "$RELEASE_LEVEL" != "minor" && "$RELEASE_LE
   exit 1
 fi
 
+# Version policy: ONLY patch releases allowed without explicit override
+if [[ "$RELEASE_LEVEL" != "patch" ]]; then
+  echo ""
+  echo "🚫 VERSION POLICY VIOLATION"
+  echo "   The project stays on the 0.1.x patch release line."
+  echo "   Minor/major bumps require explicit human approval."
+  echo ""
+  echo "   If you have human approval, set: ALLOW_NON_PATCH=1"
+  echo "   Example: ALLOW_NON_PATCH=1 $0 prepare --level $RELEASE_LEVEL --execute"
+  echo ""
+  if [[ "${ALLOW_NON_PATCH:-}" != "1" ]]; then
+    exit 1
+  fi
+  echo "⚠️  ALLOW_NON_PATCH=1 set — proceeding with $RELEASE_LEVEL bump."
+  echo ""
+fi
+
 run_cmd() {
   local cmd="$1"
   if [[ "$DRY_RUN" == "true" ]]; then

--- a/scripts/verify-release-state.sh
+++ b/scripts/verify-release-state.sh
@@ -58,6 +58,18 @@ if [[ -z "$WORKSPACE_VERSION" ]]; then
 fi
 
 echo "📦 Workspace version: $WORKSPACE_VERSION"
+
+# ─── 1.5. Enforce 0.1.x patch release line ───
+MAJOR_MINOR=$(echo "$WORKSPACE_VERSION" | grep -oP '^\d+\.\d+')
+if [[ "$MAJOR_MINOR" != "0.1" ]]; then
+  echo ""
+  echo "🚫 VERSION POLICY VIOLATION: Workspace version is $WORKSPACE_VERSION"
+  echo "   The project MUST stay on the 0.1.x patch release line."
+  echo "   Minor/major bumps require EXPLICIT human approval."
+  echo "   Fix: Change version in Cargo.toml to 0.1.x (next patch after latest release)"
+  echo ""
+  failures=$((failures + 1))
+fi
 echo ""
 
 # ─── 2. Check all workspace member versions match ───


### PR DESCRIPTION
## Summary

Reverts the incorrect semver bump from PR #822 (v0.2.0) back to v0.1.35. The project stays on the `0.1.x` patch release line per Version Policy.

## Changes

### Version Fix
- Workspace version: 0.2.0 → 0.1.35
- Inter-crate deps: 0.2.0 → 0.1.35 (memory-mcp, memory-storage-turso, memory-storage-redb)

### Version Policy Enforcement (new)
- `AGENTS.md`: Added Version Policy (MANDATORY) section
- `release.yml`: Added 0.1.x line check in preflight
- `release-manager.sh`: Rejects --level minor/major without ALLOW_NON_PATCH=1
- `verify-release-state.sh`: Fails if version leaves 0.1.x
- Skills: Added version guard to release-guard, goap-agent, feature-implement

### Release Prep
- CHANGELOG.md: v0.1.35 entry with breaking change note for MCP crate
- GOAP_STATE.md: Updated sprint plan
- ADR-072: Comprehensive Analysis v0.1.35

## Breaking Changes (documented in CHANGELOG)
MCP crate has semver-incompatible changes (lazy tool registration). Permitted under pre-1.0 semver §4. Kept on 0.1.x.

## Verification
- `cargo check --workspace` ✅ (all crates at v0.1.35)
- `cargo clippy --workspace` ✅ (0 warnings)
- `cargo fmt --all -- --check` ✅