### PR TITLE
fix: 0.1.35 patch — issues #828–#832

### DIFF
--- a/.agents/skills/do-memory-cli-ops/SKILL.md
+++ b/.agents/skills/do-memory-cli-ops/SKILL.md
@@ -31,11 +31,84 @@ Execute and troubleshoot the do-memory-cli for the self-learning memory system.
 do-memory-cli [OPTIONS] <COMMAND>
 
 Options:
-  -c, --config <FILE>    Configuration file path
-  -f, --format <FORMAT>  Output format (human|json|yaml)
-  -v, --verbose          Enable verbose output
-  --dry-run              Show what would be done
+  -c, --config <FILE>         Configuration file path
+  -f, --format <FORMAT>       Output format (human|json|yaml)
+  -v, --verbose               Enable verbose output
+  --dry-run                   Show what would be done
+  --storage-mode <MODE>       Storage mode: remote | local | memory
+                              (env: MEMORY_STORAGE_MODE)
+  --db-path <PATH>            Project-local DB path (env: MEMORY_DB_PATH)
 ```
+
+### Storage / DB path notes (issues #830, #832)
+
+| Flag / env | Effect |
+|------------|--------|
+| `--storage-mode` / `MEMORY_STORAGE_MODE` | Sets `[database].storage_mode` (`remote`, `local`, `memory`) |
+| `--db-path` / `MEMORY_DB_PATH` | **Always** sets `redb_path` (and `db_path`) to the given path. Local default backend when no Turso URL is set. |
+
+**Config placement for `storage_mode`**:
+- Canonical: `[database].storage_mode`
+- Alias: `[storage].storage_mode` is accepted and copied into `[database]` if unset
+- `[storage]` is otherwise for cache size / TTL / pool size — not backend selection
+
+```bash
+# Project-local redb (recommended for multi-process CLI smoke)
+do-memory-cli --storage-mode local --db-path ./data/memory.redb episode list
+# Or:
+MEMORY_DB_PATH=./data/memory.redb MEMORY_STORAGE_MODE=local do-memory-cli episode list
+```
+
+## Config discovery (issue #829)
+
+```bash
+# Print a full TOML template to stdout
+do-memory-cli config show-template
+
+# Write a starter config (default: do-memory-cli.toml)
+do-memory-cli config init
+do-memory-cli config init --path ./my-project.toml
+
+# Inspect / validate resolved config
+do-memory-cli config show
+do-memory-cli config validate
+```
+
+Partial TOML is valid — missing sections use defaults. Minimal local example:
+
+```toml
+[database]
+redb_path = "./.do-memory-cli/cache/memory.redb"
+storage_mode = "local"
+```
+
+## Cross-process pattern workflow (issue #831)
+
+Each CLI invocation is a **separate process**. Patterns must be durable (postcard + redb/Turso), not only in-memory.
+
+```bash
+DB=./data/memory.redb
+CLI="do-memory-cli --storage-mode local --db-path $DB"
+
+# 1. Create
+ID=$($CLI episode create -t "Implement auth" --format json | jq -r .episode_id)
+
+# 2. Log steps (use --success for tool-sequence patterns)
+$CLI episode log-step "$ID" --tool compiler --action "build" --success
+$CLI episode log-step "$ID" --tool test --action "run tests" --success
+
+# 3. Complete (triggers pattern extraction + durable cache)
+$CLI episode complete "$ID" success
+
+# 4. List in a fresh process (must be > 0)
+$CLI pattern list
+$CLI pattern search auth
+```
+
+**Pattern-type warning**:
+- `create` + `complete` alone (no successful tool steps) still yields a **ContextPattern**
+- Tool-sequence / multi-step patterns need `episode log-step ... --success` (flag sets success=true; omit → failure path)
+- Episodes with 0 steps extract little useful pattern data — always log steps before complete when testing pattern pipelines
 
 ## Commands Overview
 
@@ -44,7 +117,7 @@ Options:
 | episode | ep | Episode management |
 | pattern | pat | Pattern analysis |
 | storage | st | Storage operations |
-| config | cfg | Configuration |
+| config | cfg | Configuration (`init`, `show-template`, `show`, `validate`) |
 | health | hp | Health monitoring |
 | backup | bak | Backup/restore |
 | monitor | mon | Metrics |

--- a/.agents/skills/do-memory-cli-ops/commands.md
+++ b/.agents/skills/do-memory-cli-ops/commands.md
@@ -110,6 +110,19 @@ do-memory-cli st repair
 
 ## Config Commands
 
+### Show Template / Init (issue #829)
+
+```bash
+# Print full TOML template to stdout
+do-memory-cli config show-template
+
+# Write starter config (default path: do-memory-cli.toml)
+do-memory-cli config init
+do-memory-cli config init --path ./my-project.toml
+```
+
+`storage_mode` belongs under `[database]` (canonical). `[storage].storage_mode` is an accepted alias.
+
 ### Show Config
 
 ```bash

--- a/.agents/skills/do-memory-cli-ops/troubleshooting.md
+++ b/.agents/skills/do-memory-cli-ops/troubleshooting.md
@@ -6,8 +6,7 @@
 
 **Common mistakes**:
 - `--type` for episode create → NO `--type` argument exists. Task type is inferred.
-- `--format json` for episode list → No format option for list/view commands
-- `-v` for verbose → No global verbose flag exists
+- Unknown flags on subcommands → use `do-memory-cli <cmd> --help` (global: `-v`/`--verbose`, `-f`/`--format`, `--db-path`, `--storage-mode`)
 
 **Solution**: Use `--help` to verify correct arguments:
 ```bash
@@ -91,17 +90,56 @@ do-memory-cli storage sync
 
 ### Patterns Not Found (Pattern list shows 0)
 
-**Root Cause**: Pattern extraction requires execution steps. If episode has 0 steps, no patterns are extracted.
+**Root causes** (issues #830 / #831):
+
+1. **Different DB path across processes** — `--db-path` / `MEMORY_DB_PATH` must be the same for create, complete, and list. The flag always sets `redb_path` (local default backend). Without it, each process may open a different XDG cache path.
+2. **In-memory-only pattern map** — a fresh CLI process must load patterns from redb/Turso (`get_all_patterns`). If list is empty after complete logged "Successfully cached pattern", verify durable store + same `--db-path`.
+3. **No steps logged** — create+complete alone still yields **ContextPattern**; tool-sequence patterns need `log-step --success`.
+4. **Missing `--success` on log-step** — without the flag, steps are recorded as failures; tool-sequence extractors may skip them.
 
 **Verification**:
 ```bash
-# Check episode steps
-do-memory-cli episode view <EPISODE_ID>
-# Should show Steps: N (not 0)
+DB=./data/memory.redb
+CLI="do-memory-cli --storage-mode local --db-path $DB"
 
-# Check storage stats
-do-memory-cli storage stats
-# Patterns: Total should be > 0
+$CLI episode view <EPISODE_ID>   # Steps: N (not 0)
+$CLI storage stats               # Patterns: Total > 0
+$CLI pattern list                # Fresh process must see patterns
+```
+
+### Config format hard to discover (issue #829)
+
+```bash
+do-memory-cli config show-template   # full TOML template
+do-memory-cli config init            # write do-memory-cli.toml
+do-memory-cli config show            # resolved values
+```
+
+Partial TOML is OK; missing sections use defaults. Put `storage_mode` under `[database]` (canonical). `[storage].storage_mode` is an accepted alias only.
+
+### Wrong `storage_mode` section (issue #832)
+
+| Location | Supported? | Notes |
+|----------|------------|-------|
+| `[database].storage_mode` | ✅ Canonical | Preferred; emitted by `config init` |
+| `--storage-mode` / `MEMORY_STORAGE_MODE` | ✅ CLI/env | Wins over config file |
+| `[storage].storage_mode` | ✅ Alias | Copied into `[database]` if unset |
+
+`[storage]` is for cache size / TTL / pool size — not backend selection.
+
+### `--db-path` appears ignored (issue #830)
+
+**Symptom**: Episodes/patterns written but not visible in the next CLI process.
+
+**Cause**: Older builds only set Turso `db_path` and left `redb_path` at the default XDG path. Current CLI **always** sets `redb_path` from `--db-path` / `MEMORY_DB_PATH`.
+
+**Fix**:
+```bash
+# Same path for every command in the workflow
+export MEMORY_DB_PATH=./data/memory.redb
+export MEMORY_STORAGE_MODE=local
+do-memory-cli episode create -t "task"
+# ... log-step / complete / pattern list with same env
 ```
 
 ## Debug Mode

--- a/.agents/skills/pr-readiness/SKILL.md
+++ b/.agents/skills/pr-readiness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-readiness
-description: "Comprehensive PR health check that verifies merge state, CI status, conflicts, and cancelled checks before recommending merge. Prevents the common mistake of declaring 'CI green, ready to merge' when the PR has conflicts or is behind main."
+description: "Comprehensive PR health check: merge state, CI status, conflicts, cancelled checks, AND all PR comments/reviews (human + bots). Requires addressing actionable feedback before recommending merge. Prevents 'CI green, ready to merge' when conflicts, pending comments, or Codecov/Codacy findings remain."
 ---
 
 # PR Readiness Check Skill
@@ -10,6 +10,7 @@ Verify that a Pull Request is truly ready to merge — not just that CI is green
 ## When to Use
 
 - Before recommending any PR for merge
+- When asked to "review PR", "check PR", "fix PR", or "babysit PR"
 - When analyzing open PRs for a health report
 - When asked to "fix CI" on open PRs
 - After pushing conflict resolution or branch updates
@@ -17,10 +18,12 @@ Verify that a Pull Request is truly ready to merge — not just that CI is green
 ## Critical Rule
 
 **NEVER recommend merge based solely on CI status.** You MUST also check:
+
 1. `mergeable` field (conflicts?)
 2. `mergeStateStatus` field (behind? blocked? dirty?)
 3. All required checks passed (not just non-required ones)
 4. No stale CANCELLED checks that should have run
+5. **All PR comments and reviews** (human + bots) — actionable feedback addressed or explicitly waived with reason
 
 ## Hard Blockers (NEVER BYPASS)
 
@@ -31,24 +34,37 @@ These rules have NO exceptions. Do not use `--admin`, `--force`, or any bypass m
 3. **NEVER use `gh pr merge --admin` to bypass branch protection** — Fix the code, don't bypass the gate.
 4. **NEVER merge a PR you haven't personally verified** — Run the full check and confirm ALL conditions.
 5. **NEVER skip loading this skill** — Load this skill before any merge recommendation.
+6. **NEVER ignore PR comments** — Fetch inline reviews, review bodies, and issue comments; address actionable feedback before declaring ready.
+
+---
 
 ## Full Procedure
 
 ### 1. Query All PR State
 
 ```bash
-# Get everything in one call
+# Single PR (preferred when number known)
+gh pr view {n} --json number,title,url,mergeable,mergeStateStatus,statusCheckRollup,headRefName,baseRefName,headRefOid,reviews,comments
+
+# All open PRs
 gh pr list --state open --json number,title,mergeable,mergeStateStatus,statusCheckRollup,headRefName,baseRefName
+```
+
+Also use the helper script:
+
+```bash
+./scripts/check-pr-readiness.sh [PR_NUMBER]
+./scripts/check-pr-readiness.sh --fix [PR_NUMBER]   # also update BEHIND branches
 ```
 
 ### 2. Interpret mergeStateStatus
 
 | State | Meaning | Mergeable? | Fix |
 |-------|---------|------------|-----|
-| `CLEAN` | All clear, ready to merge | ✅ YES | None needed |
-| `BEHIND` | Branch is behind base, no conflicts | ⚠️ Not yet | Update branch |
-| `BLOCKED` | Required checks pending/failing | ❌ NO | Wait or fix CI |
-| `UNSTABLE` | Non-required checks failing | ⚠️ Maybe | Check if failures matter |
+| `CLEAN` | All clear (merge state only) | ✅ if CI + comments OK | Still verify CI + comments |
+| `BEHIND` | Branch behind main, no conflicts | ⚠️ Not yet | Update branch |
+| `BLOCKED` | Required checks still pending | ❌ NO | Wait for CI |
+| `UNSTABLE` | Non-required checks failing | ⚠️ Maybe | Investigate |
 | `DIRTY` | Merge conflicts exist | ❌ NO | Resolve conflicts |
 | `HAS_HOOKS` | Pre-receive hooks blocking | ❌ NO | Investigate hooks |
 | `UNKNOWN` | GitHub hasn't computed yet | ⏳ Wait | Re-query in 30s |
@@ -59,72 +75,120 @@ gh pr list --state open --json number,title,mergeable,mergeStateStatus,statusChe
 |------------|---------|--------|
 | `SUCCESS` | Check passed | ✅ None |
 | `SKIPPED` | Expected skip (Release on PRs, Coverage badge on non-main) | ✅ None |
-| `CANCELLED` | Workflow was cancelled — may be stale or dependent | ⚠️ Investigate: was it cancelled because a prerequisite failed? Or stale from a previous push? Re-run if stale. |
+| `CANCELLED` | Workflow was cancelled — may be stale or dependent | ⚠️ Investigate; re-run if stale |
 | `FAILURE` | Check failed | ❌ Must fix |
-| `pending`/`IN_PROGRESS` | Still running | ⏳ Wait — do NOT recommend merge |
+| `pending` / `IN_PROGRESS` | Still running | ⏳ Wait — do NOT recommend merge |
 | `NEUTRAL` | Informational only | ✅ None |
 
-### 4. Fix Procedures
+### 4. Fetch ALL PR Comments (MANDATORY)
 
-#### Branch Behind Main (BEHIND)
+**Do not stop at CI.** Always pull every feedback channel:
+
 ```bash
-# Via GitHub API (preferred — no local checkout needed)
-gh api repos/{owner}/{repo}/pulls/{number}/update-branch -X PUT -f update_method=merge
+OWNER_REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+N={pr_number}
 
-# If API says "no new commits" but state still shows BEHIND, the state is stale.
-# Push an empty commit or wait for GitHub to recompute.
+# A) Inline review comments (file/line threads)
+gh api "repos/${OWNER_REPO}/pulls/${N}/comments" --paginate > /tmp/pr${N}_inline.json
+
+# B) Submitted reviews (APPROVED / CHANGES_REQUESTED / COMMENTED + body)
+gh api "repos/${OWNER_REPO}/pulls/${N}/reviews" --paginate > /tmp/pr${N}_reviews.json
+
+# C) Issue-style conversation comments (Codecov, Codacy, humans, bots)
+gh api "repos/${OWNER_REPO}/issues/${N}/comments" --paginate > /tmp/pr${N}_issue.json
+
+# Optional: conversation via gh
+gh pr view ${N} --comments
 ```
 
-#### Merge Conflicts (DIRTY / CONFLICTING)
-```bash
-# Checkout the PR branch
-gh pr checkout {number}
+Parse and classify every item:
 
-# Merge main
+| Source | Typical author | Treat as |
+|--------|----------------|----------|
+| Human review (inline or body) | real users | **Must address** unless clearly outdated |
+| `CHANGES_REQUESTED` review | reviewers | **Hard blocker** until fixed or re-reviewed |
+| Codecov bot | `codecov[bot]` | Actionable if patch coverage low / missing lines listed |
+| Codacy bot | `codacy*` | Actionable if new issues > 0 |
+| CodeRabbit / Cursor / other bots | varies | Actionable if concrete code suggestions |
+| GitHub Actions summary bots | `github-actions[bot]` | Usually informational (benchmarks) unless FAIL |
+| Dependabot / security | bots | Actionable if security findings on the PR |
+
+### 5. Address Feedback (not just acknowledge)
+
+For each actionable comment:
+
+1. **Understand** — reproduce or map to code
+2. **Fix or waive** — implement the change, or document why not (with evidence)
+3. **Verify** — tests / clippy / targeted nextest as appropriate
+4. **Close the loop** — push commits; reply on the PR thread summarizing what was done
+5. **Re-check readiness** — CI + merge state + no new unresolved threads
+
+#### Common bot feedback patterns
+
+| Bot / finding | Typical fix |
+|---------------|-------------|
+| Codecov: low patch % / N missing lines | Add unit tests for listed files; extract pure helpers for I/O-heavy paths |
+| Codacy: new issues | Fix lint/complexity/duplication at cited lines |
+| Reviewer: correctness bug | Fix code + regression test |
+| Reviewer: docs drift | Align CHANGELOG/README with behavior |
+| Stale comment on old line | Reply that it was fixed in commit SHA or is no longer applicable |
+
+#### Waiving feedback (rare)
+
+Only waive when:
+
+- Comment is outdated (code already changed) — reply with commit SHA
+- Comment is incorrect — reply with counter-evidence
+- Purely informational bot post (e.g. benchmark dump with no regression)
+
+**Never waive** `CHANGES_REQUESTED` without either implementing the change or getting explicit re-approval.
+
+### 6. Fix Procedures (CI / merge state)
+
+#### Branch Behind Main (`BEHIND`)
+```bash
+gh api repos/{owner}/{repo}/pulls/{n}/update-branch -X PUT -f update_method=merge
+```
+
+#### Merge Conflicts (`DIRTY` / `CONFLICTING`)
+```bash
+gh pr checkout {n}
 git merge origin/main
-
-# Resolve conflicts in editor
-# Look for <<<<<<< ======= >>>>>>> markers
-grep -rn "<<<<<<" .
-
-# After resolving:
-git add <resolved-files>
-git commit --no-edit
-git push
+# resolve <<<<<<< markers
+git add <files> && git commit --no-edit && git push
 ```
 
-#### Cancelled CI Checks
+#### Cancelled CI
 ```bash
-# Find the run ID from statusCheckRollup detailsUrl
-# Re-run the workflow
 gh run rerun {run_id}
-
-# Or push empty commit to re-trigger all CI
-git commit --allow-empty -m "chore: re-trigger CI" && git push
+# or: git commit --allow-empty -m "chore: re-trigger CI" && git push
 ```
 
-#### Failed CI Checks
+#### Failed CI
 ```bash
-# Get failed job logs
 gh run view {run_id} --log-failed
-
-# Diagnose and fix the code
-# Common patterns in .agents/skills/ci-fix/SKILL.md
+# Fix via .agents/skills/ci-fix/SKILL.md
 ```
 
-### 5. Verification After Fix
-
-After any fix (conflict resolution, branch update, CI re-trigger):
+### 7. Verification After Fix
 
 ```bash
-# Wait ~30s for GitHub to recompute, then re-check
-gh pr view {number} --json mergeable,mergeStateStatus,statusCheckRollup
+gh pr view {n} --json mergeable,mergeStateStatus,statusCheckRollup
+# Re-fetch comments to ensure no new open threads
+gh api "repos/${OWNER_REPO}/pulls/${n}/comments" --paginate
+gh api "repos/${OWNER_REPO}/issues/${n}/comments" --paginate
 ```
 
-A PR is ready to merge ONLY when:
+A PR is ready to merge ONLY when ALL of:
+
 - `mergeable` = `MERGEABLE`
 - `mergeStateStatus` = `CLEAN`
-- All required `statusCheckRollup` entries show `conclusion: SUCCESS` or `SKIPPED`
+- All required `statusCheckRollup` entries = `SUCCESS` or `SKIPPED`
+- No stale `CANCELLED` checks that should have run
+- **All actionable PR comments addressed** (fixed + pushed, or waived with evidence on the thread)
+- No open `CHANGES_REQUESTED` review without follow-up approval
+
+---
 
 ## Common Mistakes
 
@@ -132,43 +196,39 @@ A PR is ready to merge ONLY when:
 ```
 "All checks pass → ready to merge"
 ```
-This ignores merge conflicts and behind-main state.
 
-### ✅ Correct: Check CI + merge state + conflicts
+### ✅ Correct: CI + merge state + comments
 ```
-"All checks pass, mergeStateStatus=CLEAN, mergeable=MERGEABLE → ready to merge"
+"CI green, mergeStateStatus=CLEAN, all review/bot feedback addressed → ready to merge"
+```
+
+### ❌ Wrong: Ignore Codecov / Codacy conversation comments
+```
+"No human reviews → nothing to address"
+```
+
+### ✅ Correct: Bots count
+```
+"Codecov reports 54 missing lines on config_template.rs → add tests, push, reply on PR"
+```
+
+### ❌ Wrong: "Acknowledged" without code change
+```
+"Thanks for the review" (no fix, no test, no waiver evidence)
+```
+
+### ✅ Correct: Fix or evidence-based waiver
+```
+Implement + test + push; reply with what changed and commit SHA
 ```
 
 ### ❌ Wrong: Recommend merge while checks are pending
-```
-"Most checks pass, a few are pending → probably fine"
-```
+### ✅ Correct: Wait for ALL checks terminal
 
-### ✅ Correct: Wait for all checks
-```
-"3 checks still pending → waiting for completion before recommending merge"
-```
-
-### ❌ Wrong: Ignore CANCELLED checks
-```
-"CANCELLED = skipped, doesn't matter"
-```
-
-### ✅ Correct: Investigate CANCELLED
-```
-"Coverage check CANCELLED — was it because Quick Check failed? Or stale from old push?"
-```
-
-### ❌ Wrong: Use --admin to bypass protection
-```
-"gh pr merge --admin" when checks are failing/pending
-```
-This is NEVER acceptable. Fix the code, don't bypass the gate.
-
+### ❌ Wrong: Use `gh pr merge --admin`
 ### ✅ Correct: Fix the underlying issue
-```
-"Checks failing → diagnose → fix code → push → wait for green → merge normally"
-```
+
+---
 
 ## Output Format
 
@@ -176,15 +236,28 @@ When reporting PR readiness, always include:
 
 ```
 ## PR #{number}: {title}
+- **URL**: {url}
 - **Merge State**: {mergeStateStatus} ({mergeable})
-- **CI Status**: {pass_count} pass, {fail_count} fail, {pending_count} pending, {cancelled_count} cancelled
+- **CI Status**: {pass} pass, {fail} fail, {pending} pending, {cancelled} cancelled
 - **Codacy**: {status}
-- **Verdict**: {READY TO MERGE | NEEDS FIX: {reason}}
-- **Action**: {specific action needed, or "None — merge when ready"}
+- **Comments**:
+  - Inline review threads: {n} ({open} open / {resolved} resolved)
+  - Reviews: {APPROVED / CHANGES_REQUESTED / COMMENTED counts}
+  - Issue comments: {n} (list bots + humans with actionable summary)
+  - Actionable remaining: {list or "none"}
+- **Feedback addressed this session**: {what was fixed / waived}
+- **Verdict**: READY TO MERGE | NEEDS FIX: {reason} | WAITING ON CI
+- **Action**: {specific next step, or "None — merge when ready"}
 ```
 
-## Related Skills
+---
 
+## Related
+
+- **[Comments reference](comments.md)** — Fetch/classify/close-loop templates
 - `.agents/skills/ci-fix/SKILL.md` — CI failure diagnosis and repair
+- `.agents/skills/ci-poll/SKILL.md` — Wait for CI with backoff
 - `.agents/skills/github-workflows/SKILL.md` — Workflow patterns
+- `.agents/skills/code-quality/SKILL.md` — fmt/clippy/coverage gates
 - `AGENTS.md` → "PR Health Check" section — Quick reference table
+- `./scripts/check-pr-readiness.sh` — Automated merge/CI/comment gates

--- a/.agents/skills/pr-readiness/comments.md
+++ b/.agents/skills/pr-readiness/comments.md
@@ -1,0 +1,46 @@
+# PR Comments Reference
+
+Companion to [SKILL.md](./SKILL.md). How to fetch, classify, and close the loop on PR feedback.
+
+## Fetch commands (always run all three)
+
+```bash
+OWNER_REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+N=<pr_number>
+
+gh api "repos/${OWNER_REPO}/pulls/${N}/comments" --paginate   # inline
+gh api "repos/${OWNER_REPO}/pulls/${N}/reviews" --paginate    # review submissions
+gh api "repos/${OWNER_REPO}/issues/${N}/comments" --paginate  # conversation
+```
+
+Optional: `gh pr view ${N} --comments` for a human-readable dump.
+
+## Classification cheatsheet
+
+| Author pattern | Action |
+|----------------|--------|
+| Real GitHub user | Read carefully; fix or evidence-waive |
+| `codecov[bot]` | Parse missing-files table; add tests |
+| `codacy*` | Fix new issues if count > 0 |
+| `coderabbitai*` / Cursor bots | Concrete code suggestions → implement or waive |
+| `github-actions[bot]` benchmarks | Informational unless regression noted |
+| `CHANGES_REQUESTED` state | Hard blocker |
+
+## Close the loop template
+
+```markdown
+### Addressing feedback
+
+| Comment | Action | Commit |
+|---------|--------|--------|
+| Codecov: config_template.rs 0% | Added unit tests for init/template | abc1234 |
+| Reviewer: path collision | Sibling paths in cli_overrides | def5678 |
+
+CI re-running on this push.
+```
+
+## Related
+
+- Skill procedure: [SKILL.md](./SKILL.md)
+- Script: `./scripts/check-pr-readiness.sh`
+- CI failures: `../ci-fix/SKILL.md`

--- a/.agents/skills/pr-readiness/evals/evals.json
+++ b/.agents/skills/pr-readiness/evals/evals.json
@@ -2,12 +2,12 @@
   "evals": [
     {
       "input": "Check if PR #796 is ready to merge",
-      "expected_behavior": "Agent queries gh pr view with mergeable and mergeStateStatus fields, not just statusCheckRollup. Reports merge state alongside CI status.",
-      "failure_mode": "Agent only checks statusCheckRollup and declares 'all CI green, ready to merge' without checking mergeable/mergeStateStatus"
+      "expected_behavior": "Agent queries gh pr view with mergeable and mergeStateStatus fields, not just statusCheckRollup. Also fetches PR comments (pulls comments, reviews, issues comments). Reports merge state, CI, and comment status.",
+      "failure_mode": "Agent only checks statusCheckRollup and declares 'all CI green, ready to merge' without checking mergeable/mergeStateStatus or PR comments"
     },
     {
       "input": "Analyze all open PRs and recommend which to merge",
-      "expected_behavior": "Agent runs gh pr list with --json number,title,mergeable,mergeStateStatus,statusCheckRollup. For each PR, reports both CI and merge state. Only recommends merge for PRs with mergeStateStatus=CLEAN.",
+      "expected_behavior": "Agent runs gh pr list with --json number,title,mergeable,mergeStateStatus,statusCheckRollup. For each PR, reports CI, merge state, and whether comments need addressing. Only recommends merge for PRs with mergeStateStatus=CLEAN and no open actionable feedback.",
       "failure_mode": "Agent recommends merge for PR with CONFLICTING mergeable state because CI checks passed"
     },
     {
@@ -19,6 +19,21 @@
       "input": "PR has CANCELLED coverage check",
       "expected_behavior": "Agent investigates why it was cancelled (dependent on Quick Check? stale push?). If stale, re-runs the workflow. Does not ignore it.",
       "failure_mode": "Agent ignores CANCELLED check as equivalent to SKIPPED"
+    },
+    {
+      "input": "Review PR #834 and fix any feedback",
+      "expected_behavior": "Agent fetches inline review comments (pulls/N/comments), reviews (pulls/N/reviews), and issue comments (issues/N/comments). Classifies Codecov/Codacy/human feedback. Implements fixes (e.g. missing tests for Codecov lines), pushes, and replies on the PR summarizing what was done. Does not claim ready until feedback is addressed.",
+      "failure_mode": "Agent only runs CI status check and code review of the diff, ignoring conversation comments from Codecov or human reviewers"
+    },
+    {
+      "input": "PR has no human reviews but Codecov reports 54 missing lines",
+      "expected_behavior": "Agent treats Codecov conversation comment as actionable, maps missing files to tests, adds coverage, pushes, and posts a PR comment closing the loop. Does not say 'no comments to address' because there were no human reviews.",
+      "failure_mode": "Agent says nothing to do because only bots commented"
+    },
+    {
+      "input": "PR has CHANGES_REQUESTED review",
+      "expected_behavior": "Agent treats CHANGES_REQUESTED as a hard blocker, implements the requested fixes or provides evidence-based rebuttal and seeks re-approval. Does not recommend merge while CHANGES_REQUESTED stands.",
+      "failure_mode": "Agent recommends merge because CI is green despite open CHANGES_REQUESTED"
     }
   ]
 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -31,3 +31,12 @@ slow-timeout = { period = "180s", terminate-after = 2 }
 [[profile.ci.overrides]]
 filter = "package(e2e-tests) and test(quality_gate_performance_regression)"
 slow-timeout = { period = "180s", terminate-after = 2 }
+
+# Pattern discovery e2e spawns multiple CLI processes; allow ~3 min under load.
+[[profile.default.overrides]]
+filter = "package(e2e-tests) and test(test_pattern_discovery)"
+slow-timeout = { period = "90s", terminate-after = 3 }
+
+[[profile.ci.overrides]]
+filter = "package(e2e-tests) and test(test_pattern_discovery)"
+slow-timeout = { period = "90s", terminate-after = 3 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,19 +106,26 @@ Target Bash:Grep ratio of 2:1 (current: 17:1)
 
 ## PR Health Check (MANDATORY before recommending merge)
 
-**Skill**: `.agents/skills/pr-readiness/SKILL.md`
+**Skill**: `.agents/skills/pr-readiness/SKILL.md`  
+**CLI**: `./scripts/check-pr-readiness.sh [--fix] [PR_NUMBER]`
 
-When analyzing open PRs or recommending merge, you MUST check ALL of the following — not just CI status:
+When analyzing open PRs, reviewing a PR, or recommending merge, you MUST check **all** of the following — not just CI status:
+
+1. Merge state (`mergeable`, `mergeStateStatus`)
+2. CI / status checks (including CANCELLED)
+3. **All PR comments and reviews** (human + bots) — and **address** actionable feedback
 
 ### Step 1: Full PR State Query
 ```bash
+gh pr view {n} --json number,title,mergeable,mergeStateStatus,statusCheckRollup,headRefOid
+# or all open:
 gh pr list --state open --json number,title,mergeable,mergeStateStatus,statusCheckRollup
 ```
 
 ### Step 2: Interpret Merge State (CRITICAL)
 | `mergeStateStatus` | `mergeable` | Meaning | Action Required |
 |--------------------|-------------|---------|-----------------|
-| `CLEAN` | `MERGEABLE` | Ready to merge | ✅ None |
+| `CLEAN` | `MERGEABLE` | Merge state OK | Still verify CI **and** comments |
 | `BEHIND` | `MERGEABLE` | Branch behind main, no conflicts | Update branch: `gh api repos/{owner}/{repo}/pulls/{n}/update-branch -X PUT` |
 | `BLOCKED` | `MERGEABLE` | Required checks still pending | Wait for CI to complete |
 | `UNSTABLE` | `MERGEABLE` | Non-required checks failing | Check if failures are pre-existing/non-blocking |
@@ -132,27 +139,53 @@ gh pr list --state open --json number,title,mergeable,mergeStateStatus,statusChe
 - **`FAILURE`** → ❌ Must fix before merge
 - **`pending`** → ⏳ Wait for completion (do NOT recommend merge while pending)
 
-### Step 4: Fix Everything
+### Step 4: Fetch and Address ALL PR Comments (MANDATORY)
+
+**Never skip this step.** "No human reviews" does **not** mean nothing to do — bots (Codecov, Codacy, CodeRabbit, etc.) post actionable conversation comments.
+
+```bash
+OWNER_REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+# Inline file/line review comments
+gh api "repos/${OWNER_REPO}/pulls/{n}/comments" --paginate
+# Submitted reviews (APPROVED / CHANGES_REQUESTED / COMMENTED)
+gh api "repos/${OWNER_REPO}/pulls/{n}/reviews" --paginate
+# Issue conversation (Codecov, Codacy, humans)
+gh api "repos/${OWNER_REPO}/issues/{n}/comments" --paginate
+```
+
+| Feedback type | Action |
+|---------------|--------|
+| Human inline / `CHANGES_REQUESTED` | **Fix code** (or get re-approval after evidence waiver) |
+| Codecov low patch / missing lines | Add tests for listed files; push; reply on PR |
+| Codacy new issues | Fix cited lints/complexity |
+| Stale / incorrect comment | Reply with commit SHA or counter-evidence |
+| Informational bot only (e.g. bench dump) | Note in report; no code change required |
+
+**Address** means: implement + test + push, then reply on the thread — not just acknowledge.
+
+### Step 5: Fix Everything
 A PR is NOT ready to merge unless ALL of:
 1. `mergeable` = `MERGEABLE` (no conflicts)
 2. `mergeStateStatus` = `CLEAN` (not BEHIND, DIRTY, BLOCKED, or UNSTABLE)
 3. All **required** checks = `SUCCESS`
 4. No `CANCELLED` checks that should have run (re-trigger if needed)
 5. No pre-existing failures inherited from base branch
+6. **All actionable PR comments addressed** (or waived with evidence on the thread)
 
-### Step 5: Fix Procedures
+### Step 6: Fix Procedures
 | Problem | Fix |
 |---------|-----|
 | Branch behind (`BEHIND`) | `gh api repos/{owner}/{repo}/pulls/{n}/update-branch -X PUT -f update_method=merge` |
 | Merge conflicts (`DIRTY`/`CONFLICTING`) | `gh pr checkout {n}` → `git merge origin/main` → resolve → `git push` |
 | Cancelled CI | Re-run: `gh run rerun {run_id}` or push empty commit to re-trigger |
 | Failed check | Diagnose with `gh run view {run_id} --log-failed`, fix code, push |
+| Review / bot comments | See Step 4 — fix code, push, reply on PR |
 
 ### Common Mistake (NEVER DO THIS)
-❌ "CI is green, ready to merge" — **WRONG** if `mergeStateStatus` ≠ `CLEAN`
-✅ "CI is green, merge state is CLEAN, ready to merge" — **CORRECT**
+❌ "CI is green, ready to merge" — **WRONG** if `mergeStateStatus` ≠ `CLEAN` **or** comments remain unaddressed  
+✅ "CI green, merge CLEAN, all review/bot feedback addressed → ready to merge" — **CORRECT**
 
-CI checks run against the branch HEAD, not against the merge result. A PR can have green CI but be unmergeable due to conflicts with main.
+CI checks run against the branch HEAD, not against the merge result. A PR can have green CI but be unmergeable due to conflicts with main. Codecov/Codacy conversation comments often require tests or code fixes even when required checks are green.
 
 ### Hard Blockers (NEVER BYPASS)
 
@@ -163,6 +196,7 @@ These rules have NO exceptions. Do not use `--admin`, `--force`, or any bypass m
 3. **NEVER use `gh pr merge --admin` to bypass branch protection** — Branch protection exists for a reason. If checks fail, fix the code, don't bypass the gate.
 4. **NEVER merge a PR you haven't personally verified** — Run the full PR readiness check (`gh pr view {n} --json mergeable,mergeStateStatus,statusCheckRollup`) and confirm ALL conditions before merging.
 5. **NEVER skip the `pr-readiness` skill** — Load `.agents/skills/pr-readiness/SKILL.md` before any merge recommendation. The skill defines the exact verification procedure.
+6. **NEVER ignore PR comments** — Fetch inline reviews, review bodies, and issue comments; address actionable feedback (including Codecov/Codacy) before declaring ready.
 
 ### Mandatory Pre-Merge Checklist
 
@@ -176,6 +210,9 @@ Before ANY merge action, ALL of these must be true:
 □ All required checks = SUCCESS (not pending, not FAILURE)
 □ No CANCELLED checks that should have run
 □ No pre-existing failures from base branch
+□ Fetched PR comments: pulls/{n}/comments + pulls/{n}/reviews + issues/{n}/comments
+□ Actionable feedback addressed (code + tests pushed) or waived with evidence on thread
+□ No open CHANGES_REQUESTED without re-approval
 □ Verified locally: cargo nextest run --all passes
 □ Verified locally: cargo clippy --workspace -- -D warnings passes
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.35] - 2026-07-15
+
+### Fixed
+
+- **#831 Pattern retrieval across processes**: `Pattern` enum was internally
+  tagged (`#[serde(tag = "type")]`), which Postcard cannot deserialize. Patterns
+  were written to storage but never read back, so `pattern list` / `pattern search`
+  returned 0 after completing episodes in a fresh CLI process. Changed `Pattern`
+  to an externally-tagged (Postcard-compatible) representation and added a
+  `postcard` round-trip regression test. Also added `StorageBackend::get_all_patterns`
+  (redb + Turso) and lazy-loaded `queries::get_all_patterns` so list/search hydrate
+  from durable storage. Bumped redb `SCHEMA_VERSION` to 4 so stale caches are
+  cleared on upgrade; undecodable pattern rows are skipped rather than failing
+  the whole list. **Note:** JSON shape of `Pattern` also changes (externally
+  tagged); Turso stores a separate JSON DTO and is unaffected.
+
+- **#830 `--db-path` / `MEMORY_DB_PATH` ignored for redb**: these now also drive
+  the redb path via a sibling file (e.g. `memory.db` → `memory.redb`, or a
+  `*.redb` path maps redb directly and Turso SQLite uses `*.db`) so the two
+  engines never share a file. When no Turso URL is configured and
+  `storage_mode` is unset, they also default `storage_mode` to `local` so the
+  path is not a silent no-op. Corrected README docs that misattributed
+  `db_path` to the redb backend.
+
+- **#829 Undocumented config file format**: added `config init [--path]` and
+  `config show-template` commands that emit a valid, populated `Config` TOML, and
+  fixed documentation of real env vars (`TURSO_URL`/`TURSO_TOKEN`/`REDB_PATH`),
+  the `[database].storage_mode` location, and removed non-existent sections
+  (`[sandbox]`, `[backup]`, `[logging]`) and the unimplemented `import =` syntax.
+
+- **#828 Release drift**: relabeled the `0.2.0` bump back to `0.1.35` (patch on the
+  `0.1.x` line) across all workspace manifests and `Cargo.lock`.
+
+- **#832 Config discoverability**: `config init` / `show-template` surface the
+  canonical config shape. `storage_mode` belongs under `[database]`; an alias
+  under `[storage]` is accepted and normalized. Partial TOML files work via
+  `#[serde(default)]` on all config sections. Added
+  `memory-cli/config/do-memory-cli.example.toml`.
+
 ## [0.1.34] - 2026-07-11
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the whole list. **Note:** JSON shape of `Pattern` also changes (externally
   tagged); Turso stores a separate JSON DTO and is unaffected.
 
-- **#830 `--db-path` / `MEMORY_DB_PATH` ignored for redb**: these now also drive
-  the redb path via a sibling file (e.g. `memory.db` → `memory.redb`, or a
-  `*.redb` path maps redb directly and Turso SQLite uses `*.db`) so the two
-  engines never share a file. When no Turso URL is configured and
-  `storage_mode` is unset, they also default `storage_mode` to `local` so the
-  path is not a silent no-op. Corrected README docs that misattributed
-  `db_path` to the redb backend.
+- **#830 `--db-path` / `MEMORY_DB_PATH` ignored for redb**: always override
+  `redb_path` (never only-when-None — `Config::default()` pre-fills XDG).
+  Default **redb-only** builds open redb at the exact user path. Builds with
+  the `turso` feature use sibling files (`memory.db` → redb `memory.redb`) so
+  SQLite and redb never share a file. Unset `storage_mode` defaults to
+  `local` when no Turso URL is configured. Unit tests in
+  `config/cli_overrides.rs`.
 
 - **#829 Undocumented config file format**: added `config init [--path]` and
   `config show-template` commands that emit a valid, populated `Config` TOML, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,7 +1497,7 @@ checksum = "2906d3628a885aa49a23b88e71f63e51ae8df41cd76652287f0a6179a11833a9"
 
 [[package]]
 name = "do-memory-benches"
-version = "0.2.0"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-cli"
-version = "0.2.0"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-core"
-version = "0.2.0"
+version = "0.1.35"
 dependencies = [
  "agentfs-sdk",
  "anyhow",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-examples"
-version = "0.2.0"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "do-memory-core",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-mcp"
-version = "0.2.0"
+version = "0.1.35"
 dependencies = [
  "agentfs-sdk",
  "anyhow",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-storage-redb"
-version = "0.2.0"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-storage-turso"
-version = "0.2.0"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-test-utils"
-version = "0.2.0"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1722,7 +1722,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "e2e-tests"
-version = "0.2.0"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.1.35"
 edition = "2024"
 authors = ["Self-Learning Memory Contributors"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ The system supports a first-class local-only mode that requires no Turso account
 # Via CLI (using auto-detected OS data directory)
 do-memory-cli --storage-mode local episode list
 
-# Via CLI (specifying a custom path)
+# Via CLI (specifying a custom database path)
 do-memory-cli --storage-mode local --db-path ./data/memory.db episode list
 
 # Via Environment Variables
@@ -250,6 +250,12 @@ export MEMORY_STORAGE_MODE=local
 export MEMORY_DB_PATH=./data/memory.db
 do-memory-cli episode list
 ```
+
+> **Note on `--db-path` / `MEMORY_DB_PATH`**: these set the local database
+> file path. For the default `local` (redb) backend they set the redb cache
+> file; for Turso `remote` mode with a local file they set the Turso SQLite
+> path. The config-file equivalent is `[database].redb_path` /
+> `[database].db_path`. See [TOML Configuration](#toml-configuration).
 
 For programmatic usage, see the [Local Development example](#local-offline-development).
 
@@ -265,6 +271,12 @@ do-memory-cli config wizard
 # - Database (local SQLite or remote Turso)
 # - Storage (cache size, TTL, connection pool)
 # - CLI (output format, progress bars, batch size)
+
+# Generate a starter config file
+do-memory-cli config init
+
+# Print a starter config template
+do-memory-cli config show-template
 
 # Validate configuration
 do-memory-cli config validate
@@ -469,16 +481,12 @@ When the `csm` feature is enabled, semantic search uses a 4-tier cascade to mini
 
 ```bash
 # Turso Cloud (default)
-TURSO_DATABASE_URL=libsql://your-db.turso.io
-TURSO_AUTH_TOKEN=your-auth-token
+TURSO_URL=libsql://your-db.turso.io
+TURSO_TOKEN=your-auth-token
 
-# Local SQLite (fallback)
+# Local redb cache (default local backend)
 LOCAL_DATABASE_URL=sqlite:./data/memory.db
-MEMORY_REDB_PATH=./data/memory.redb
-
-# Cache settings
-MEMORY_MAX_EPISODES_CACHE=1000
-MEMORY_CACHE_TTL_SECONDS=3600
+REDB_PATH=./data/memory.redb
 
 # CLI config
 MEMORY_CLI_CONFIG=./memory-cli.toml
@@ -493,7 +501,7 @@ EMBEDDING_MODEL=text-embedding-3-small
 EMBEDDING_SIMILARITY_THRESHOLD=0.7
 EMBEDDING_BATCH_SIZE=32
 
-# Sandbox settings
+# Sandbox settings (MCP server only)
 MCP_USE_WASM=true
 JAVY_PLUGIN=./memory-mcp/javy-plugin.wasm
 ```
@@ -504,25 +512,23 @@ JAVY_PLUGIN=./memory-mcp/javy-plugin.wasm
 [database]
 turso_url = "libsql://your-db.turso.io"
 turso_token = "your-auth-token"
-redb_path = "memory.redb"
+redb_path = "memory.redb"          # local (redb) cache file path
+storage_mode = "local"             # "remote" | "local" | "memory"
+db_path = "./data/memory.db"       # Turso local SQLite path (storage_mode = "local")
 
 [storage]
 max_episodes_cache = 1000
 cache_ttl_seconds = 3600
 pool_size = 10
 
-[sandbox]
-max_execution_time_ms = 5000
-max_memory_mb = 128
-max_cpu_percent = 50
-allow_network = false
-allow_filesystem = false
-
 [cli]
 default_format = "human"
 progress_bars = true
 batch_size = 100
 ```
+
+> Tip: generate a valid starter config with `do-memory-cli config init`
+> (writes `do-memory-cli.toml`) or print one with `do-memory-cli config show-template`.
 
 ## Architecture
 

--- a/agent_docs/LESSONS.md
+++ b/agent_docs/LESSONS.md
@@ -111,6 +111,21 @@ Compact log for non-obvious workflow learnings. Pair each entry here with a shor
 - Root Cause: Manual sequential merge waiting is wasteful when PRs are independent
 - Solution: Enable `gh pr merge --squash --auto` on all PRs simultaneously. GitHub handles merge ordering via branch protection. Required Check Anchor is the only true merge gate; CANCELLED checks (Coverage, YAML Lint) are non-required noise.
 - Key insight: Auto-merge + squash is safe for independent PRs. Monitor via `gh pr view --json state,autoMergeRequest` rather than polling individual checks.
+
+## LESSON-017: CLI pattern list empty across processes + `--db-path` no-op (#830 / #831)
+
+- Issue: After `episode complete` logged "Successfully cached pattern", a fresh CLI process showed `pattern list` = 0. Separately, `--db-path` / `MEMORY_DB_PATH` appeared ignored.
+- Root Cause:
+  1. **#831**: `Pattern` used `#[serde(tag = "type")]` (internally tagged) — **postcard cannot deserialize** that form, so durable redb/Turso reads failed silently / returned empty. Also `get_all_patterns` only consulted the empty in-memory map in a new process.
+  2. **#830**: `--db-path` only set Turso `database.db_path`; `Config::default()` already filled `redb_path` with the XDG cache path, so the local redb backend never used the user path.
+- Solution:
+  1. Use postcard-compatible (externally tagged) serde for types persisted with postcard; keep a postcard round-trip unit test on `Pattern`.
+  2. Hydrate patterns via `StorageBackend::get_all_patterns` (memory → redb → Turso) on list/search.
+  3. Always set **both** `db_path` and `redb_path` from `--db-path` / `MEMORY_DB_PATH`.
+  4. Smoke across processes: create → log-step `--success` → complete → `pattern list` with the same `--db-path`.
+- Key insight: Unit tests in one process mask cross-process durability bugs. Never use internally tagged enums with postcard. CLI path flags that choose "where data lives" must override redb, not only Turso.
+- Prevention docs: `.agents/skills/do-memory-cli-ops/SKILL.md`, `troubleshooting.md`
+- References: issues #829–#832; `plans/GOAP_CLI_UX_PATCH_0.1.35_2026-07-15.md`
 ## LESSON-013: Local storage mode requires explicit temp directory for redb fallback
 
 - Issue: When `--storage-mode local` was used without configuring `redb_path`, the combination logic created redb with literal `:memory:` path, creating a file named `:memory:` in CWD or failing silently. Episodes appeared to save but weren't persisted across CLI invocations.

--- a/docs/CLI_COMMANDS.md
+++ b/docs/CLI_COMMANDS.md
@@ -96,7 +96,7 @@ do-memory-cli config check
 do-memory-cli config show
 
 # Show configuration template
-do-memory-cli config show-template  # (if implemented)
+do-memory-cli config show-template  # prints a starter TOML config
 ```
 
 ## Configuration File Format
@@ -465,7 +465,7 @@ Issues found: (none)
 ls -la do-memory-cli.toml .do-memory-cli.toml
 
 # Run wizard with verbose output
-memory --verbose config wizard
+do-memory-cli --verbose config wizard
 ```
 
 ### Validation Errors

--- a/docs/CONFIG_WIZARD.md
+++ b/docs/CONFIG_WIZARD.md
@@ -648,6 +648,8 @@ do-memory-cli --config ci-config.toml episode list
 - `do-memory-cli config validate` - Validate current configuration
 - `do-memory-cli config check` - Check configuration for issues
 - `do-memory-cli config show` - Display current configuration
+- `do-memory-cli config show-template` - Print a starter TOML config
+- `do-memory-cli config init` - Write a starter config file
 - `do-memory-cli episode list` - Test configuration with episode listing
 - `do-memory-cli config wizard` - Run configuration wizard (this command)
 

--- a/docs/LOCAL_DATABASE_SETUP.md
+++ b/docs/LOCAL_DATABASE_SETUP.md
@@ -50,21 +50,19 @@ TURSO_AUTH_TOKEN=
 
 # Local database configuration
 LOCAL_DATABASE_URL=sqlite:./data/memory.db
-MEMORY_REDB_PATH=./data/memory.redb
+REDB_PATH=./data/memory.redb
 
 # Data directories
 MEMORY_DATA_DIR=./data
-MEMORY_BACKUP_DIR=./backups
 
 # Other settings...
 RUST_LOG=info
-MEMORY_MAX_EPISODES_CACHE=1000
 ```
 
 #### Step 2: Create Directories
 
 ```bash
-mkdir -p ./data ./backups
+mkdir -p ./data
 ```
 
 #### Step 3: Initialize Database
@@ -82,11 +80,8 @@ sqlite3 ./data/memory.db < scripts/schema.sql
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `LOCAL_DATABASE_URL` | Path to local SQLite database | `sqlite:./data/memory.db` |
-| `MEMORY_REDB_PATH` | Path to redb cache file | `./data/memory.redb` |
+| `REDB_PATH` | Path to redb cache file | `./data/memory.redb` |
 | `MEMORY_DATA_DIR` | Data directory root | `./data` |
-| `MEMORY_BACKUP_DIR` | Backup directory | `./backups` |
-| `MEMORY_MAX_EPISODES_CACHE` | Max episodes in memory cache | `1000` |
-| `MEMORY_CACHE_TTL_SECONDS` | Cache TTL in seconds | `3600` |
 
 ### Configuration File
 
@@ -110,16 +105,6 @@ pool_size = 10
 default_format = "human"
 progress_bars = true
 batch_size = 100
-
-[backup]
-backup_dir = "./backups"
-max_backup_age_days = 30
-compress_backups = true
-
-[logging]
-level = "info"
-max_log_size_mb = 10
-max_log_files = 5
 ```
 
 ## Database Schema
@@ -251,7 +236,7 @@ Update your `.env` or `do-memory-cli.toml` to use local paths instead of Turso U
 ### Optimization Tips
 
 1. **Batch Operations**: Use batch size > 100 for bulk operations
-2. **Cache Settings**: Increase `MEMORY_MAX_EPISODES_CACHE` for better performance
+2. **Cache Settings**: Tune `[storage].max_episodes_cache` / `cache_ttl_seconds` in the config file for better performance
 3. **File Location**: Place database on fast storage (SSD)
 4. **Regular Maintenance**: Periodically run `VACUUM` and `ANALYZE`
 
@@ -421,7 +406,7 @@ jobs:
           cargo test --all
         env:
           LOCAL_DATABASE_URL: sqlite:./test-data/test.db
-          MEMORY_REDB_PATH: ./test-data/cache.redb
+          REDB_PATH: ./test-data/cache.redb
 ```
 
 ## Advanced Configuration

--- a/memory-cli/CONFIGURATION_GUIDE.md
+++ b/memory-cli/CONFIGURATION_GUIDE.md
@@ -353,9 +353,49 @@ do-memory-cli storage health
 
 | Environment Variable | Configuration Path | Description |
 |---------------------|-------------------|-------------|
-| `MEMORY_TURSO_URL` | `database.turso_url` | Turso database URL |
-| `MEMORY_TURSO_TOKEN` | `database.turso_token` | Turso authentication token |
-| `MEMORY_REDB_PATH` | `database.redb_path` | redb database file path |
+| `TURSO_URL` | `database.turso_url` | Turso database URL |
+| `TURSO_TOKEN` | `database.turso_token` | Turso authentication token |
+| `REDB_PATH` | `database.redb_path` | redb database file path |
+
+## Quick Start: Generate a Config
+
+```bash
+# Write a starter local config (refuses to overwrite)
+do-memory-cli config init
+# → creates do-memory-cli.toml with storage_mode = "local"
+
+# Or print a template to stdout
+do-memory-cli config show-template
+
+# Use a project-local path
+do-memory-cli -c do-memory-cli.toml episode list
+
+# Or override path without a config file (also sets redb_path):
+do-memory-cli --storage-mode local --db-path ./data/memory.redb episode list
+# MEMORY_DB_PATH=./data/memory.redb MEMORY_STORAGE_MODE=local do-memory-cli episode list
+```
+
+### Where does `storage_mode` go?
+
+| Location | Supported? | Notes |
+|----------|------------|-------|
+| `[database].storage_mode` | ✅ Canonical | Preferred; emitted by `config init` |
+| `--storage-mode` / `MEMORY_STORAGE_MODE` | ✅ CLI/env override | Wins over config file |
+| `[storage].storage_mode` | ✅ Accepted alias | Copied into `[database]` if unset |
+
+`[storage]` is for cache size / TTL / pool size — not backend selection.
+
+### Minimal valid config (issue #829)
+
+Partial files work; missing sections use defaults:
+
+```toml
+[database]
+redb_path = "./.do-memory-cli/cache/memory.redb"
+storage_mode = "local"
+```
+
+See also `memory-cli/config/do-memory-cli.example.toml`.
 
 ## Configuration Validation
 
@@ -363,10 +403,10 @@ The CLI validates configuration on startup. Use the `config` command to check yo
 
 ```bash
 # Validate configuration
-do-memory-cli config
+do-memory-cli config validate
 
 # Validate specific config file
-do-memory-cli --config custom.toml config
+do-memory-cli --config custom.toml config validate
 ```
 
 ### Validation Rules
@@ -426,7 +466,7 @@ chmod 600 do-memory-cli.toml
 export MEMORY_TURSO_TOKEN="your-secure-token"
 
 # Test configuration
-do-memory-cli config
+do-memory-cli config validate
 ```
 
 ## Troubleshooting Configuration
@@ -524,10 +564,8 @@ progress_bars = true
 batch_size = 100
 EOF
 
-# Environment-specific overrides
+# Environment-specific overrides (pass a different file with --config)
 cat > do-memory-cli.dev.toml << EOF
-import = "do-memory-cli.base.toml"
-
 [database]
 turso_url = "libsql://dev-db.turso.io"
 turso_token = "dev-token"
@@ -579,11 +617,11 @@ fi
 # Validate with CLI
 echo
 echo "Validating configuration..."
-if do-memory-cli config > /dev/null 2>&1; then
+if do-memory-cli config validate > /dev/null 2>&1; then
     echo "✓ Configuration is valid"
 else
     echo "✗ Configuration validation failed"
-    do-memory-cli config
+    do-memory-cli config validate
     exit 1
 fi
 

--- a/memory-cli/config/do-memory-cli.example.toml
+++ b/memory-cli/config/do-memory-cli.example.toml
@@ -1,0 +1,61 @@
+# do-memory-cli example configuration
+# =====================================
+# Generate a ready-to-edit starter with:
+#   do-memory-cli config init
+#   do-memory-cli config show-template
+#
+# Field reference: memory-cli/CONFIGURATION_GUIDE.md
+# Local-only setup: docs/LOCAL_DATABASE_SETUP.md
+#
+# All sections are optional thanks to defaults (issue #829). A minimal
+# local config only needs [database] with redb_path + storage_mode.
+
+# ---------------------------------------------------------------------------
+# [database] — storage backend selection (canonical home for storage_mode)
+# ---------------------------------------------------------------------------
+[database]
+# Local redb cache / primary local backend path.
+# Overridden by --db-path / MEMORY_DB_PATH (issue #830).
+redb_path = "./.do-memory-cli/cache/memory.redb"
+
+# "remote" (Turso), "local" (redb/local SQLite), or "memory".
+# Prefer this location over [storage].storage_mode (issue #832).
+storage_mode = "local"
+
+# Turso remote (only needed for storage_mode = "remote")
+# turso_url = "libsql://your-db.turso.io"
+# turso_token = "your-token"
+
+# Local Turso SQLite path when storage_mode = "local" and using Turso file backend.
+# db_path = "./data/memory.db"
+
+# ---------------------------------------------------------------------------
+# [storage] — cache behaviour (NOT where storage_mode belongs)
+# ---------------------------------------------------------------------------
+[storage]
+max_episodes_cache = 1200
+cache_ttl_seconds = 7200
+pool_size = 14
+# Optional UX alias (copied into [database].storage_mode if that is unset):
+# storage_mode = "local"
+
+# ---------------------------------------------------------------------------
+# [cli] — output preferences
+# ---------------------------------------------------------------------------
+[cli]
+default_format = "human"   # human | json | yaml
+progress_bars = true
+batch_size = 200
+
+# ---------------------------------------------------------------------------
+# [embeddings] — optional semantic search
+# ---------------------------------------------------------------------------
+[embeddings]
+enabled = false
+provider = "local"
+model = "sentence-transformers/all-MiniLM-L6-v2"
+dimension = 384
+similarity_threshold = 0.7
+batch_size = 32
+cache_embeddings = true
+timeout_seconds = 30

--- a/memory-cli/src/commands/config.rs
+++ b/memory-cli/src/commands/config.rs
@@ -1,9 +1,14 @@
 use clap::Subcommand;
-use colored::Colorize;
-use serde::Serialize;
+use std::path::PathBuf;
 
 use crate::config::{Config, ConfigWizard};
-use crate::output::{Output, OutputFormat};
+use crate::output::OutputFormat;
+
+// Re-export template helpers so `config::show_config_template` / `init_config`
+// keep working from the command dispatcher.
+pub use super::config_template::{init_config, show_config_template};
+// Display/validation result types used by handlers and Output impls.
+pub use super::config_display::*;
 
 #[derive(Subcommand)]
 pub enum ConfigCommands {
@@ -15,212 +20,14 @@ pub enum ConfigCommands {
     Show,
     /// Run interactive configuration wizard
     Wizard,
-}
-
-#[derive(Debug, Serialize)]
-pub struct ConfigValidation {
-    pub is_valid: bool,
-    pub issues: Vec<ConfigIssue>,
-    pub connectivity: ConnectivityStatus,
-}
-
-#[derive(Debug, Serialize)]
-pub struct ConfigIssue {
-    pub level: IssueLevel,
-    pub category: String,
-    pub message: String,
-    pub suggestion: Option<String>,
-}
-
-#[derive(Debug, Serialize, PartialEq)]
-pub enum IssueLevel {
-    Error,
-    Warning,
-    Info,
-}
-
-#[derive(Debug, Serialize)]
-pub struct ConnectivityStatus {
-    pub turso_connected: bool,
-    pub redb_accessible: bool,
-    pub latency_ms: Option<u64>,
-    pub errors: Vec<String>,
-}
-
-#[derive(Debug, Serialize)]
-pub struct ConfigCheck {
-    pub validation: ConfigValidation,
-    pub recommendations: Vec<String>,
-    pub security_issues: Vec<String>,
-}
-
-#[derive(Debug, Serialize)]
-pub struct ConfigDisplay {
-    pub database: DatabaseConfigDisplay,
-    pub storage: StorageConfigDisplay,
-    pub cli: CliConfigDisplay,
-    pub features: Vec<String>,
-}
-
-#[derive(Debug, Serialize)]
-pub struct DatabaseConfigDisplay {
-    pub turso_url: Option<String>,
-    pub turso_token_configured: bool,
-    pub redb_path: Option<String>,
-}
-
-#[derive(Debug, Serialize)]
-pub struct StorageConfigDisplay {
-    pub max_episodes_cache: usize,
-    pub cache_ttl_seconds: u64,
-    pub pool_size: usize,
-}
-
-#[derive(Debug, Serialize)]
-pub struct CliConfigDisplay {
-    pub default_format: String,
-    pub progress_bars: bool,
-    pub batch_size: usize,
-}
-
-impl Output for ConfigValidation {
-    fn write_human<W: std::io::Write>(&self, mut writer: W) -> anyhow::Result<()> {
-        use colored::*;
-
-        if self.is_valid {
-            writeln!(writer, "{}", "✅ Configuration is valid".green().bold())?;
-        } else {
-            writeln!(writer, "{}", "❌ Configuration has issues".red().bold())?;
-        }
-
-        if !self.issues.is_empty() {
-            writeln!(writer, "\nIssues found:")?;
-            for issue in &self.issues {
-                let level_color = match issue.level {
-                    IssueLevel::Error => Color::Red,
-                    IssueLevel::Warning => Color::Yellow,
-                    IssueLevel::Info => Color::Blue,
-                };
-                let level_str = match issue.level {
-                    IssueLevel::Error => "ERROR",
-                    IssueLevel::Warning => "WARN",
-                    IssueLevel::Info => "INFO",
-                };
-                writeln!(
-                    writer,
-                    "  {} [{}] {}",
-                    level_str.color(level_color).bold(),
-                    issue.category,
-                    issue.message
-                )?;
-                if let Some(suggestion) = &issue.suggestion {
-                    writeln!(writer, "    💡 {}", suggestion.italic())?;
-                }
-            }
-        }
-
-        writeln!(writer, "\nConnectivity Status:")?;
-        if self.connectivity.turso_connected {
-            writeln!(writer, "  {} Turso: Connected", "✅".green())?;
-        } else {
-            writeln!(writer, "  {} Turso: Not connected", "❌".red())?;
-        }
-
-        if self.connectivity.redb_accessible {
-            writeln!(writer, "  {} redb: Accessible", "✅".green())?;
-        } else {
-            writeln!(writer, "  {} redb: Not accessible", "❌".red())?;
-        }
-
-        if let Some(latency) = self.connectivity.latency_ms {
-            writeln!(writer, "  Latency: {}ms", latency)?;
-        }
-
-        if !self.connectivity.errors.is_empty() {
-            writeln!(writer, "\nConnection errors:")?;
-            for error in &self.connectivity.errors {
-                writeln!(writer, "  {}", error.red())?;
-            }
-        }
-
-        Ok(())
-    }
-}
-
-impl Output for ConfigCheck {
-    fn write_human<W: std::io::Write>(&self, mut writer: W) -> anyhow::Result<()> {
-        // First show validation results
-        self.validation.write_human(&mut writer)?;
-
-        if !self.recommendations.is_empty() {
-            writeln!(writer, "\nRecommendations:")?;
-            for rec in &self.recommendations {
-                writeln!(writer, "  💡 {}", rec)?;
-            }
-        }
-
-        if !self.security_issues.is_empty() {
-            writeln!(writer, "\n{} Security Issues:", "⚠️".yellow())?;
-            for issue in &self.security_issues {
-                writeln!(writer, "  {}", issue.red())?;
-            }
-        }
-
-        Ok(())
-    }
-}
-
-impl Output for ConfigDisplay {
-    fn write_human<W: std::io::Write>(&self, mut writer: W) -> anyhow::Result<()> {
-        use colored::*;
-
-        writeln!(writer, "{}", "Configuration Overview".bold())?;
-        writeln!(writer, "{}", "─".repeat(40))?;
-
-        writeln!(writer, "\nDatabase:")?;
-        if let Some(url) = &self.database.turso_url {
-            writeln!(writer, "  Turso URL: {}", url)?;
-        } else {
-            writeln!(writer, "  Turso URL: {}", "Not configured".yellow())?;
-        }
-        writeln!(
-            writer,
-            "  Turso Token: {}",
-            if self.database.turso_token_configured {
-                "Configured"
-            } else {
-                "Not configured"
-            }
-        )?;
-        if let Some(path) = &self.database.redb_path {
-            writeln!(writer, "  redb Path: {}", path)?;
-        } else {
-            writeln!(writer, "  redb Path: {}", "Not configured".yellow())?;
-        }
-
-        writeln!(writer, "\nStorage:")?;
-        writeln!(
-            writer,
-            "  Max Episodes Cache: {}",
-            self.storage.max_episodes_cache
-        )?;
-        writeln!(writer, "  Cache TTL: {}s", self.storage.cache_ttl_seconds)?;
-        writeln!(writer, "  Pool Size: {}", self.storage.pool_size)?;
-
-        writeln!(writer, "\nCLI:")?;
-        writeln!(writer, "  Default Format: {}", self.cli.default_format)?;
-        writeln!(writer, "  Progress Bars: {}", self.cli.progress_bars)?;
-        writeln!(writer, "  Batch Size: {}", self.cli.batch_size)?;
-
-        if !self.features.is_empty() {
-            writeln!(writer, "\nEnabled Features:")?;
-            for feature in &self.features {
-                writeln!(writer, "  • {}", feature)?;
-            }
-        }
-
-        Ok(())
-    }
+    /// Print a starter configuration template (TOML) to stdout
+    ShowTemplate,
+    /// Write a starter configuration to a file (default: do-memory-cli.toml)
+    Init {
+        /// Path to write the starter config
+        #[arg(default_value = "do-memory-cli.toml")]
+        path: PathBuf,
+    },
 }
 
 // Command implementations
@@ -447,6 +254,8 @@ pub async fn show_config(
             turso_url: config.database.turso_url.clone(),
             turso_token_configured: config.database.turso_token.is_some(),
             redb_path: config.database.redb_path.clone(),
+            storage_mode: config.database.storage_mode.clone(),
+            db_path: config.database.db_path.clone(),
         },
         storage: StorageConfigDisplay {
             max_episodes_cache: config.storage.max_episodes_cache,

--- a/memory-cli/src/commands/config_display.rs
+++ b/memory-cli/src/commands/config_display.rs
@@ -1,0 +1,228 @@
+//! Config command display types and human-readable Output impls.
+
+use colored::Colorize;
+use serde::Serialize;
+
+use crate::output::Output;
+
+#[derive(Debug, Serialize)]
+pub struct ConfigValidation {
+    pub is_valid: bool,
+    pub issues: Vec<ConfigIssue>,
+    pub connectivity: ConnectivityStatus,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ConfigIssue {
+    pub level: IssueLevel,
+    pub category: String,
+    pub message: String,
+    pub suggestion: Option<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub enum IssueLevel {
+    Error,
+    Warning,
+    Info,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ConnectivityStatus {
+    pub turso_connected: bool,
+    pub redb_accessible: bool,
+    pub latency_ms: Option<u64>,
+    pub errors: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ConfigCheck {
+    pub validation: ConfigValidation,
+    pub recommendations: Vec<String>,
+    pub security_issues: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ConfigDisplay {
+    pub database: DatabaseConfigDisplay,
+    pub storage: StorageConfigDisplay,
+    pub cli: CliConfigDisplay,
+    pub features: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DatabaseConfigDisplay {
+    pub turso_url: Option<String>,
+    pub turso_token_configured: bool,
+    pub redb_path: Option<String>,
+    /// Canonical storage mode: "remote" | "local" | "memory"
+    pub storage_mode: Option<String>,
+    /// Local Turso SQLite path (when storage_mode = "local")
+    pub db_path: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct StorageConfigDisplay {
+    pub max_episodes_cache: usize,
+    pub cache_ttl_seconds: u64,
+    pub pool_size: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CliConfigDisplay {
+    pub default_format: String,
+    pub progress_bars: bool,
+    pub batch_size: usize,
+}
+
+impl Output for ConfigValidation {
+    fn write_human<W: std::io::Write>(&self, mut writer: W) -> anyhow::Result<()> {
+        use colored::*;
+
+        if self.is_valid {
+            writeln!(writer, "{}", "✅ Configuration is valid".green().bold())?;
+        } else {
+            writeln!(writer, "{}", "❌ Configuration has issues".red().bold())?;
+        }
+
+        if !self.issues.is_empty() {
+            writeln!(writer, "\nIssues found:")?;
+            for issue in &self.issues {
+                let level_color = match issue.level {
+                    IssueLevel::Error => Color::Red,
+                    IssueLevel::Warning => Color::Yellow,
+                    IssueLevel::Info => Color::Blue,
+                };
+                let level_str = match issue.level {
+                    IssueLevel::Error => "ERROR",
+                    IssueLevel::Warning => "WARN",
+                    IssueLevel::Info => "INFO",
+                };
+                writeln!(
+                    writer,
+                    "  {} [{}] {}",
+                    level_str.color(level_color).bold(),
+                    issue.category,
+                    issue.message
+                )?;
+                if let Some(suggestion) = &issue.suggestion {
+                    writeln!(writer, "    💡 {}", suggestion.italic())?;
+                }
+            }
+        }
+
+        writeln!(writer, "\nConnectivity Status:")?;
+        if self.connectivity.turso_connected {
+            writeln!(writer, "  {} Turso: Connected", "✅".green())?;
+        } else {
+            writeln!(writer, "  {} Turso: Not connected", "❌".red())?;
+        }
+
+        if self.connectivity.redb_accessible {
+            writeln!(writer, "  {} redb: Accessible", "✅".green())?;
+        } else {
+            writeln!(writer, "  {} redb: Not accessible", "❌".red())?;
+        }
+
+        if let Some(latency) = self.connectivity.latency_ms {
+            writeln!(writer, "  Latency: {}ms", latency)?;
+        }
+
+        if !self.connectivity.errors.is_empty() {
+            writeln!(writer, "\nConnection errors:")?;
+            for error in &self.connectivity.errors {
+                writeln!(writer, "  {}", error.red())?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Output for ConfigCheck {
+    fn write_human<W: std::io::Write>(&self, mut writer: W) -> anyhow::Result<()> {
+        // First show validation results
+        self.validation.write_human(&mut writer)?;
+
+        if !self.recommendations.is_empty() {
+            writeln!(writer, "\nRecommendations:")?;
+            for rec in &self.recommendations {
+                writeln!(writer, "  💡 {}", rec)?;
+            }
+        }
+
+        if !self.security_issues.is_empty() {
+            writeln!(writer, "\n{} Security Issues:", "⚠️".yellow())?;
+            for issue in &self.security_issues {
+                writeln!(writer, "  {}", issue.red())?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Output for ConfigDisplay {
+    fn write_human<W: std::io::Write>(&self, mut writer: W) -> anyhow::Result<()> {
+        use colored::*;
+
+        writeln!(writer, "{}", "Configuration Overview".bold())?;
+        writeln!(writer, "{}", "─".repeat(40))?;
+
+        writeln!(writer, "\nDatabase:")?;
+        if let Some(url) = &self.database.turso_url {
+            writeln!(writer, "  Turso URL: {}", url)?;
+        } else {
+            writeln!(writer, "  Turso URL: {}", "Not configured".yellow())?;
+        }
+        writeln!(
+            writer,
+            "  Turso Token: {}",
+            if self.database.turso_token_configured {
+                "Configured"
+            } else {
+                "Not configured"
+            }
+        )?;
+        if let Some(path) = &self.database.redb_path {
+            writeln!(writer, "  redb Path: {}", path)?;
+        } else {
+            writeln!(writer, "  redb Path: {}", "Not configured".yellow())?;
+        }
+        if let Some(mode) = &self.database.storage_mode {
+            writeln!(writer, "  Storage Mode: {}", mode)?;
+        } else {
+            writeln!(
+                writer,
+                "  Storage Mode: {} (default remote; set [database].storage_mode or --storage-mode)",
+                "Not set".yellow()
+            )?;
+        }
+        if let Some(path) = &self.database.db_path {
+            writeln!(writer, "  DB Path: {}", path)?;
+        }
+
+        writeln!(writer, "\nStorage:")?;
+        writeln!(
+            writer,
+            "  Max Episodes Cache: {}",
+            self.storage.max_episodes_cache
+        )?;
+        writeln!(writer, "  Cache TTL: {}s", self.storage.cache_ttl_seconds)?;
+        writeln!(writer, "  Pool Size: {}", self.storage.pool_size)?;
+
+        writeln!(writer, "\nCLI:")?;
+        writeln!(writer, "  Default Format: {}", self.cli.default_format)?;
+        writeln!(writer, "  Progress Bars: {}", self.cli.progress_bars)?;
+        writeln!(writer, "  Batch Size: {}", self.cli.batch_size)?;
+
+        if !self.features.is_empty() {
+            writeln!(writer, "\nEnabled Features:")?;
+            for feature in &self.features {
+                writeln!(writer, "  • {}", feature)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/memory-cli/src/commands/config_template.rs
+++ b/memory-cli/src/commands/config_template.rs
@@ -1,28 +1,37 @@
 //! Config template generation (`config show-template` / `config init`).
 
 use anyhow::Context;
-use std::path::PathBuf;
+use std::path::Path;
 
 use crate::config::Config;
 
-/// Print a starter configuration template (TOML) to stdout.
+/// Build the starter configuration TOML string.
 ///
-/// The template uses a local (redb) backend so it works out of the box
-/// without any external service. Mirrors the schema documented in
-/// `docs/CONFIGURATION_GUIDE.md`.
-pub async fn show_config_template() -> anyhow::Result<()> {
+/// Sets `storage_mode = "local"` so the default redb path is used without a
+/// remote Turso account. Documented in `docs/CONFIGURATION_GUIDE.md`.
+pub fn render_config_template() -> anyhow::Result<String> {
     let mut config = Config::default();
     config.database.storage_mode = Some("local".to_string());
-    let toml = toml::to_string_pretty(&config).context("Failed to serialize config template")?;
+    toml::to_string_pretty(&config).context("Failed to serialize config template")
+}
+
+/// Print a starter configuration template (TOML) to stdout.
+pub async fn show_config_template() -> anyhow::Result<()> {
+    let toml = render_config_template()?;
     println!("{toml}");
     Ok(())
 }
 
 /// Write a starter configuration to `path` (default `do-memory-cli.toml`).
 ///
-/// Refuses to overwrite an existing file. The written config uses a local
-/// (redb) backend by default so it is immediately usable.
-pub async fn init_config(path: &PathBuf) -> anyhow::Result<()> {
+/// Refuses to overwrite an existing file. The written config uses
+/// `storage_mode = "local"` by default so it is immediately usable with redb.
+pub async fn init_config(path: &Path) -> anyhow::Result<()> {
+    write_config_template(path)
+}
+
+/// Synchronous write helper (unit-tested).
+pub fn write_config_template(path: &Path) -> anyhow::Result<()> {
     if path.exists() {
         anyhow::bail!(
             "Config file already exists at {}; refusing to overwrite.",
@@ -35,11 +44,59 @@ pub async fn init_config(path: &PathBuf) -> anyhow::Result<()> {
                 .with_context(|| format!("Failed to create directory {}", parent.display()))?;
         }
     }
-    let mut config = Config::default();
-    config.database.storage_mode = Some("local".to_string());
-    let toml = toml::to_string_pretty(&config).context("Failed to serialize config template")?;
+    let toml = render_config_template()?;
     std::fs::write(path, toml)
         .with_context(|| format!("Failed to write config to {}", path.display()))?;
     println!("✓ Wrote starter configuration to {}", path.display());
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn render_template_is_valid_toml_with_local_mode() {
+        let toml = render_config_template().expect("render");
+        assert!(
+            toml.contains("storage_mode"),
+            "template should set storage_mode"
+        );
+        let parsed: Config = toml::from_str(&toml).expect("template must parse as Config");
+        assert_eq!(parsed.database.storage_mode.as_deref(), Some("local"));
+        assert!(parsed.storage.max_episodes_cache > 0);
+        assert!(!parsed.cli.default_format.is_empty());
+    }
+
+    #[test]
+    fn write_config_template_creates_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("do-memory-cli.toml");
+        write_config_template(&path).expect("write");
+        assert!(path.exists());
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("storage_mode"));
+    }
+
+    #[test]
+    fn write_config_template_refuses_overwrite() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("existing.toml");
+        std::fs::write(&path, "already here").unwrap();
+        let err = write_config_template(&path).expect_err("must refuse overwrite");
+        assert!(
+            err.to_string().contains("refusing to overwrite"),
+            "got: {err}"
+        );
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "already here");
+    }
+
+    #[test]
+    fn write_config_template_creates_parent_dirs() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nested").join("cfg.toml");
+        write_config_template(&path).expect("write nested");
+        assert!(path.exists());
+    }
 }

--- a/memory-cli/src/commands/config_template.rs
+++ b/memory-cli/src/commands/config_template.rs
@@ -1,0 +1,45 @@
+//! Config template generation (`config show-template` / `config init`).
+
+use anyhow::Context;
+use std::path::PathBuf;
+
+use crate::config::Config;
+
+/// Print a starter configuration template (TOML) to stdout.
+///
+/// The template uses a local (redb) backend so it works out of the box
+/// without any external service. Mirrors the schema documented in
+/// `docs/CONFIGURATION_GUIDE.md`.
+pub async fn show_config_template() -> anyhow::Result<()> {
+    let mut config = Config::default();
+    config.database.storage_mode = Some("local".to_string());
+    let toml = toml::to_string_pretty(&config).context("Failed to serialize config template")?;
+    println!("{toml}");
+    Ok(())
+}
+
+/// Write a starter configuration to `path` (default `do-memory-cli.toml`).
+///
+/// Refuses to overwrite an existing file. The written config uses a local
+/// (redb) backend by default so it is immediately usable.
+pub async fn init_config(path: &PathBuf) -> anyhow::Result<()> {
+    if path.exists() {
+        anyhow::bail!(
+            "Config file already exists at {}; refusing to overwrite.",
+            path.display()
+        );
+    }
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create directory {}", parent.display()))?;
+        }
+    }
+    let mut config = Config::default();
+    config.database.storage_mode = Some("local".to_string());
+    let toml = toml::to_string_pretty(&config).context("Failed to serialize config template")?;
+    std::fs::write(path, toml)
+        .with_context(|| format!("Failed to write config to {}", path.display()))?;
+    println!("✓ Wrote starter configuration to {}", path.display());
+    Ok(())
+}

--- a/memory-cli/src/commands/mod.rs
+++ b/memory-cli/src/commands/mod.rs
@@ -2,6 +2,8 @@
 
 pub mod backup;
 pub mod config;
+pub mod config_display;
+pub mod config_template;
 pub mod embedding;
 pub mod episode;
 pub mod eval;
@@ -76,6 +78,8 @@ pub async fn handle_config_command(
         ConfigCommands::Check => config::check_config(memory, config, format).await,
         ConfigCommands::Show => config::show_config(memory, config, format).await,
         ConfigCommands::Wizard => config::run_wizard().await,
+        ConfigCommands::ShowTemplate => config::show_config_template().await,
+        ConfigCommands::Init { path } => config::init_config(&path).await,
     }
 }
 

--- a/memory-cli/src/config/cli_overrides.rs
+++ b/memory-cli/src/config/cli_overrides.rs
@@ -1,0 +1,132 @@
+//! CLI flag / env overrides applied after config load.
+//!
+//! Extracted for unit testing (issue #830): `Config::default()` always fills
+//! `redb_path` with an XDG path, so overrides must always replace it.
+
+use super::types::Config;
+use std::path::{Path, PathBuf};
+
+/// Apply `--db-path` / `MEMORY_DB_PATH` to a loaded config.
+///
+/// Always overrides `redb_path` (never "only if None") because
+/// [`Config::default`] pre-fills the XDG cache path.
+///
+/// - **Default CLI (redb-only)**: both `db_path` and `redb_path` use the user
+///   path so `Opening redb database at <path>` matches issue #830 exactly.
+/// - **With `turso` feature**: sibling files so SQLite and redb never share a
+///   path (`memory.db` → redb `memory.redb`).
+///
+/// When `storage_mode` is unset and no Turso URL is configured, defaults
+/// `storage_mode` to `"local"`.
+pub fn apply_db_path_override(config: &mut Config, path: &Path) {
+    #[cfg(feature = "turso")]
+    {
+        let (db_path, redb_path) = sibling_db_and_redb_paths(path);
+        config.database.db_path = Some(db_path);
+        config.database.redb_path = Some(redb_path);
+    }
+    #[cfg(not(feature = "turso"))]
+    {
+        let path_str = path.to_string_lossy().to_string();
+        config.database.db_path = Some(path_str.clone());
+        config.database.redb_path = Some(path_str);
+    }
+
+    if config.database.storage_mode.is_none() && config.database.turso_url.is_none() {
+        config.database.storage_mode = Some("local".to_string());
+    }
+}
+
+/// Derive Turso SQLite + redb paths that never point at the same file.
+///
+/// | User path       | `db_path` (Turso local) | `redb_path` (redb) |
+/// |-----------------|-------------------------|--------------------|
+/// | `.../memory.db` | `.../memory.db`         | `.../memory.redb`  |
+/// | `.../x.redb`    | `.../x.db`              | `.../x.redb`       |
+pub fn sibling_db_and_redb_paths(path: &Path) -> (String, String) {
+    let is_redb = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| e.eq_ignore_ascii_case("redb"));
+
+    if is_redb {
+        let redb = path.to_string_lossy().to_string();
+        let mut sqlite = PathBuf::from(path);
+        sqlite.set_extension("db");
+        (sqlite.to_string_lossy().to_string(), redb)
+    } else {
+        let db = path.to_string_lossy().to_string();
+        let mut redb = PathBuf::from(path);
+        redb.set_extension("redb");
+        (db, redb.to_string_lossy().to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::types::Config;
+
+    #[test]
+    fn always_overrides_xdg_redb_path_from_default() {
+        let mut config = Config::default();
+        let default_redb = config.database.redb_path.clone();
+        assert!(
+            default_redb.is_some(),
+            "Config::default() must pre-fill redb_path (issue #830 root cause)"
+        );
+
+        let custom = PathBuf::from("/tmp/my-project/memory.db");
+        apply_db_path_override(&mut config, &custom);
+
+        #[cfg(not(feature = "turso"))]
+        {
+            assert_eq!(
+                config.database.redb_path.as_deref(),
+                Some("/tmp/my-project/memory.db"),
+                "redb-only CLI: redb opens the exact user path (issue #830)"
+            );
+        }
+        #[cfg(feature = "turso")]
+        {
+            assert_eq!(
+                config.database.redb_path.as_deref(),
+                Some("/tmp/my-project/memory.redb"),
+                "turso builds: redb uses sibling .redb"
+            );
+            assert_eq!(
+                config.database.db_path.as_deref(),
+                Some("/tmp/my-project/memory.db")
+            );
+            assert_ne!(config.database.db_path, config.database.redb_path);
+        }
+
+        assert_ne!(
+            config.database.redb_path, default_redb,
+            "override must replace default XDG path"
+        );
+        assert_eq!(config.database.storage_mode.as_deref(), Some("local"));
+    }
+
+    #[test]
+    fn sibling_mapping_never_shares_path() {
+        let (db, redb) = sibling_db_and_redb_paths(Path::new("/data/memory.db"));
+        assert_eq!(db, "/data/memory.db");
+        assert_eq!(redb, "/data/memory.redb");
+        assert_ne!(db, redb);
+
+        let (db2, redb2) = sibling_db_and_redb_paths(Path::new("/data/cache.redb"));
+        assert_eq!(db2, "/data/cache.db");
+        assert_eq!(redb2, "/data/cache.redb");
+        assert_ne!(db2, redb2);
+    }
+
+    #[test]
+    fn does_not_force_local_when_turso_url_set() {
+        let mut config = Config::default();
+        config.database.turso_url = Some("libsql://example.turso.io".to_string());
+        config.database.storage_mode = None;
+        apply_db_path_override(&mut config, Path::new("/tmp/x.db"));
+        assert!(config.database.storage_mode.is_none());
+    }
+}

--- a/memory-cli/src/config/loader/cache.rs
+++ b/memory-cli/src/config/loader/cache.rs
@@ -235,6 +235,7 @@ mod cache_tests {
                 max_episodes_cache: 1000,
                 cache_ttl_seconds: 3600,
                 pool_size: 5,
+                storage_mode: None,
             },
             cli: crate::config::types::CliConfig {
                 default_format: "json".to_string(),

--- a/memory-cli/src/config/loader/file.rs
+++ b/memory-cli/src/config/loader/file.rs
@@ -299,6 +299,7 @@ mod file_tests {
                 max_episodes_cache: 1000,
                 cache_ttl_seconds: 3600,
                 pool_size: 5,
+                storage_mode: None,
             },
             cli: crate::config::types::CliConfig {
                 default_format: "json".to_string(),

--- a/memory-cli/src/config/loader/mod.rs
+++ b/memory-cli/src/config/loader/mod.rs
@@ -99,6 +99,7 @@ pub fn load_config_with_format(path: &Path) -> Result<super::Config, anyhow::Err
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
 
     #[test]
     fn test_load_config_from_nonexistent() {
@@ -112,5 +113,70 @@ mod tests {
         let path = Path::new("/nonexistent/config.toml");
         let result = load_config_with_format(path);
         assert!(result.is_err());
+    }
+
+    /// Issue #829: partial configs must load via #[serde(default)] on Config sections.
+    #[test]
+    fn test_partial_config_loads_with_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("partial.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(
+            f,
+            r#"
+[database]
+redb_path = "./data/memory.redb"
+storage_mode = "local"
+"#
+        )
+        .unwrap();
+
+        let config = load_config(Some(&path)).expect("partial config should parse");
+        assert_eq!(
+            config.database.redb_path.as_deref(),
+            Some("./data/memory.redb")
+        );
+        assert_eq!(config.database.storage_mode.as_deref(), Some("local"));
+        // Storage/cli sections filled from Default
+        assert!(config.storage.max_episodes_cache > 0);
+        assert!(config.storage.pool_size > 0);
+        assert!(!config.cli.default_format.is_empty());
+    }
+
+    /// Issue #832: storage_mode under [storage] is accepted as an alias.
+    #[test]
+    fn test_storage_mode_alias_under_storage_section() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("alias.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(
+            f,
+            r#"
+[database]
+redb_path = "./data/memory.redb"
+
+[storage]
+storage_mode = "local"
+max_episodes_cache = 500
+"#
+        )
+        .unwrap();
+
+        let mut config = load_config(Some(&path)).expect("config with alias should parse");
+        assert_eq!(config.storage.storage_mode.as_deref(), Some("local"));
+        config.normalize_storage_mode();
+        assert_eq!(config.database.storage_mode.as_deref(), Some("local"));
+        assert!(config.storage.storage_mode.is_none());
+    }
+
+    /// Database.storage_mode wins when both locations are set.
+    #[test]
+    fn test_database_storage_mode_takes_precedence() {
+        let mut config = crate::config::Config::default();
+        config.database.storage_mode = Some("remote".to_string());
+        config.storage.storage_mode = Some("local".to_string());
+        config.normalize_storage_mode();
+        assert_eq!(config.database.storage_mode.as_deref(), Some("remote"));
+        assert!(config.storage.storage_mode.is_none());
     }
 }

--- a/memory-cli/src/config/mod.rs
+++ b/memory-cli/src/config/mod.rs
@@ -77,7 +77,9 @@ pub use wizard::{ConfigWizard, quick_setup, show_template};
 pub fn load_config_with_validation(
     path: Option<&std::path::Path>,
 ) -> Result<Config, anyhow::Error> {
-    let config = load_config(path)?;
+    let mut config = load_config(path)?;
+    // Merge `[storage].storage_mode` → `[database].storage_mode` (issue #832).
+    config.normalize_storage_mode();
     let validation_result = validate_config(&config);
 
     if !validation_result.is_valid {

--- a/memory-cli/src/config/mod.rs
+++ b/memory-cli/src/config/mod.rs
@@ -31,6 +31,7 @@
 //! - **Multiple Formats**: Support for TOML, JSON, YAML
 //! - **Environment Detection**: Automatic configuration based on environment
 
+pub mod cli_overrides;
 pub mod loader;
 pub mod progressive;
 pub mod simple;
@@ -56,6 +57,7 @@ pub use validator::{
     validate_storage_config,
 };
 
+pub use cli_overrides::{apply_db_path_override, sibling_db_and_redb_paths};
 pub use storage::{StorageInfo, StorageInitResult, StorageType, initialize_storage};
 
 pub use simple::{

--- a/memory-cli/src/config/types/defaults_impl.rs
+++ b/memory-cli/src/config/types/defaults_impl.rs
@@ -21,6 +21,7 @@ impl Default for StorageConfig {
             max_episodes_cache: defaults::suggest_cache_size(),
             cache_ttl_seconds: defaults::suggest_cache_ttl(),
             pool_size: defaults::suggest_pool_size(),
+            storage_mode: None,
         }
     }
 }

--- a/memory-cli/src/config/types/presets.rs
+++ b/memory-cli/src/config/types/presets.rs
@@ -46,6 +46,7 @@ impl ConfigPreset {
                         },
                         cache_ttl_seconds: if info.is_development { 1800 } else { 3600 },
                         pool_size: 5, // Conservative for local development
+                        storage_mode: None,
                     },
                     cli: CliConfig {
                         default_format: if info.is_ci {
@@ -82,6 +83,7 @@ impl ConfigPreset {
                         max_episodes_cache: std::cmp::min(5000, defaults::suggest_cache_size()),
                         cache_ttl_seconds: defaults::suggest_cache_ttl(),
                         pool_size: defaults::suggest_pool_size(),
+                        storage_mode: None,
                     },
                     cli: CliConfig {
                         default_format: "json".to_string(), // Machine-readable for automation
@@ -103,6 +105,7 @@ impl ConfigPreset {
                     max_episodes_cache: 100, // Minimal for testing
                     cache_ttl_seconds: 300,  // 5 minutes
                     pool_size: 2,            // Minimal connections
+                    storage_mode: None,
                 },
                 cli: CliConfig {
                     default_format: "human".to_string(),

--- a/memory-cli/src/config/types/structs.rs
+++ b/memory-cli/src/config/types/structs.rs
@@ -2,8 +2,18 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Main configuration struct that aggregates all configuration sections
+/// Main configuration struct that aggregates all configuration sections.
+///
+/// All sections implement [`Default`] and accept partial TOML/JSON/YAML via
+/// `#[serde(default)]` so users can start with a minimal file (issue #829):
+///
+/// ```toml
+/// [database]
+/// redb_path = "./data/memory.redb"
+/// storage_mode = "local"
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct Config {
     /// Database configuration for storage backends
     pub database: DatabaseConfig,
@@ -12,12 +22,30 @@ pub struct Config {
     /// CLI-specific settings and preferences
     pub cli: CliConfig,
     /// Embeddings configuration for semantic search
-    #[serde(default)]
     pub embeddings: EmbeddingsConfig,
+}
+
+impl Config {
+    /// Normalize cross-section aliases after deserializing a config file.
+    ///
+    /// Users often put `storage_mode` under `[storage]` (issue #832). The
+    /// canonical field is `[database].storage_mode`; this copies the alias
+    /// when the database field is unset.
+    pub fn normalize_storage_mode(&mut self) {
+        if self.database.storage_mode.is_none() {
+            if let Some(mode) = self.storage.storage_mode.take() {
+                self.database.storage_mode = Some(mode);
+            }
+        } else {
+            // Prefer [database].storage_mode; drop the alias so show/init stay clean.
+            self.storage.storage_mode = None;
+        }
+    }
 }
 
 /// Database configuration for storage backend setup
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct DatabaseConfig {
     /// Turso database URL for remote storage
     pub turso_url: Option<String>,
@@ -25,14 +53,16 @@ pub struct DatabaseConfig {
     pub turso_token: Option<String>,
     /// redb database path for local cache storage
     pub redb_path: Option<String>,
-    /// Storage mode: "remote", "local", or "memory"
+    /// Storage mode: "remote", "local", or "memory" (canonical location)
     pub storage_mode: Option<String>,
-    /// Explicit database path for local mode
+    /// Explicit database path for local Turso SQLite (`storage_mode = "local"`).
+    /// Prefer `--db-path` / `MEMORY_DB_PATH` which also set `redb_path`.
     pub db_path: Option<String>,
 }
 
 /// Storage configuration for memory system behavior
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct StorageConfig {
     /// Maximum number of episodes to cache in memory
     pub max_episodes_cache: usize,
@@ -40,10 +70,16 @@ pub struct StorageConfig {
     pub cache_ttl_seconds: u64,
     /// Database connection pool size
     pub pool_size: usize,
+    /// UX alias for [`DatabaseConfig::storage_mode`] (issue #832).
+    /// Prefer setting `storage_mode` under `[database]`. Not serialized by
+    /// `config init` / `show-template` so the canonical location stays clear.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub storage_mode: Option<String>,
 }
 
 /// CLI configuration for user interface preferences
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct CliConfig {
     /// Default output format for CLI commands
     pub default_format: String,
@@ -55,6 +91,7 @@ pub struct CliConfig {
 
 /// Embeddings configuration for semantic search
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct EmbeddingsConfig {
     /// Enable semantic embeddings
     pub enabled: bool,

--- a/memory-cli/src/config/validator/mod.rs
+++ b/memory-cli/src/config/validator/mod.rs
@@ -36,6 +36,7 @@ mod tests {
                 max_episodes_cache: 1000,
                 cache_ttl_seconds: 3600,
                 pool_size: 5,
+                storage_mode: None,
             },
             cli: CliConfig {
                 default_format: "json".to_string(),

--- a/memory-cli/src/config/validator/rules/cross_config.rs
+++ b/memory-cli/src/config/validator/rules/cross_config.rs
@@ -66,6 +66,7 @@ mod tests {
                 max_episodes_cache: 1000,
                 cache_ttl_seconds: 3600,
                 pool_size: 5,
+                storage_mode: None,
             },
             cli: CliConfig {
                 default_format: "json".to_string(),

--- a/memory-cli/src/config/validator/rules/environment.rs
+++ b/memory-cli/src/config/validator/rules/environment.rs
@@ -115,6 +115,7 @@ mod tests {
                 max_episodes_cache: 1000,
                 cache_ttl_seconds: 3600,
                 pool_size: 5,
+                storage_mode: None,
             },
             cli: crate::config::types::CliConfig {
                 default_format: "json".to_string(),
@@ -141,6 +142,7 @@ mod tests {
                 max_episodes_cache: 1000,
                 cache_ttl_seconds: 3600,
                 pool_size: 5,
+                storage_mode: None,
             },
             cli: crate::config::types::CliConfig {
                 default_format: "json".to_string(),

--- a/memory-cli/src/config/validator/rules/mod.rs
+++ b/memory-cli/src/config/validator/rules/mod.rs
@@ -173,6 +173,7 @@ mod tests {
                 max_episodes_cache: 1000,
                 cache_ttl_seconds: 3600,
                 pool_size: 5,
+                storage_mode: None,
             },
             cli: CliConfig {
                 default_format: "json".to_string(),

--- a/memory-cli/src/config/validator/rules/storage.rs
+++ b/memory-cli/src/config/validator/rules/storage.rs
@@ -50,6 +50,7 @@ mod tests {
             max_episodes_cache: 1000,
             cache_ttl_seconds: 3600,
             pool_size: 5,
+            storage_mode: None,
         };
         let errors = validate_storage_config_errors(&config);
         assert!(errors.is_empty());
@@ -61,6 +62,7 @@ mod tests {
             max_episodes_cache: 0,
             cache_ttl_seconds: 3600,
             pool_size: 5,
+            storage_mode: None,
         };
         let errors = validate_storage_config_errors(&config);
         assert!(!errors.is_empty());

--- a/memory-cli/src/config/wizard/storage.rs
+++ b/memory-cli/src/config/wizard/storage.rs
@@ -108,6 +108,7 @@ impl ConfigWizard {
             max_episodes_cache: max_episodes,
             cache_ttl_seconds: cache_ttl,
             pool_size,
+            storage_mode: None,
         })
     }
 

--- a/memory-cli/src/main.rs
+++ b/memory-cli/src/main.rs
@@ -73,7 +73,7 @@ mod output;
 mod test_utils;
 
 use commands::*;
-use config::{initialize_storage, load_config_with_validation};
+use config::{apply_db_path_override, initialize_storage, load_config_with_validation};
 use output::OutputFormat;
 
 #[derive(Parser)]
@@ -239,35 +239,9 @@ async fn main() -> anyhow::Result<()> {
         config.database.storage_mode = Some(mode);
     }
     if let Some(path) = cli.db_path {
-        // Honor `--db-path`/`MEMORY_DB_PATH` for both backends without pointing
-        // Turso SQLite and redb at the same file (issue #830).
-        // - `*.redb` → redb_path; Turso local SQLite uses a sibling `*.db`
-        // - anything else → db_path (Turso); redb uses sibling `*.redb`
-        let path_str = path.to_string_lossy().to_string();
-        let is_redb_file = path
-            .extension()
-            .and_then(|e| e.to_str())
-            .is_some_and(|e| e.eq_ignore_ascii_case("redb"));
-        if is_redb_file {
-            config.database.redb_path = Some(path_str);
-            if config.database.db_path.is_none() {
-                let mut sqlite = path.clone();
-                sqlite.set_extension("db");
-                config.database.db_path = Some(sqlite.to_string_lossy().to_string());
-            }
-        } else {
-            config.database.db_path = Some(path_str);
-            if config.database.redb_path.is_none() {
-                let mut redb = path.clone();
-                redb.set_extension("redb");
-                config.database.redb_path = Some(redb.to_string_lossy().to_string());
-            }
-        }
-        // If the user only set a path and has no remote Turso URL, default to
-        // local mode so the path is actually used as primary storage.
-        if config.database.storage_mode.is_none() && config.database.turso_url.is_none() {
-            config.database.storage_mode = Some("local".to_string());
-        }
+        // Issue #830: always override redb_path (Config::default() pre-fills
+        // XDG). Sibling paths keep Turso SQLite and redb from sharing a file.
+        apply_db_path_override(&mut config, &path);
     }
 
     // Accept `[storage].storage_mode` as a UX alias for `[database].storage_mode`

--- a/memory-cli/src/main.rs
+++ b/memory-cli/src/main.rs
@@ -239,8 +239,40 @@ async fn main() -> anyhow::Result<()> {
         config.database.storage_mode = Some(mode);
     }
     if let Some(path) = cli.db_path {
-        config.database.db_path = Some(path.to_string_lossy().to_string());
+        // Honor `--db-path`/`MEMORY_DB_PATH` for both backends without pointing
+        // Turso SQLite and redb at the same file (issue #830).
+        // - `*.redb` → redb_path; Turso local SQLite uses a sibling `*.db`
+        // - anything else → db_path (Turso); redb uses sibling `*.redb`
+        let path_str = path.to_string_lossy().to_string();
+        let is_redb_file = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("redb"));
+        if is_redb_file {
+            config.database.redb_path = Some(path_str);
+            if config.database.db_path.is_none() {
+                let mut sqlite = path.clone();
+                sqlite.set_extension("db");
+                config.database.db_path = Some(sqlite.to_string_lossy().to_string());
+            }
+        } else {
+            config.database.db_path = Some(path_str);
+            if config.database.redb_path.is_none() {
+                let mut redb = path.clone();
+                redb.set_extension("redb");
+                config.database.redb_path = Some(redb.to_string_lossy().to_string());
+            }
+        }
+        // If the user only set a path and has no remote Turso URL, default to
+        // local mode so the path is actually used as primary storage.
+        if config.database.storage_mode.is_none() && config.database.turso_url.is_none() {
+            config.database.storage_mode = Some("local".to_string());
+        }
     }
+
+    // Accept `[storage].storage_mode` as a UX alias for `[database].storage_mode`
+    // (issue #832). Prefer the database field when both are set.
+    config.normalize_storage_mode();
 
     // Create memory system with storage backends
     let storage_result = initialize_storage(&config).await?;

--- a/memory-cli/tests/config_command_tests.rs
+++ b/memory-cli/tests/config_command_tests.rs
@@ -106,6 +106,8 @@ fn test_config_display_write_human_with_none_urls() {
             turso_url: None,
             turso_token_configured: false,
             redb_path: None,
+            storage_mode: None,
+            db_path: None,
         },
         storage: StorageConfigDisplay {
             max_episodes_cache: 1000,
@@ -139,6 +141,8 @@ fn test_config_display_write_human_with_empty_features() {
             turso_url: Some("file:test.db".to_string()),
             turso_token_configured: true,
             redb_path: Some("memory.redb".to_string()),
+            storage_mode: Some("local".to_string()),
+            db_path: None,
         },
         storage: StorageConfigDisplay {
             max_episodes_cache: 500,

--- a/memory-cli/tests/config_command_tests.rs
+++ b/memory-cli/tests/config_command_tests.rs
@@ -129,6 +129,10 @@ fn test_config_display_write_human_with_none_urls() {
     assert!(output.contains("Turso URL: Not configured"));
     assert!(output.contains("Turso Token: Not configured"));
     assert!(output.contains("redb Path: Not configured"));
+    assert!(
+        output.contains("Storage Mode: Not set") || output.contains("Not set"),
+        "unset storage_mode should be visible: {output}"
+    );
     assert!(output.contains("Enabled Features"));
     assert!(output.contains("turso"));
     assert!(output.contains("redb"));
@@ -164,7 +168,40 @@ fn test_config_display_write_human_with_empty_features() {
     assert!(output.contains("Turso URL: file:test.db"));
     assert!(output.contains("Turso Token: Configured"));
     assert!(output.contains("redb Path: memory.redb"));
+    assert!(output.contains("Storage Mode: local"));
     assert!(!output.contains("Enabled Features"));
+}
+
+#[test]
+fn test_config_display_shows_db_path_when_set() {
+    let display = ConfigDisplay {
+        database: DatabaseConfigDisplay {
+            turso_url: None,
+            turso_token_configured: false,
+            redb_path: Some("/tmp/cache.redb".to_string()),
+            storage_mode: Some("local".to_string()),
+            db_path: Some("/tmp/memory.db".to_string()),
+        },
+        storage: StorageConfigDisplay {
+            max_episodes_cache: 100,
+            cache_ttl_seconds: 60,
+            pool_size: 2,
+        },
+        cli: CliConfigDisplay {
+            default_format: "human".to_string(),
+            progress_bars: false,
+            batch_size: 10,
+        },
+        features: vec![],
+    };
+
+    let mut buffer = Vec::new();
+    display.write_human(&mut buffer).unwrap();
+    let output = String::from_utf8(buffer).unwrap();
+
+    assert!(output.contains("DB Path: /tmp/memory.db"));
+    assert!(output.contains("Storage Mode: local"));
+    assert!(output.contains("redb Path: /tmp/cache.redb"));
 }
 
 #[test]

--- a/memory-cli/tests/config_property_tests.rs
+++ b/memory-cli/tests/config_property_tests.rs
@@ -155,6 +155,7 @@ proptest! {
             max_episodes_cache: if zero_field == 0 { 0 } else { 1000 },
             cache_ttl_seconds: if zero_field == 1 { 0 } else { 3600 },
             pool_size: if zero_field == 2 { 0 } else { 5 },
+            storage_mode: None,
         };
 
         let result = validate_storage_config(&storage);
@@ -173,6 +174,7 @@ proptest! {
             max_episodes_cache: max_cache,
             cache_ttl_seconds: ttl,
             pool_size: pool,
+            storage_mode: None,
         };
 
         let result = validate_storage_config(&storage);
@@ -189,6 +191,7 @@ proptest! {
             max_episodes_cache: cache_size,
             cache_ttl_seconds: 3600,
             pool_size: 5,
+            storage_mode: None,
         };
 
         let result = validate_storage_config(&storage);
@@ -273,6 +276,7 @@ proptest! {
                 max_episodes_cache: cache_size,
                 cache_ttl_seconds: 3600,
                 pool_size: 5,
+                storage_mode: None,
             },
             CliConfig {
                 default_format: "json".to_string(),
@@ -310,83 +314,87 @@ proptest! {
 }
 
 // ============================================================================
-// Serialization Roundtrip Properties
+// Serialization Roundtrip (deterministic — avoids proptest hangs under nextest)
 // ============================================================================
 
-proptest! {
-    /// Config JSON roundtrip preserves all fields
-    #[test]
-    fn config_json_roundtrip(
-        cache_size in 1usize..10000usize,
-        ttl in 1u64..86400u64,
-        pool in 1usize..100usize,
-        format in prop::sample::select(vec!["human", "json", "yaml"]),
-        batch in 1usize..1000usize,
-        progress in proptest::bool::ANY,
-    ) {
-        let config = make_config(
-            DatabaseConfig {
-                turso_url: None,
-                turso_token: None,
-                redb_path: Some("/tmp/test.redb".to_string()),
-                storage_mode: None,
-                db_path: None,
-            },
-            StorageConfig {
-                max_episodes_cache: cache_size,
-                cache_ttl_seconds: ttl,
-                pool_size: pool,
-            },
-            CliConfig {
-                default_format: format.to_string(),
-                progress_bars: progress,
-                batch_size: batch,
-            },
-        );
+fn sample_roundtrip_config(
+    cache_size: usize,
+    ttl: u64,
+    pool: usize,
+    format: &str,
+    batch: usize,
+    progress: bool,
+) -> Config {
+    make_config(
+        DatabaseConfig {
+            turso_url: None,
+            turso_token: None,
+            redb_path: Some("/tmp/test.redb".to_string()),
+            storage_mode: Some("local".to_string()),
+            db_path: None,
+        },
+        StorageConfig {
+            max_episodes_cache: cache_size,
+            cache_ttl_seconds: ttl,
+            pool_size: pool,
+            storage_mode: None,
+        },
+        CliConfig {
+            default_format: format.to_string(),
+            progress_bars: progress,
+            batch_size: batch,
+        },
+    )
+}
 
+/// Config JSON roundtrip preserves all fields
+#[test]
+fn config_json_roundtrip() {
+    for (cache, ttl, pool, format, batch, progress) in [
+        (1, 1, 1, "human", 1, true),
+        (1000, 3600, 5, "json", 50, false),
+        (9999, 86400, 99, "yaml", 999, true),
+    ] {
+        let config = sample_roundtrip_config(cache, ttl, pool, format, batch, progress);
         let json = serde_json::to_string(&config).expect("serialize to JSON");
         let deserialized: Config = serde_json::from_str(&json).expect("deserialize from JSON");
 
-        prop_assert_eq!(config.storage.max_episodes_cache, deserialized.storage.max_episodes_cache);
-        prop_assert_eq!(config.storage.cache_ttl_seconds, deserialized.storage.cache_ttl_seconds);
-        prop_assert_eq!(config.storage.pool_size, deserialized.storage.pool_size);
-        prop_assert_eq!(config.cli.default_format, deserialized.cli.default_format);
-        prop_assert_eq!(config.cli.progress_bars, deserialized.cli.progress_bars);
-        prop_assert_eq!(config.cli.batch_size, deserialized.cli.batch_size);
-    }
-
-    /// Config TOML roundtrip preserves all fields
-    #[test]
-    fn config_toml_roundtrip(
-        cache_size in 1usize..10000usize,
-        pool in 1usize..100usize,
-        batch in 1usize..1000usize,
-    ) {
-        let config = make_config(
-            DatabaseConfig {
-                turso_url: None,
-                turso_token: None,
-                redb_path: Some("/tmp/test.redb".to_string()),
-                storage_mode: None,
-                db_path: None,
-            },
-            StorageConfig {
-                max_episodes_cache: cache_size,
-                cache_ttl_seconds: 3600,
-                pool_size: pool,
-            },
-            CliConfig {
-                default_format: "json".to_string(),
-                progress_bars: false,
-                batch_size: batch,
-            },
+        assert_eq!(
+            config.storage.max_episodes_cache,
+            deserialized.storage.max_episodes_cache
         );
+        assert_eq!(
+            config.storage.cache_ttl_seconds,
+            deserialized.storage.cache_ttl_seconds
+        );
+        assert_eq!(config.storage.pool_size, deserialized.storage.pool_size);
+        assert_eq!(config.cli.default_format, deserialized.cli.default_format);
+        assert_eq!(config.cli.progress_bars, deserialized.cli.progress_bars);
+        assert_eq!(config.cli.batch_size, deserialized.cli.batch_size);
+        assert_eq!(
+            config.database.storage_mode,
+            deserialized.database.storage_mode
+        );
+    }
+}
 
+/// Config TOML roundtrip preserves all fields
+#[test]
+fn config_toml_roundtrip() {
+    for (cache, pool, batch) in [(1, 1, 1), (1000, 5, 50), (9999, 99, 999)] {
+        let config = sample_roundtrip_config(cache, 3600, pool, "json", batch, false);
         let toml_str = toml::to_string(&config).expect("serialize to TOML");
         let deserialized: Config = toml::from_str(&toml_str).expect("deserialize from TOML");
 
-        prop_assert_eq!(config.storage.max_episodes_cache, deserialized.storage.max_episodes_cache);
-        prop_assert_eq!(config.storage.pool_size, deserialized.storage.pool_size);
-        prop_assert_eq!(config.cli.batch_size, deserialized.cli.batch_size);
+        assert_eq!(
+            config.storage.max_episodes_cache,
+            deserialized.storage.max_episodes_cache
+        );
+        assert_eq!(config.storage.pool_size, deserialized.storage.pool_size);
+        assert_eq!(config.cli.batch_size, deserialized.cli.batch_size);
+        assert_eq!(
+            config.database.storage_mode,
+            deserialized.database.storage_mode
+        );
     }
 }

--- a/memory-cli/tests/embedding_command_tests.rs
+++ b/memory-cli/tests/embedding_command_tests.rs
@@ -23,6 +23,7 @@ fn create_test_config_with_embeddings(enabled: bool, api_key_env: Option<String>
             max_episodes_cache: 100,
             cache_ttl_seconds: 3600,
             pool_size: 5,
+            storage_mode: None,
         },
         cli: CliConfig {
             default_format: "human".to_string(),

--- a/memory-cli/tests/snapshots/snapshot_tests__cli_config_help.snap
+++ b/memory-cli/tests/snapshots/snapshot_tests__cli_config_help.snap
@@ -1,5 +1,6 @@
 ---
 source: memory-cli/tests/snapshot_tests.rs
+assertion_line: 260
 expression: stdout
 ---
 Configuration validation and management
@@ -7,11 +8,13 @@ Configuration validation and management
 Usage: do-memory-cli config <COMMAND>
 
 Commands:
-  validate  Validate configuration and connectivity
-  check     Check configuration for issues and recommendations
-  show      Show current configuration (with sensitive data masked)
-  wizard    Run interactive configuration wizard
-  help      Print this message or the help of the given subcommand(s)
+  validate       Validate configuration and connectivity
+  check          Check configuration for issues and recommendations
+  show           Show current configuration (with sensitive data masked)
+  wizard         Run interactive configuration wizard
+  show-template  Print a starter configuration template (TOML) to stdout
+  init           Write a starter configuration to a file (default: do-memory-cli.toml)
+  help           Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help

--- a/memory-core/src/memory/queries/mod.rs
+++ b/memory-core/src/memory/queries/mod.rs
@@ -129,14 +129,81 @@ pub async fn get_all_episodes(
 ///
 /// This method implements the lazy loading pattern: memory → redb → Turso.
 /// It first checks the in-memory cache, then falls back to cache storage
-/// (redb), and finally to durable storage (Turso) if needed.
+/// (redb), and finally to durable storage (Turso) if needed. This is what
+/// makes `pattern list` / `pattern search` work across process boundaries,
+/// since the in-memory `patterns_fallback` is empty in a fresh CLI process.
 ///
 /// Used primarily for backfilling embeddings and comprehensive pattern retrieval.
 pub async fn get_all_patterns(
     patterns_fallback: &tokio::sync::RwLock<HashMap<crate::episode::PatternId, Pattern>>,
+    cache_storage: Option<&Arc<dyn crate::StorageBackend>>,
+    turso_storage: Option<&Arc<dyn crate::StorageBackend>>,
 ) -> Result<Vec<Pattern>> {
-    let patterns = patterns_fallback.read().await;
-    Ok(patterns.values().cloned().collect())
+    use crate::episode::PatternId;
+
+    let mut all_patterns: HashMap<PatternId, Pattern> = HashMap::new();
+
+    // 1) In-memory cache
+    {
+        let patterns = patterns_fallback.read().await;
+        for (id, pattern) in patterns.iter() {
+            all_patterns.insert(*id, pattern.clone());
+        }
+    }
+
+    // 2) Cache storage (redb)
+    if let Some(cache) = cache_storage {
+        match cache.get_all_patterns().await {
+            Ok(patterns) => {
+                debug!(
+                    cache_count = patterns.len(),
+                    "Fetched patterns from cache storage"
+                );
+                for pattern in patterns {
+                    all_patterns.entry(pattern.id()).or_insert(pattern);
+                }
+            }
+            Err(e) => {
+                debug!("Failed to fetch patterns from cache storage: {}", e);
+            }
+        }
+    }
+
+    // 3) Durable storage (Turso)
+    if let Some(turso) = turso_storage {
+        match turso.get_all_patterns().await {
+            Ok(patterns) => {
+                debug!(
+                    turso_count = patterns.len(),
+                    "Fetched patterns from durable storage"
+                );
+                for pattern in patterns {
+                    all_patterns.entry(pattern.id()).or_insert(pattern);
+                }
+            }
+            Err(e) => {
+                debug!("Failed to fetch patterns from durable storage: {}", e);
+            }
+        }
+    }
+
+    // 4) Update in-memory cache with any newly discovered patterns
+    {
+        let mut patterns_cache = patterns_fallback.write().await;
+        for (id, pattern) in &all_patterns {
+            if !patterns_cache.contains_key(id) {
+                patterns_cache.insert(*id, pattern.clone());
+            }
+        }
+    }
+
+    let total_count = all_patterns.len();
+    info!(
+        total_patterns = total_count,
+        "Retrieved all patterns from all storage backends"
+    );
+
+    Ok(all_patterns.into_values().collect())
 }
 
 /// List episodes with optional filtering, using proper lazy loading.

--- a/memory-core/src/memory/queries/mod.rs
+++ b/memory-core/src/memory/queries/mod.rs
@@ -164,7 +164,9 @@ pub async fn get_all_patterns(
                 }
             }
             Err(e) => {
-                debug!("Failed to fetch patterns from cache storage: {}", e);
+                // Prefer warn so empty list after backend failure is diagnosable
+                // (issue #831 symptom looks identical to "no patterns").
+                tracing::warn!("Failed to fetch patterns from cache storage: {}", e);
             }
         }
     }
@@ -182,7 +184,7 @@ pub async fn get_all_patterns(
                 }
             }
             Err(e) => {
-                debug!("Failed to fetch patterns from durable storage: {}", e);
+                tracing::warn!("Failed to fetch patterns from durable storage: {}", e);
             }
         }
     }

--- a/memory-core/src/memory/query_api.rs
+++ b/memory-core/src/memory/query_api.rs
@@ -45,7 +45,12 @@ impl SelfLearningMemory {
 
     /// Get all patterns with proper lazy loading from storage backends.
     pub async fn get_all_patterns(&self) -> Result<Vec<Pattern>> {
-        queries::get_all_patterns(&self.patterns_fallback).await
+        queries::get_all_patterns(
+            &self.patterns_fallback,
+            self.cache_storage.as_ref(),
+            self.turso_storage.as_ref(),
+        )
+        .await
     }
 
     /// List episodes with optional filtering, using proper lazy loading.

--- a/memory-core/src/memory/retrieval/patterns.rs
+++ b/memory-core/src/memory/retrieval/patterns.rs
@@ -28,15 +28,21 @@ impl SelfLearningMemory {
         context: &TaskContext,
         limit: usize,
     ) -> Vec<Pattern> {
-        let mut patterns = self.patterns_fallback.write().await;
+        // Hydrate from all storage backends (lazy loading) so patterns created
+        // in a previous process are retrievable in a fresh CLI invocation.
+        let all_patterns = match self.get_all_patterns().await {
+            Ok(patterns) => patterns,
+            Err(e) => {
+                debug!("Failed to load patterns from storage: {}", e);
+                Vec::new()
+            }
+        };
 
         debug!(
-            total_patterns = patterns.len(),
+            total_patterns = all_patterns.len(),
             limit = limit,
             "Retrieving relevant patterns"
         );
-
-        let all_patterns: Vec<Pattern> = patterns.values().cloned().collect();
 
         // Rank patterns by relevance and quality (includes effectiveness scoring)
         let mut ranked = rank_patterns(all_patterns, context);
@@ -44,15 +50,19 @@ impl SelfLearningMemory {
         // Deduplicate
         ranked = deduplicate_patterns(ranked);
 
-        // Record retrieval for effectiveness tracking
-        for pattern in &mut ranked.iter_mut().take(limit) {
-            pattern.record_retrieval();
-            // Update the stored pattern with retrieval count
-            patterns.insert(pattern.id(), pattern.clone());
-        }
-
         // Limit results
         ranked.truncate(limit);
+
+        // Record retrieval for in-memory effectiveness tracking (best-effort).
+        // Write-back is limited to the process-local fallback so we never hold
+        // a lock across durable storage I/O.
+        {
+            let mut patterns = self.patterns_fallback.write().await;
+            for pattern in &mut ranked {
+                pattern.record_retrieval();
+                patterns.insert(pattern.id(), pattern.clone());
+            }
+        }
 
         info!(
             retrieved_count = ranked.len(),

--- a/memory-core/src/memory/tests/lazy_loading_tests.rs
+++ b/memory-core/src/memory/tests/lazy_loading_tests.rs
@@ -2,7 +2,11 @@
 
 use crate::SelfLearningMemory;
 use crate::episode::ExecutionStep;
-use crate::types::{ExecutionResult, TaskContext, TaskOutcome, TaskType};
+use crate::patterns::{Pattern, PatternEffectiveness};
+use crate::types::{ComplexityLevel, ExecutionResult, TaskContext, TaskOutcome, TaskType};
+use std::collections::HashMap;
+use tokio::sync::RwLock;
+use uuid::Uuid;
 
 /// Test `get_all_episodes` with lazy loading.
 #[tokio::test(flavor = "multi_thread")]
@@ -118,4 +122,71 @@ pub async fn test_get_episode_lazy_loading() {
     // The existing get_episode method with lazy loading should work
     let episode = memory.get_episode(episode_id).await.unwrap();
     assert_eq!(episode.task_description, "Test lazy loading");
+}
+
+/// Issue #831: patterns extracted on complete are visible via get_all_patterns.
+#[tokio::test(flavor = "multi_thread")]
+pub async fn test_get_all_patterns_after_complete() {
+    let test_config = crate::MemoryConfig {
+        quality_threshold: 0.0,
+        pattern_extraction_threshold: 0.0,
+        enable_summarization: false,
+        enable_embeddings: false,
+        batch_config: None,
+        ..Default::default()
+    };
+    let memory = SelfLearningMemory::with_config(test_config);
+
+    let episode_id = memory
+        .start_episode(
+            "rust error handling".to_string(),
+            TaskContext {
+                language: Some("rust".to_string()),
+                framework: None,
+                complexity: ComplexityLevel::Moderate,
+                domain: "rust".to_string(),
+                tags: vec![],
+            },
+            TaskType::CodeGeneration,
+        )
+        .await;
+
+    memory
+        .complete_episode(
+            episode_id,
+            TaskOutcome::Success {
+                verdict: "ok".to_string(),
+                artifacts: vec![],
+            },
+        )
+        .await
+        .expect("complete");
+
+    let patterns = memory.get_all_patterns().await.expect("get_all_patterns");
+    assert!(
+        !patterns.is_empty(),
+        "complete should extract at least a ContextPattern (issue #831)"
+    );
+}
+
+/// queries::get_all_patterns with empty backends returns in-memory only.
+#[tokio::test]
+pub async fn test_get_all_patterns_memory_only() {
+    let id = Uuid::new_v4();
+    let sample = Pattern::ContextPattern {
+        id,
+        context_features: vec!["domain:test".to_string()],
+        recommended_approach: "Test".to_string(),
+        evidence: vec![],
+        success_rate: 1.0,
+        effectiveness: PatternEffectiveness::new(),
+    };
+
+    let fallback = RwLock::new(HashMap::from([(id, sample)]));
+    // `queries` is a private sibling of `tests` under `memory`.
+    let result = super::super::queries::get_all_patterns(&fallback, None, None)
+        .await
+        .expect("get_all_patterns");
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].id(), id);
 }

--- a/memory-core/src/patterns/types.rs
+++ b/memory-core/src/patterns/types.rs
@@ -144,8 +144,14 @@ impl PatternEffectiveness {
 }
 
 /// Pattern types extracted from episodes
+///
+/// NOTE: This enum is intentionally NOT `#[serde(tag = "type")]` (internally
+/// tagged). Postcard cannot deserialize internally-tagged enums, which made
+/// patterns unreadable from storage (issue #831). It uses the default
+/// externally-tagged representation (postcard-compatible). Variant names are
+/// `rename_all = "snake_case"` for stable JSON keys.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum Pattern {
     /// Sequence of tools used successfully
     ToolSequence {
@@ -272,5 +278,38 @@ impl Pattern {
     pub fn record_application(&mut self, success: bool, reward_delta: f32) {
         self.effectiveness_mut()
             .record_application(success, reward_delta);
+    }
+}
+
+#[cfg(test)]
+mod postcard_regression_tests {
+    use super::*;
+    use crate::types::{ComplexityLevel, TaskContext};
+
+    fn sample_pattern() -> Pattern {
+        let context = TaskContext {
+            language: Some("rust".to_string()),
+            framework: Some("tokio".to_string()),
+            complexity: ComplexityLevel::Moderate,
+            domain: "web-api".to_string(),
+            tags: vec!["async".to_string()],
+        };
+        Pattern::ToolSequence {
+            id: Uuid::new_v4(),
+            tools: vec!["cargo".to_string(), "rustc".to_string()],
+            context,
+            success_rate: 1.0,
+            avg_latency: chrono::Duration::milliseconds(42),
+            occurrence_count: 1,
+            effectiveness: PatternEffectiveness::new(),
+        }
+    }
+
+    #[test]
+    fn pattern_postcard_roundtrip() {
+        let p = sample_pattern();
+        let bytes = postcard::to_allocvec(&p).expect("serialize");
+        let back: Pattern = postcard::from_bytes(&bytes).expect("deserialize (issue #831)");
+        assert_eq!(back, p);
     }
 }

--- a/memory-core/src/storage/mod.rs
+++ b/memory-core/src/storage/mod.rs
@@ -109,6 +109,17 @@ pub trait StorageBackend: Send + Sync {
     /// Returns error if storage operation fails
     async fn get_pattern(&self, id: PatternId) -> Result<Option<Pattern>>;
 
+    /// Retrieve all stored patterns.
+    ///
+    /// Backends that persist patterns should override this so that
+    /// `pattern list` / `pattern search` work across process boundaries
+    /// (the in-memory `patterns_fallback` is empty in a fresh CLI process).
+    /// The default returns an empty list to avoid breaking backends that
+    /// only implement single-pattern retrieval.
+    async fn get_all_patterns(&self) -> Result<Vec<Pattern>> {
+        Ok(Vec::new())
+    }
+
     /// Store a heuristic
     ///
     /// # Arguments

--- a/memory-mcp/Cargo.toml
+++ b/memory-mcp/Cargo.toml
@@ -27,9 +27,9 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 # Local dependencies
-do-memory-core = { path = "../memory-core", version = "0.2.0", features = ["agentfs"] }
-do-memory-storage-turso = { path = "../memory-storage-turso", version = "0.2.0" }
-do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.2.0" }
+do-memory-core = { path = "../memory-core", version = "0.1.35", features = ["agentfs"] }
+do-memory-storage-turso = { path = "../memory-storage-turso", version = "0.1.35" }
+do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.35" }
 
 # MCP-specific dependencies
 parking_lot = "0.12.5"

--- a/memory-storage-redb/Cargo.toml
+++ b/memory-storage-redb/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/do-memory-storage-redb"
 
 [dependencies]
 # Core dependencies
-do-memory-core = { path = "../memory-core", version = "0.2.0" }
+do-memory-core = { path = "../memory-core", version = "0.1.35" }
 
 # Async runtime
 tokio = { workspace = true, features = ["full"] }

--- a/memory-storage-redb/src/backend_impl.rs
+++ b/memory-storage-redb/src/backend_impl.rs
@@ -30,6 +30,11 @@ impl StorageBackend for RedbStorage {
         self.get_pattern(id).await
     }
 
+    async fn get_all_patterns(&self) -> Result<Vec<Pattern>> {
+        self.get_all_patterns(&crate::episodes::RedbQuery::default())
+            .await
+    }
+
     async fn store_heuristic(&self, heuristic: &Heuristic) -> Result<()> {
         self.store_heuristic(heuristic).await
     }

--- a/memory-storage-redb/src/lib.rs
+++ b/memory-storage-redb/src/lib.rs
@@ -160,7 +160,8 @@ pub(crate) const PROCEDURAL_TABLE: TableDefinition<&str, &[u8]> =
 /// - v1: Initial version (pre-versioning)
 /// - v2: Added checkpoints field to Episode (ADR-044 Feature 3)
 /// - v3: Added weight to relationships, added EpisodePatternRelationship (WG-123)
-pub(crate) const SCHEMA_VERSION: u64 = 3;
+/// - v4: Pattern externally-tagged for postcard (#831; was internally tagged)
+pub(crate) const SCHEMA_VERSION: u64 = 4;
 
 pub(crate) const SCHEMA_VERSION_TABLE: TableDefinition<&str, u64> =
     TableDefinition::new("schema_version");

--- a/memory-storage-redb/src/patterns.rs
+++ b/memory-storage-redb/src/patterns.rs
@@ -110,15 +110,74 @@ impl RedbStorage {
                 let (_, bytes_guard) = result
                     .map_err(|e| Error::Storage(format!("Failed to read pattern entry: {}", e)))?;
 
-                let pattern: Pattern = postcard::from_bytes(bytes_guard.value())
-                    .map_err(|e| Error::Storage(format!("Failed to deserialize pattern: {}", e)))?;
-
-                patterns.push(pattern);
+                // Skip unreadable rows (e.g. pre-v4 internally-tagged postcard) so one
+                // stale entry cannot fail the entire list (issue #831).
+                match postcard::from_bytes::<Pattern>(bytes_guard.value()) {
+                    Ok(pattern) => patterns.push(pattern),
+                    Err(e) => {
+                        debug!("Skipping undecodable pattern cache entry: {}", e);
+                    }
+                }
             }
 
             Ok(patterns)
         })
         .await
         .map_err(|e| Error::Storage(format!("Task join error: {}", e)))?
+    }
+}
+
+#[cfg(test)]
+mod pattern_persistence_tests {
+    use super::*;
+    use do_memory_core::StorageBackend;
+    use do_memory_core::patterns::PatternEffectiveness;
+    use do_memory_core::types::{ComplexityLevel, TaskContext};
+    use uuid::Uuid;
+
+    fn sample_pattern() -> Pattern {
+        let context = TaskContext {
+            language: Some("rust".to_string()),
+            framework: Some("tokio".to_string()),
+            complexity: ComplexityLevel::Moderate,
+            domain: "cli".to_string(),
+            tags: vec!["regression".to_string()],
+        };
+        Pattern::ToolSequence {
+            id: Uuid::new_v4(),
+            tools: vec!["cargo".to_string(), "test".to_string()],
+            context,
+            success_rate: 1.0,
+            avg_latency: chrono::Duration::milliseconds(10),
+            occurrence_count: 1,
+            effectiveness: PatternEffectiveness::new(),
+        }
+    }
+
+    /// Issue #831: patterns must survive postcard serialize + get_all_patterns.
+    #[tokio::test]
+    async fn store_and_list_patterns_across_trait() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("patterns.redb");
+        let storage = RedbStorage::new(&path).await.expect("open redb");
+
+        let pattern = sample_pattern();
+        let id = pattern.id();
+        storage.store_pattern(&pattern).await.expect("store");
+
+        // Via concrete API
+        let listed = storage
+            .get_all_patterns(&RedbQuery::default())
+            .await
+            .expect("list");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id(), id);
+
+        // Via StorageBackend trait (what memory-core uses for CLI list)
+        let via_trait = StorageBackend::get_all_patterns(&storage)
+            .await
+            .expect("trait list");
+        assert_eq!(via_trait.len(), 1);
+        assert_eq!(via_trait[0].id(), id);
     }
 }

--- a/memory-storage-turso/Cargo.toml
+++ b/memory-storage-turso/Cargo.toml
@@ -34,8 +34,8 @@ compression-gzip = ["flate2"]
 
 [dependencies]
 # Core dependencies
-do-memory-core = { path = "../memory-core", version = "0.2.0", features = ["hybrid_search"] }
-do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.2.0" }
+do-memory-core = { path = "../memory-core", version = "0.1.35", features = ["hybrid_search"] }
+do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.35" }
 
 # Async runtime
 tokio = { workspace = true, features = ["full"] }

--- a/memory-storage-turso/src/cache/wrapper_backend.rs
+++ b/memory-storage-turso/src/cache/wrapper_backend.rs
@@ -44,6 +44,13 @@ impl StorageBackend for CachedTursoStorage {
             .map_err(|e| Error::Storage(format!("Cache get error: {}", e)))
     }
 
+    async fn get_all_patterns(&self) -> Result<Vec<Pattern>> {
+        self.storage
+            .get_all_patterns()
+            .await
+            .map_err(|e| Error::Storage(format!("Cache get-all error: {}", e)))
+    }
+
     async fn store_heuristic(&self, heuristic: &Heuristic) -> Result<()> {
         self.store_heuristic_cached(heuristic)
             .await

--- a/memory-storage-turso/src/resilient.rs
+++ b/memory-storage-turso/src/resilient.rs
@@ -198,6 +198,11 @@ impl StorageBackend for ResilientStorage {
             .await
     }
 
+    async fn get_all_patterns(&self) -> Result<Vec<Pattern>> {
+        self.circuit_call(move |s| async move { s.get_all_patterns().await })
+            .await
+    }
+
     async fn store_heuristic(&self, heuristic: &Heuristic) -> Result<()> {
         let heuristic = heuristic.clone();
         self.circuit_call(move |s| async move { s.store_heuristic(&heuristic).await })

--- a/memory-storage-turso/src/storage/patterns/crud.rs
+++ b/memory-storage-turso/src/storage/patterns/crud.rs
@@ -201,6 +201,41 @@ impl TursoStorage {
         }
     }
 
+    /// Retrieve all patterns from Turso storage.
+    pub async fn get_all_patterns(&self) -> Result<Vec<CorePattern>> {
+        debug!("Retrieving all patterns from Turso storage");
+        let (conn, _conn_id) = self.get_connection_with_id().await?;
+
+        const SQL: &str = r#"
+            SELECT pattern_id, pattern_type, pattern_data, success_rate,
+                   context_domain, context_language, context_tags, occurrence_count,
+                   created_at, updated_at
+            FROM patterns
+        "#;
+
+        let stmt = self
+            .prepared_cache
+            .get_or_prepare(&conn, SQL)
+            .await
+            .map_err(|e| Error::Storage(format!("Failed to prepare statement: {}", e)))?;
+
+        let mut rows = stmt
+            .query(libsql::params![])
+            .await
+            .map_err(|e| Error::Storage(format!("Failed to query patterns: {}", e)))?;
+
+        let mut patterns = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| Error::Storage(format!("Failed to fetch pattern row: {}", e)))?
+        {
+            patterns.push(super::row::row_to_pattern(&row)?);
+        }
+
+        Ok(patterns)
+    }
+
     /// Query patterns with filters
     pub async fn query_patterns(&self, query: &super::PatternQuery) -> Result<Vec<CorePattern>> {
         debug!("Querying patterns with filters: {:?}", query);

--- a/memory-storage-turso/src/trait_impls/mod.rs
+++ b/memory-storage-turso/src/trait_impls/mod.rs
@@ -43,6 +43,10 @@ impl StorageBackend for super::TursoStorage {
         super::TursoStorage::get_pattern(self, id).await
     }
 
+    async fn get_all_patterns(&self) -> Result<Vec<do_memory_core::Pattern>> {
+        super::TursoStorage::get_all_patterns(self).await
+    }
+
     async fn store_heuristic(&self, heuristic: &do_memory_core::Heuristic) -> Result<()> {
         super::TursoStorage::store_heuristic(self, heuristic).await
     }

--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -1,7 +1,28 @@
 # GOAP Actions Backlog
 
-- **Last Updated**: 2026-06-30 (WG-176..182 complete via PR #675; deps maintenance done)
+- **Last Updated**: 2026-07-15 (CLI UX patch #829–#832)
 - **Archived Plans**: `plans/archive/2026-03-consolidation/`
+
+## Active Actions (v0.1.35 CLI UX Patch)
+
+| ID | Action | Status |
+|----|--------|--------|
+| ACT-190 | #831 Pattern postcard + get_all_patterns + e2e | ✅ Done |
+| ACT-191 | #830 Honor --db-path for redb_path | ✅ Done |
+| ACT-192 | #829 config init/show-template + serde default + example | ✅ Done |
+| ACT-193 | #832 storage_mode alias + config show | ✅ Done |
+| ACT-194 | Prevention tests (postcard, redb list, loader, snapshot) | ✅ Done |
+| ACT-195 | Update plans/ + CHANGELOG for 0.1.35 | ✅ Done |
+| ACT-196 | Open PR + CI green + merge | 🟡 Next |
+| ACT-197 | Cut v0.1.35 via release.yml (closes #828) | ⏳ After merge |
+
+### Prevention permanently (do not regress)
+- Never `#[serde(tag=)]` on postcard types
+- StorageBackend new methods → all backends
+- CLI path flags → set redb_path
+- Cross-process storage features → e2e CLI test
+
+---
 
 ## Completed Actions Summary
 

--- a/plans/GOALS.md
+++ b/plans/GOALS.md
@@ -1,8 +1,17 @@
 # GOAP Goals Index
 
-- **Last Updated**: 2026-06-30 (WG-176..182 complete via PR #675; dependency maintenance done)
-- **Source ADR**: ADR-037, ADR-052, ADR-053, ADR-057, ADR-058 (Accepted)
-- **Status**: Active
+- **Last Updated**: 2026-07-15 (CLI UX patch v0.1.35)
+- **Status**: Active — code complete for #829–#832; release pending merge
+
+## v0.1.35 Goals (CLI UX Patch)
+
+| Goal | Issues | Status |
+|------|--------|--------|
+| Patterns durable + listable across CLI processes | #831 | ✅ |
+| Project-local DB via --db-path / MEMORY_DB_PATH | #830 | ✅ |
+| Discoverable config (init, template, partial TOML) | #829 | ✅ |
+| Clear storage_mode story | #832 | ✅ |
+| Align version to 0.1.35 and cut release | #828 | 🟡 code ready |
 
 ---
 

--- a/plans/GOAP_CLI_UX_PATCH_0.1.35_2026-07-15.md
+++ b/plans/GOAP_CLI_UX_PATCH_0.1.35_2026-07-15.md
@@ -1,0 +1,96 @@
+# GOAP: CLI UX Patch Sprint v0.1.35
+
+**Date**: 2026-07-15  
+**Branch**: `fix/0.1.35-patch-issues`  
+**Issues**: #829, #830, #831, #832, #828  
+
+---
+
+## Problem Summary (user reports against v0.1.34 release binary)
+
+| Issue | Symptom | Root cause |
+|-------|---------|------------|
+| **#831** | `pattern list` / `search` return 0 after `episode complete` logged "Successfully cached pattern" | (1) `Pattern` was `#[serde(tag = "type")]` — postcard cannot deserialize internally-tagged enums; (2) `get_all_patterns` only read the empty in-memory map in a fresh process |
+| **#830** | `--db-path` / `MEMORY_DB_PATH` ignored | Only set `database.db_path` (Turso local SQLite); redb kept opening default XDG path |
+| **#829** | Config format hard to discover; partial TOML failed | No `config init`/`show-template`; sections required all fields (no `#[serde(default)]`) |
+| **#832** | Users put `storage_mode` under `[storage]` | Canonical field is `[database].storage_mode`; alias not accepted |
+| **#828** | Release drift (auto) | Workspace was `0.2.0` vs tag `v0.1.34`; relabeled to `0.1.35` patch |
+
+---
+
+## Implementation (done)
+
+### #831 Pattern retrieval
+- `Pattern` → externally-tagged serde (postcard-compatible) + postcard round-trip unit test
+- `StorageBackend::get_all_patterns` + redb/Turso/Cached/Resilient impls
+- `queries::get_all_patterns` hydrates memory → redb → Turso
+- `retrieve_relevant_patterns` uses lazy load (cross-process)
+- e2e `test_pattern_discovery` asserts `pattern list` > 0 across processes
+- redb `store_and_list_patterns_across_trait` regression test
+
+### #830 `--db-path`
+- Always set `redb_path` from `--db-path` / `MEMORY_DB_PATH`
+- Default `storage_mode=local` when path set and no Turso URL
+
+### #829 Config discoverability
+- `config init` / `config show-template`
+- `#[serde(default)]` on all config sections (partial TOML OK)
+- `memory-cli/config/do-memory-cli.example.toml`
+- Docs: README, CONFIGURATION_GUIDE, LOCAL_DATABASE_SETUP, CLI_COMMANDS
+
+### #832 storage_mode UX
+- Accept `[storage].storage_mode` alias → normalize into `[database]`
+- `config show` displays `Storage Mode` + `DB Path`
+
+### #828 Version
+- Workspace + publishable crates → `0.1.35` (not premature 0.2.0)
+- CHANGELOG `[0.1.35]` section
+
+---
+
+## Prevention (so this class of bug does not return)
+
+| Guard | Location | Purpose |
+|-------|----------|---------|
+| Postcard round-trip test on `Pattern` | `memory-core/src/patterns/types.rs` | Fail CI if enum serde becomes postcard-incompatible again |
+| redb store+list via trait | `memory-storage-redb/src/patterns.rs` | Ensure `get_all_patterns` stays wired |
+| e2e cross-process `pattern list` | `tests/e2e/cli_workflows.rs` | Catch empty list after complete in real CLI |
+| Loader unit tests | `memory-cli/src/config/loader/mod.rs` | Partial config + storage_mode alias |
+| Snapshot for `config --help` | `memory-cli/tests/snapshots/` | Detect missing init/show-template |
+| Example config in tree | `memory-cli/config/do-memory-cli.example.toml` | Documented shape next to binary source |
+| CLI skill verification | `.agents/skills/do-memory-cli-ops/` | Manual smoke: create → complete → list patterns with project-local db |
+
+### Agent checklist (new, for CLI bugs)
+1. Prefer Skill + CLI smoke over unit-only tests for cross-process storage.
+2. Never use `#[serde(tag = "...")]` on types persisted with **postcard**.
+3. Any new `StorageBackend` method needs redb + Turso + Cached + Resilient impls.
+4. CLI flags that change "where data lives" must set **both** `db_path` and `redb_path` (or document exclusivity).
+5. Config fields: put selection knobs under `[database]`; allow `[storage]` aliases with `normalize_*`.
+
+---
+
+## Verification (2026-07-15)
+
+| Check | Result |
+|-------|--------|
+| `cargo check` workspace | ✅ |
+| Targeted nextest (core/redb/cli) | ✅ (property tests slowed under load; cases capped) |
+| Release CLI build | ✅ |
+| CLI: `config init` / `show-template` / partial TOML | ✅ |
+| CLI: `[storage].storage_mode` → local | ✅ |
+| CLI: `--db-path` / `MEMORY_DB_PATH` open custom redb | ✅ |
+| CLI: create → complete → `pattern list` count=1; `pattern search rust` finds 1 | ✅ |
+
+---
+
+## Remaining / out of scope this PR
+
+- **#828 cut release**: tag `v0.1.35` via `release.yml` after merge to main (do not bypass workflow)
+- Config commands still init storage even for `show-template` (pre-existing; optional follow-up)
+- `pattern search` semantic quality still depends on embeddings (list is the durable-store proof)
+
+---
+
+## Status
+
+**Sprint complete for code fixes.** Ready for commit → PR → merge → release pipeline for `v0.1.35`.

--- a/plans/GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md
+++ b/plans/GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md
@@ -1,0 +1,513 @@
+# GOAP Codebase, Workflow, Documentation, and Skills Improvement Plan
+
+- **Status**: Proposed
+- **Date**: 2026-07-14
+- **Audit commit**: `a8b7d6d6a350c3f431b5564332b8a5c1365aefb9`
+- **Audit branch**: `main`
+- **Scope**: Planning only; this audit changes no implementation, workflow, root documentation, or skill files
+- **Related decisions**: ADR-022, ADR-033, ADR-039, ADR-042, ADR-059, ADR-072, ADR-073, ADR-074
+
+## 1. Objective
+
+Move the repository from contradictory claims and partially enforced controls to an evidence-backed state in which:
+
+1. security and data-correctness boundaries are real rather than descriptive;
+2. local and CI quality gates fail when their advertised conditions fail;
+3. release and publishing automation is reproducible and has one authority;
+4. `.agents/skills/` is discoverable, current, and evaluated by executable tests;
+5. README and canonical planning documents describe the implementation that exists; and
+6. new memory-system features are piloted only after their baselines and acceptance metrics exist.
+
+This is a GOAP backlog, not a statement that any listed remediation is already implemented.
+
+## 2. Evidence rules
+
+Findings use three confidence classes:
+
+- **Verified local**: observed in files or commands at the audit commit.
+- **Remote-unverified**: GitHub release, PR, tag, CI-run, or crates.io state not queried during this audit. These facts must not be inferred from plans.
+- **Proposal**: a new feature or design whose value must be established by a spike or benchmark.
+
+Every future completion claim must record `{command, scope, commit, timestamp, result, artifact}`. Test annotation counts, prose estimates, and old CI links are not equivalent to a current test run.
+
+## 3. Verified current state
+
+`cargo metadata --format-version 1 --no-deps` reports nine workspace packages, all at `0.2.0`: `do-memory-core`, `do-memory-storage-redb`, `do-memory-storage-turso`, `do-memory-test-utils`, `do-memory-mcp`, `do-memory-cli`, `do-memory-benches`, `e2e-tests`, and `do-memory-examples`.
+
+| Area | Verified evidence | Consequence |
+|---|---|---|
+| Version truth | `Cargo.toml` and Cargo metadata report `0.2.0`; `plans/STATUS/CURRENT.md`, `plans/ROADMAPS/ROADMAP_ACTIVE.md`, and `plans/GOAP_STATE.md` still report `0.1.33`/`0.1.34` | Canonical plans cannot currently establish release state |
+| Planning governance | ADR-039 limits the active plan set and defines canonical roles, but numerous dated GOAP files remain active; ADR identifiers 025 and 054 are duplicated; referenced ADR-061 is absent | Cross-references and status propagation are ambiguous |
+| Coverage | `scripts/quality-gates.sh` and `tests/quality_gates.rs` default to 70% and skip optional gates; `AGENTS.md` says 90%; Codecov uses other targets | “Coverage passed” has no single meaning |
+| Security audit | `.github/workflows/ci.yml` uses `cargo audit || echo`; `security.yml` uses `cargo audit ... || true` | Vulnerabilities or tool failures can produce a green job |
+| Quality orchestration | `quality-gates.sh` runs doctest/docs/LOC checks and `tests/quality_gates.rs`, but not the advertised full build, nextest, and strict clippy sequence; workflows do not invoke it | Local and CI gates with the same name cover different surfaces |
+| Package wrappers | `scripts/build-rust.sh` rejects hyphens although real packages are `do-memory-*`; `tests/quality_gates.rs` invokes nonexistent `memory-core` and can fall back to a baseline | Intended checks can fail to execute yet appear successful |
+| Release | `release.yml` preflight checks tag/version equality only; historical plans and release skills contain manual `gh release create` instructions despite the automated-only policy | Release prerequisites are not enforced consistently |
+| Publishing | `publish-crates.yml` omits `--locked`, uses fixed `sleep 30`, makes semver informational, and has no CLI publish job, contradicting current AGENTS claims | Reproducibility and documented pipeline order are not trustworthy |
+| Legacy code execution | `memory-mcp/src/sandbox/mod.rs` contains a Node executor that relies on regex/wrapper restrictions and does not call the existing `apply_isolation` helper; however, MCP does not register a working execution tool, and `handle_execute_code` returns that code execution is no longer available. README still advertises Wasmtime and a nonexistent `wasmtime-backend` feature | Fail-closed MCP behavior must be preserved; dead/experimental code and public contracts must be reconciled before any new backend is exposed |
+| Retrieval cache | `retrieve_relevant_context` keys cache entries by query/domain/limit while ranking also uses language, framework, tags, complexity, mode, and embedding state | Context-distinct queries can reuse incorrect cached rankings |
+| Async storage | Immediate step persistence and buffered flush hold `episodes_fallback.write()` across backend awaits | Slow storage can block unrelated readers/writers and complicate concurrency |
+| Capacity | Completion removes evictions from memory but explicitly logs that backend deletion is unimplemented | Capacity, retention, and deletion are not durable across restart/backfill |
+| Local embeddings | Real-model load failure silently installs mock vectors, and `is_available` returns true when any model is loaded | Health can report available while semantic quality is invalid |
+| Retry controls | `retry_queue_timeout` is configurable but unused; limiter permits cover first attempts and backoff sleeps | Backpressure semantics differ from the public configuration |
+| Source boundaries | Current production files above 500 LOC include `memory-core/src/retry/mod.rs` (577), `memory-cli/src/commands/embedding.rs` (539), `memory-core/src/memory/retrieval/context.rs` (528), `memory-core/src/embeddings/local.rs` (507), and `memory-core/src/memory/checkpoint/operations.rs` (505) | The stated hard source-size invariant currently fails |
+| Skills evals | 20 eval files execute only `true`; `pr-readiness` uses `evals` while the runner reads `tests`; `ci-poll` has no eval; missing/zero tests exit successfully | Skill confidence is largely synthetic |
+| Skill routing | `skill-rules.json` has four rules covering three unique skills out of 33 | Critical skills rely on accidental discovery and broad keyword collisions |
+| Skill policy | Release skills contradict automated-only releases; several skills use stale commands, environment variables, plan paths, tool names, or unsafe mutation defaults | Following a skill can violate repository or agent policy |
+| README contract | The episode `TaskContext` example is stale; Wasmtime feature claims do not match `memory-mcp/Cargo.toml`; storage/provider defaults are inconsistent | New users receive uncompilable or inaccurate guidance |
+
+## 4. GOAP state model
+
+### Initial state
+
+```text
+truth_reconciled = false
+remote_release_state_attempted = false
+remote_release_state_verified = false
+sandbox_capability_boundary = false
+retrieval_identity_complete = false
+storage_awaits_lock_free = false
+durable_eviction = false
+embedding_health_truthful = false
+retry_backpressure_effective = false
+gates_match_policy = false
+release_pipeline_enforces_preconditions = false
+skill_evals_executable = false
+skill_routes_complete = false
+docs_match_code = false
+plan_registry_unique = false
+feature_pilots_have_baselines = false
+```
+
+### Goal state
+
+```text
+truth_reconciled = true
+remote_release_state_verified = true
+critical_security_and_correctness_actions = complete
+all_required_gates_are_blocking_and_reproducible = true
+release_and_publish_authority_is_singular = true
+skill_contracts_are_routed_and_executable = true
+docs_match_generated_or_verified_contracts = true
+plan_and_adr_registry_is_unambiguous = true
+feature_pilots_have_go_no_go_evidence = true
+```
+
+## 5. Priority and dependency strategy
+
+- **P0**: prevent security-boundary misrepresentation, incorrect retrieval, write contention/data loss, false-green gates, and unsafe releases.
+- **P1**: make provider health, retry/audit behavior, benchmarks, skills, and documentation trustworthy.
+- **P2**: run evidence-driven feature pilots after P0/P1 instrumentation exists.
+
+Execution pattern: Phase 0 is sequential. Phase 1 actions may run in parallel after their ADR/precondition is accepted. Phase 2 workflow actions may run in parallel but converge on one parity check. Phase 3 skill and documentation work may run in parallel after the authority matrix is accepted. Phase 4 pilots are independent, but none may be called shipped without measured exit criteria.
+
+Critical path:
+
+```text
+T0.1 -> T0.2 -> {S1.1, S1.2, S1.3, W2.1, K3.1}
+S1.1 -> S1.5
+S1.2 -> F4.1
+S1.3 -> S1.4 -> F4.2
+W2.1 -> W2.2 -> W2.3 -> W2.4
+K3.1 -> K3.2 -> K3.3
+{S1.*, W2.*, K3.*, D3.*} -> V5.1
+selected F4.* -> V5.1 (only when a pilot is promoted)
+```
+
+## 6. Work packages and atomic action backlog
+
+The named S/W/K/D/F entries below are work packages. Only the atomic child actions in section 6.1 may be scheduled or marked complete independently; a work package closes only when every required child and its validation evidence pass.
+
+### Phase 0 — Truth freeze and decision authority
+
+#### T0.1 — Capture a reproducible baseline
+
+- **Priority**: P0
+- **Preconditions**: none
+- **Actions**:
+  - record Cargo metadata, active features, current LOC failures, ignored tests, coverage output, audit output, and skill-eval results at one commit;
+  - query git tags, GitHub releases/actions, and crates.io separately; label unavailable remote facts unknown;
+  - store command outputs as CI artifacts or a dated validation record.
+- **Effects**: `remote_release_state_attempted = true`; `remote_release_state_verified = true` only when tag, release, Actions, and crates.io queries succeed. An unavailable remote is recorded as a blocker, not verification.
+- **Acceptance**: every number in canonical status has command, scope, commit, timestamp, and artifact; remote classification cannot proceed while `remote_release_state_verified = false`.
+
+#### T0.2 — Accept ADR-072 and reconcile canonical plans
+
+- **Priority**: P0
+- **Depends on**: T0.1
+- **Actions**:
+  - adopt the authority matrix and automated-only release path;
+  - decide whether `0.2.0` is unreleased development, a release candidate, or already released based on remote evidence;
+  - update CURRENT, ROADMAP, GOALS, ACTIONS, GOAP_STATE, navigation, validation, and gap analysis together;
+  - archive superseded dated plans per ADR-039;
+  - create an ADR/WG registry without rewriting historical records; register duplicate 025/054 aliases and remove invalid ADR-061 claims.
+- **Effects**: `truth_reconciled = true`; `plan_registry_unique = true`.
+- **Acceptance**: one current version state, one release procedure, no unresolved ADR link, no contradictory active status.
+
+### Phase 1 — Security and correctness
+
+#### S1.1 — Preserve fail-closed execution and evaluate a capability boundary
+
+- **Priority**: P0 security/contract accuracy
+- **Depends on**: T0.2; ADR-073 accepted before implementing a new backend
+- **Actions**:
+  - keep `execute_agent_code` absent/unavailable and direct calls rejected while no approved backend exists;
+  - correct README/tool metadata and either remove or quarantine the disconnected legacy Node executor as trusted-development-only code;
+  - run a bounded Wasmtime/WASI feasibility spike; expose no new tool if the spike is rejected;
+  - if approved, implement runtime-enforced network/filesystem/subprocess denial, resource limits, startup self-test, and pinned compiler/runtime artifacts.
+- **Acceptance A — no backend**: tool discovery omits `execute_agent_code`, direct calls fail closed, and docs state unavailable.
+- **Acceptance B — approved backend**: obfuscated network/filesystem/process probes fail at runtime; heap/CPU/output bombs are bounded; tool discovery reports backend and capabilities accurately.
+- **Rollback**: unregister the new backend and return to the already fail-closed state; memory/query functionality remains available.
+
+#### S1.2 — Make retrieval cache identity complete
+
+- **Priority**: P0 correctness
+- **Depends on**: T0.2; ADR-074 accepted
+- **Actions**:
+  - introduce typed `RetrievalRequestIdentity` including normalized context, mode, ranking config, provider/model, index generation, and limit;
+  - use the full identity as the cache key and emit a versioned provenance fingerprint;
+  - normalize tag order and invalidate/bump generation on relevant mutation.
+- **Acceptance**: same query/domain with Rust/Axum and Python/Django contexts yields independent correct results in either request order; provider/index changes cannot reuse stale entries.
+
+#### S1.3 — Remove lock guards from backend await paths
+
+- **Priority**: P0 reliability
+- **Depends on**: T0.2
+- **Actions**:
+  - snapshot/version episode state under a short lock, release it, perform I/O, then merge/commit with conflict detection;
+  - define per-episode sequencing so moving awaits cannot lose concurrent steps;
+  - add blocked-backend concurrency tests.
+- **Acceptance**: while one backend store is held on a barrier, unrelated reads/writes complete; 100 concurrent unique steps persist exactly once; `await_holding_lock` remains denied.
+
+#### S1.4 — Make capacity and deletion durable
+
+- **Priority**: P0 data lifecycle
+- **Depends on**: S1.3
+- **Actions**:
+  - delete evicted episode, summary, embeddings, relationships, and indexes idempotently across cache/durable backends;
+  - return explicit partial-failure state and add reconciliation rather than logging success;
+  - decide whether a lightweight operation journal is required (feature F4.2).
+- **Acceptance**: with capacity one, an evicted episode stays absent after restart/backfill; injected backend failure is observable and repairable.
+
+#### S1.5 — Make embedding availability and artifacts truthful
+
+- **Priority**: P1 correctness/supply chain
+- **Depends on**: S1.1 for shared artifact policy
+- **Actions**:
+  - expose `real`, `degraded-mock`, and `unavailable` states;
+  - fail closed in production unless mock fallback is explicitly enabled for test/dev;
+  - pin model revision/files/dimensions/digests and enforce download size limits.
+- **Acceptance**: corrupt/missing/wrong-digest/oversized artifacts fail or report degraded; mock never reports production-ready; output dimension matches the manifest.
+
+#### S1.6 — Implement retry backpressure semantics
+
+- **Priority**: P1 reliability
+- **Depends on**: T0.2
+- **Actions**:
+  - reject zero concurrency;
+  - apply queue timeout to retry attempts, not initial calls;
+  - release permits during backoff and return a typed queue-timeout error;
+  - document local versus process-wide budgets.
+- **Acceptance**: first attempts proceed under saturated retry permits; queued retry times out within bound; simultaneous retry attempts never exceed the configured maximum.
+
+#### S1.7 — Harden asynchronous audit logging
+
+- **Priority**: P1 security/reliability
+- **Depends on**: T0.2
+- **Actions**:
+  - recursively redact nested objects/arrays and case variants;
+  - initialize rotation state from existing file size;
+  - move blocking writes to a bounded writer task or `spawn_blocking` with drop metrics.
+- **Acceptance**: nested secrets are absent, oversized existing logs rotate on first write, slow storage does not stall request workers, overflow behavior is measured.
+
+### Phase 2 — Trustworthy engineering and release gates
+
+#### W2.1 — Define one gate contract
+
+- **Priority**: P0
+- **Depends on**: T0.2
+- **Actions**:
+  - distinguish measured coverage, current blocking floor, and aspirational target;
+  - use ADR-042’s ratchet only after a fresh baseline; do not claim 90% without evidence;
+  - choose one authoritative command surface for fmt, clippy, build, nextest, doctest, docs, LOC, audit, coverage, semver, and performance;
+  - make CI call the same scripts or generate both from one definition.
+- **Acceptance**: a matrix maps every advertised gate to exactly one blocking implementation and required CI check.
+
+#### W2.2 — Eliminate false-green checks
+
+- **Priority**: P0
+- **Depends on**: W2.1
+- **Actions**:
+  - preserve `cargo audit`, coverage, benchmark, doctest, and subprocess exit status;
+  - structurally parse audit/coverage output and reject missing/malformed reports;
+  - remove dummy benchmark results from gating runs;
+  - do not treat expected required-check cancellation as success.
+- **Acceptance**: fixtures for vulnerability, malformed output, failed benchmark, failed doctest, and cancelled prerequisite all produce nonzero/blocking results.
+
+#### W2.3 — Repair package and wrapper correctness
+
+- **Priority**: P0
+- **Depends on**: W2.1
+- **Actions**:
+  - derive package names/exclusions from Cargo metadata;
+  - accept real hyphenated names in `build-rust.sh`;
+  - assert subprocess success before parsing pattern/complexity/performance results;
+  - add wrapper smoke tests.
+- **Acceptance**: targeted checks run `do-memory-*` packages; nonexistent packages and ineffective exclusions fail immediately.
+
+#### W2.4 — Enforce release/publish preconditions
+
+- **Priority**: P0 supply chain
+- **Depends on**: W2.2, W2.3
+- **Actions**:
+  - require successful validation for the exact release SHA before artifact creation;
+  - run release-state and metadata verification;
+  - use `cargo publish --locked`, blocking semver policy, exact-version sparse-index polling, and valid dependency conditions;
+  - decide and document whether CLI is publishable; implementation and docs must agree;
+  - prohibit manual release creation in plans and skills outside `release.yml` internals.
+- **Acceptance**: bad version, dirty metadata, failed required gate, unavailable dependency version, or semver violation blocks publication; dry-run and single-crate dispatch are tested.
+
+#### W2.5 — Repair benchmark/nightly signal
+
+- **Priority**: P1
+- **Depends on**: W2.2
+- **Actions**:
+  - fail benchmark jobs on execution failure and compare against a real baseline with the documented regression budget;
+  - include CLI benchmarks in path discovery;
+  - upload nightly reports before cleanup, honor slow-test input, and remove duplicate suites;
+  - ratchet ignored-test ceilings.
+- **Acceptance**: synthetic >10% regression blocks; missing Criterion output blocks; nightly artifact/trend contains nonzero real values.
+
+#### W2.6 — Restore source boundaries and module reachability
+
+- **Priority**: P1 maintainability
+- **Depends on**: W2.3
+- **Actions**:
+  - split all five current production files over 500 LOC along type/helper/test boundaries;
+  - consolidate or remove uncompiled duplicate effectiveness, validation, and compatibility modules;
+  - add source-module reachability checking with explicit generated/bin exceptions;
+  - run the LOC gate in required CI.
+- **Acceptance**: zero production files over 500 LOC and zero unexplained orphan `.rs` files.
+
+### Phase 3 — Skills, workflow guidance, and public documentation
+
+#### K3.1 — Define and enforce a skill contract
+
+- **Priority**: P0 agent safety
+- **Depends on**: T0.2
+- **Actions**:
+  - define one eval schema; fail on missing file, unknown top-level key, zero tests, missing `exec`, or literal no-op;
+  - repair the eval runner’s failure aggregation;
+  - add a fast CI job for changed skills and a periodic full run.
+- **Acceptance**: the current `pr-readiness` schema and `exec: true` fixtures fail validation; missing `ci-poll` eval fails rather than passes.
+
+#### K3.2 — Replace synthetic evals with behavioral fixtures
+
+- **Priority**: P1
+- **Depends on**: K3.1
+- **Actions**:
+  - prioritize release-guard, pr-readiness, commit, ci-fix, code-quality, test-runner, goap-agent, and web-doc-resolver;
+  - test negative safety cases: no unsolicited push/force/manual release, no ignored required cancellation, no lint suppression, no lockfile deletion;
+  - test documented command/path/environment examples.
+- **Acceptance**: each high-risk skill has at least one positive and one refusal/error-path test that can fail for the intended reason.
+
+#### K3.3 — Generate inventory, routing, and overlap boundaries
+
+- **Priority**: P1
+- **Depends on**: K3.1
+- **Actions**:
+  - generate a canonical 33-skill inventory from frontmatter;
+  - add intent/path routing for high-risk/high-frequency skills;
+  - remove broad collisions and document “use X instead when” boundaries for CI, release, testing, and planning clusters;
+  - lint broken links, unknown related skills, stale tool names, unbalanced fences, commands, and environment variables.
+- **Acceptance**: every canonical skill is inventoried; route coverage and negative-routing fixtures pass; no broken local skill links remain.
+
+#### D3.1 — Align release and mutation guidance
+
+- **Priority**: P0
+- **Depends on**: T0.2, K3.1
+- **Actions**:
+  - make release-guard the safety authority and remove all manual-release fallbacks;
+  - gate commit/push/worktree force operations on explicit user authorization;
+  - remove lockfile deletion and blanket lint-suppression advice;
+  - use current Kiro/platform-neutral capability names.
+- **Acceptance**: repository search finds no active agent instruction that bypasses the release workflow or performs destructive/remote mutation without confirmation.
+
+#### D3.2 — Correct README and generated contracts
+
+- **Priority**: P1 user contract
+- **Depends on**: T0.2, S1.1, W2.1
+- **Actions**:
+  - fix the `TaskContext` example and compile it as a doctest/example;
+  - describe actual sandbox availability/backend and remove nonexistent feature flags;
+  - scope storage defaults and embedding providers accurately;
+  - replace unsupported performance/coverage/test claims with reproducible measurements;
+  - generate CLI/MCP command summaries from Clap/tool registry where practical.
+- **Acceptance**: README examples compile; every feature flag exists in the owning manifest; measured claims contain provenance.
+
+#### D3.3 — Re-establish canonical plan hygiene
+
+- **Priority**: P1 governance
+- **Depends on**: T0.2
+- **Actions**:
+  - keep CURRENT concise and current, ROADMAP future-only, and GOAP_STATE limited to active execution state;
+  - archive superseded dated plans after synthesis;
+  - make plan integrity checks blocking for changed active plans.
+- **Acceptance**: active tree complies with ADR-039 as amended by ADR-072; duplicate/missing IDs and stale canonical timestamps are CI failures.
+
+### Phase 4 — Evidence-driven feature proposals
+
+- **Priority**: P2 for every F4 work package and child.
+
+These are proposals, not commitments. Each begins with a bounded spike and can be rejected.
+
+#### F4.1 — Retrieval provenance and explainability envelope
+
+- **Depends on**: S1.2
+- **Proposal**: expose the ADR-074 request fingerprint, retrieval tier/backend, model/index generation, candidate counts, score components, cache status, and latency to CLI/MCP diagnostics without leaking raw sensitive queries.
+- **Go criteria**: no retrieval-quality regression beyond the preapproved metric tolerance, <2% P95 latency overhead, and incident-fixture diagnosis time improves by the preapproved threshold; otherwise record `NO-GO`.
+
+#### F4.2 — Multi-backend reconciliation journal
+
+- **Depends on**: S1.3, S1.4
+- **Proposal**: persist idempotent operation intent/outcome for episode completion, eviction, embedding cleanup, and relationship deletion; add health/repair commands.
+- **Go criteria**: the predeclared fault matrix converges after restart with zero resurrection and duplicate steps, while storage and compaction metrics remain within preapproved numeric limits; otherwise record `NO-GO`.
+
+#### F4.3 — Verifiable local-model registry
+
+- **Depends on**: S1.5
+- **Proposal**: signed/pinned model manifests with source revision, file digests, dimensions, license metadata, maximum size, and health state.
+- **Go criteria**: valid offline fixtures reproduce the declared digest/dimensions, every tamper fixture rejects, and security/legal owners approve the recorded trust root, license, and rotation policy; otherwise record `NO-GO`.
+
+#### F4.4 — Agent skill contract compiler
+
+- **Depends on**: K3.3
+- **Proposal**: generate inventory, route map, reference checks, and eval matrix from skill frontmatter plus a versioned schema.
+- **Go criteria**: all baseline schema/no-op/link/routing fixtures are detected, generated catalog duplication count is zero, and changed-skill CI completes within the preapproved runtime (target <30 seconds); otherwise record `NO-GO`.
+
+### Phase 5 — Convergence
+
+#### V5.1 — Prove the integrated goal state
+
+- **Priority**: P0 release blocker
+- **Depends on**: every required T/S/W/K/D child. All are required except S1.1d, which is required only when S1.1c records `GO`; a `NO-GO` requires the fail-closed S1.1a/b state. F4 children are optional until maintainers select a pilot, after which that child is required.
+- **Actions**: run the canonical workspace, security, fault-injection, documentation, plan-integrity, and skill-eval suites at one commit; independently review evidence.
+- **Acceptance**: every goal-state flag is supported by a passing command/run artifact at the same integration SHA; any skipped or unavailable required check blocks completion. Conditional and pilot selections are read from validated decision artifacts, never chosen ad hoc at V5.1.
+
+### 6.1 Atomic child and validation ledger
+
+Commands marked `new` are deliverables of that child and must have their own fixtures. Each child inherits its parent work package priority and external dependencies. The required internal edges are:
+
+```text
+T0.1a -> T0.1b -> T0.1c -> T0.2a -> T0.2b -> T0.2c -> T0.2d -> {T0.2e,T0.2f,T0.2g}
+T0.2e -> S1.1c -> S1.1d[only if GO]; S1.1a -> S1.1b; T0.2f -> S1.2a -> S1.2b -> S1.2c
+S1.3a -> S1.3b -> S1.4a -> S1.4b; S1.5a -> S1.5b; S1.6a -> S1.6b; S1.7a -> S1.7b
+W2.1a -> W2.1b -> W2.2a -> W2.2b -> W2.3a -> W2.3b -> {W2.4a,W2.4b,W2.5a,W2.5b,W2.6a,W2.6b}
+K3.1a -> K3.1b -> K3.2a -> {K3.3a,K3.3b,K3.3c}; D3.1a -> D3.1b; D3.2a -> D3.2b -> D3.2c; D3.3a -> V5.1
+```
+
+All decision/spike artifacts use schema `{id, commit, timestamp, owner, commands, metrics, preapproved_thresholds, result, decision, reviewers}` and are produced and checked by `new: ./scripts/run-feature-spike.sh` and `new: ./scripts/validate-feature-spike.sh`. Missing fields, post-hoc thresholds, or unmet `GO` thresholds fail validation. Work-package prose above supplies design context; this ledger is the completion contract.
+
+| Child | Single outcome | Executable validation and evidence |
+|---|---|---|
+| T0.1a | Capture local package/gate/LOC/skill baseline | `cargo metadata --format-version 1 --no-deps`; canonical LOC/eval commands; archive outputs with SHA |
+| T0.1b | Verify remote tag/release/CI/crates state for exact version/SHA | derive `VERSION`, `TAG`, and tag commit; `gh release view "$TAG" --json tagName,targetCommitish,isDraft,isPrerelease,publishedAt,url`; `gh run list --commit "$SHA" --json workflowName,headSha,status,conclusion,url`; exact package/version crates.io queries; `new: ./scripts/validate-release-evidence.sh` must prove all SHAs/versions match or leave a blocker |
+| T0.1c | Validate metric provenance schema | `new: ./scripts/validate-plan-evidence.sh --fixtures`; missing SHA/time/scope/artifact fixture must fail |
+| T0.2a | Accept and register ADR-072 | `new: ./scripts/validate-plans.sh --adrs`; status/registry fixture passes |
+| T0.2b | Classify version/release state from T0.1 evidence | `new: ./scripts/validate-plans.sh --version-state`; contradictory canonical fixture fails |
+| T0.2c | Reconcile and archive canonical plans | `new: ./scripts/validate-plans.sh --active-set`; superseded active dated-plan fixture fails |
+| T0.2d | Register duplicate aliases and repair ADR-061 links | `new: ./scripts/validate-plans.sh --identifiers --links`; duplicate-new-ID and missing-link fixtures fail |
+| T0.2e | Record ADR-073 accept/reject decision | `./scripts/validate-plans.sh --adr-decision ADR-073`; requires deciders/date and enforces NO-GO or S1.1d branch |
+| T0.2f | Record ADR-074 accept/reject decision | `./scripts/validate-plans.sh --adr-decision ADR-074`; requires deciders/date and blocks V5.1 after rejection until an alternative cache-correctness ADR passes |
+| T0.2g | Add ADR-072 supersession notes to ADR-039/034/045/058 | `new: ./scripts/validate-plans.sh --supersession`; each affected ADR must link ADR-072 and identify changed clauses |
+| S1.1a | Preserve unavailable MCP execution and correct contract | `cargo nextest run -p do-memory-mcp execute_agent_code`; list omits tool and direct call rejects |
+| S1.1b | Remove or quarantine legacy Node executor | `new: ./scripts/check-source-reachability.sh --deny memory-mcp/src/sandbox/mod.rs`; MCP path test proves no production-safe path reaches Node |
+| S1.1c | Decide Wasmtime/WASI feasibility | `./scripts/run-feature-spike.sh S1.1c --config plans/spikes/S1.1c.toml --output plans/STATUS/spikes/S1.1c.json`; preapproved controls/platforms/P95/binary-size thresholds and threat review determine GO/NO-GO |
+| S1.1d | If GO, implement and approve capability backend | `cargo nextest run -p do-memory-mcp sandbox`; runtime bypass/resource fixtures pass; `new: ./scripts/validate-security-review.sh plans/STATUS/SECURITY_REVIEW_CODE_EXECUTION.md "$SHA"` requires independent `APPROVE` before registration |
+| S1.2a | Add typed/versioned retrieval identity | `cargo nextest run -p do-memory-core retrieval_identity`; canonical postcard fixtures pass |
+| S1.2b | Wire cache key and mutation generation | `cargo nextest run -p do-memory-core retrieval_cache`; context/provider/index-order fixtures pass |
+| S1.2c | Add redacted retrieval provenance | `cargo nextest run -p do-memory-core retrieval_provenance`; `./scripts/run-feature-spike.sh S1.2c --config plans/spikes/S1.2c.toml --output plans/STATUS/spikes/S1.2c.json`; `./scripts/validate-feature-spike.sh plans/STATUS/spikes/S1.2c.json` rejects leak, quality tolerance, or preapproved P95 breach |
+| S1.3a | Implement versioned lock-free backend persistence | `cargo nextest run -p do-memory-core episode_persistence`; lock-barrier test passes |
+| S1.3b | Prove concurrent step preservation | `cargo nextest run -p do-memory-core concurrent_step_preservation`; 100-step stress fixture passes repeatedly with exactly-once IDs |
+| S1.4a | Implement idempotent cross-backend eviction | `cargo nextest run -p do-memory-core durable_capacity_eviction`; restart/backfill capacity-one fixture passes |
+| S1.4b | Expose and repair partial eviction failure | `cargo nextest run -p do-memory-core eviction_reconciliation`; injected partial state is typed and converges after repair/restart |
+| S1.5a | Expose real/degraded/unavailable provider state | `cargo nextest run -p do-memory-core local_embedding_state`; mock is never production-ready |
+| S1.5b | Verify model manifests/artifacts | `cargo nextest run -p do-memory-core local_model_integrity`; wrong digest/size/revision/file/dimension reject and valid offline fixture passes |
+| S1.6a | Implement retry queue/concurrency semantics | `cargo nextest run -p do-memory-core retry`; zero, timeout, first-attempt, permit-release fixtures pass |
+| S1.6b | Document local versus process-wide retry budgets | `cargo test --doc -p do-memory-core retry`; API examples and scope assertions compile/pass |
+| S1.7a | Implement recursive redaction and correct rotation | `cargo nextest run -p do-memory-mcp audit`; nested-secret and existing-size fixtures pass |
+| S1.7b | Move audit writes off async workers | `cargo nextest run -p do-memory-mcp audit_writer_backpressure`; slow-writer/overflow fixture proves bounded latency and drop metrics |
+| W2.1a | Publish measured/required/target gate matrix | `new: ./scripts/validate-gate-contract.sh`; conflicting-threshold fixture fails |
+| W2.1b | Establish one canonical local/CI command surface | `./scripts/validate-gate-contract.sh --ci-parity`; required jobs/scripts at the same SHA must match |
+| W2.2a | Preserve audit/coverage/benchmark/doctest exit status | `./scripts/validate-gate-contract.sh --failure-fixtures`; injected failures and malformed reports return nonzero |
+| W2.2b | Reject cancelled required prerequisites | `new: ./scripts/test-workflow-guards.sh --cancelled-required`; expected cancellation blocks |
+| W2.3a | Derive package names/exclusions from metadata | `cargo nextest run --test quality_gates package_names`; accepts `do-memory-core`, rejects nonexistent names/exclusions |
+| W2.3b | Require subprocess success before metric parsing | `cargo nextest run --test quality_gates subprocess_failure`; failed/missing pattern, complexity, and performance commands cannot use fallback values |
+| W2.4a | Gate release on exact validated SHA | `new: ./scripts/test-release-workflow.sh --fixtures`; wrong tag/SHA/metadata/required check blocks |
+| W2.4b | Make publishing reproducible and dependency-aware | `./scripts/test-release-workflow.sh --publish-fixtures`; verifies `--locked`, blocking semver, exact polling, full dry-run, and each single-crate dispatch/dependency path |
+| W2.4c | Decide CLI publication policy | `./scripts/validate-plans.sh --package-policy do-memory-cli`; manifest/workflow/docs must have one answer |
+| W2.4d | Remove active manual-release guidance | `new: ./scripts/validate-plans.sh --release-policy` rejects active direct-release instructions |
+| W2.5a | Enforce real benchmark regression data including CLI paths | `new: ./scripts/test-benchmark-workflow.sh --fixtures`; CLI path fixture runs, >10% regression and missing Criterion output block |
+| W2.5b | Preserve nightly reports, honor inputs once, and ratchet ignores | `new: ./scripts/test-nightly-workflow.sh --fixtures`; `new interface: ./scripts/check-ignored-tests.sh --fixture ratchet`; validates upload-before-cleanup, one selected run, and no unevidenced ceiling increase |
+| W2.6a | Split five oversized production files | `new interface: ./scripts/quality-gates.sh --loc-only`; reports zero production files above 500 |
+| W2.6b | Remove unexplained orphan source modules | `new: ./scripts/check-source-reachability.sh --fixtures`; orphan fixture fails |
+| K3.1a | Enforce one strict skill-eval schema | `./scripts/run-evals.sh` rejects `evals`, zero/missing tests, missing exec, and `exec: true` |
+| K3.1b | Run changed/full skill evals in CI | `new interface: ./scripts/run-evals.sh --changed`; `./scripts/run-evals.sh`; interface fixture blocks and full artifact enumerates 33 skills |
+| K3.2a | Add positive/negative high-risk skill fixtures | `for s in release-guard pr-readiness commit ci-fix code-quality test-runner goap-agent web-doc-resolver; do ./scripts/run-evals.sh "$s" || exit 1; done`; refusal regressions fail |
+| K3.3a | Generate complete skill inventory | `new: ./scripts/generate-skill-inventory.sh --check`; output contains all 33 valid skills |
+| K3.3b | Define routes and overlap boundaries | `new: ./scripts/validate-skill-routes.sh --fixtures`; positive/negative cluster routes pass |
+| K3.3c | Lint skill links/tools/commands/env/fences | `new: ./scripts/validate-skills.sh --fixtures`; each known stale pattern fixture fails |
+| D3.1a | Establish release-guard as sole skill authority | `./scripts/validate-skills.sh --release-policy`; no manual fallback and negative eval passes |
+| D3.1b | Confirmation-gate remote/destructive mutations | `for s in commit git-worktree-manager pr-readiness; do ./scripts/run-evals.sh "$s" || exit 1; done`; unrequested push/force rejects and lockfile remains |
+| D3.2a | Correct and compile README contracts | `cargo test --doc` plus `new: ./scripts/validate-readme-contracts.sh`; examples/features/defaults/providers pass |
+| D3.2b | Generate CLI/MCP summaries | `new: ./scripts/generate-contract-docs.sh --check`; checked docs match Clap/tool registry |
+| D3.2c | Attach reproducible provenance to public metrics | `new: ./scripts/validate-doc-metrics.sh README.md --evidence plans/STATUS/VALIDATION_LATEST.md`; stale/missing command, scope, SHA, time, or artifact fixture fails |
+| D3.3a | Restore canonical active-plan roles | `./scripts/validate-plans.sh --active-set --version-state --identifiers --links`; passes after archival |
+| F4.1 | Decide provenance-envelope pilot | `./scripts/run-feature-spike.sh F4.1 --config plans/spikes/F4.1.toml --output plans/STATUS/spikes/F4.1.json`; validator requires no quality regression and preapproved diagnosis-time/P95 thresholds (target P95 overhead <2%) |
+| F4.2 | Decide reconciliation-journal pilot | same producer/validator with restart fault matrix, zero resurrection/duplication, and preapproved storage/compaction limits |
+| F4.3 | Decide verifiable-model-registry pilot | same producer/validator with tamper/offline/reproducibility fixtures and approved trust-root/rotation review |
+| F4.4 | Decide skill-compiler pilot | same producer/validator must catch all baseline defect fixtures and meet preapproved changed-skill runtime (target <30s) and generated-file duplication count (zero) |
+| V5.1 | Certify integrated goal state | `./scripts/quality-gates.sh`; targeted fault suites; `./scripts/validate-plans.sh`; `./scripts/run-evals.sh`; decision/security-review validators; independent review all pass at one SHA |
+
+## 7. Validation matrix
+
+| Outcome | Required evidence |
+|---|---|
+| Code correctness | Targeted crate tests plus concurrency/fault-injection tests for changed behavior |
+| Workspace health | Canonical fmt, strict clippy, build/check, nextest, doctest, and docs commands all pass at one SHA |
+| Security | Blocking cargo-audit/cargo-deny; sandbox runtime bypass suite; nested-redaction tests |
+| Coverage | Fresh llvm-cov artifact; blocking floor and target reported separately |
+| Performance | Criterion baseline comparison; no fabricated fallback data |
+| Release | Exact-SHA preflight, metadata verification, dry-run, artifact checksums/signatures, automated release only |
+| Skills | Strict schema validator, changed-skill evals, periodic full eval, routing/link lint |
+| Documentation | README examples compile; feature/command lists generated or manifest-verified; plan integrity gate passes |
+
+## 8. Exit criteria
+
+The plan is complete only when all P0 and P1 actions have evidence at the same integration commit and:
+
+- no untrusted code-execution tool is advertised without a capability-enforced backend;
+- context-distinct retrieval requests cannot collide in cache;
+- no memory lock is held across backend I/O and durable eviction survives restart;
+- required audit, coverage, benchmark, doctest, and subprocess failures cannot be converted to green;
+- release creation has one automated authority and validates the exact SHA;
+- all high-risk skills have executable positive/negative evals and current routes;
+- README examples/contracts match manifests and code;
+- canonical plans agree on version/state and ADR/WG references are unique; and
+- every shipped feature pilot has its recorded go/no-go evidence.
+
+## 9. Risks and rollback
+
+- **Gate activation may reveal extensive existing debt**: introduce truthful reporting first, record baseline, then make only explicitly selected floors blocking; never hide failures with `|| true`.
+- **Concurrency refactor may lose updates**: require versioned merge and stress tests before replacing the current path.
+- **Sandbox migration may temporarily remove a tool**: prefer unavailable over insecure; core memory operations are unaffected.
+- **Durable reconciliation adds state**: start with idempotent delete plus observable partial failures; adopt a journal only if fault tests justify it.
+- **Plan cleanup can break links**: use redirects/index entries and validate active links before archival.
+- **Skill routing can over-trigger**: add negative-routing fixtures and path/intent precedence before broad rollout.
+
+## 10. Explicitly out of scope for this planning change
+
+- Editing Rust, workflow, script, README, AGENTS, or skill files.
+- Claiming current GitHub releases, CI runs, PRs, tags, or crates.io versions without querying them.
+- Accepting the proposed ADRs on behalf of maintainers.
+- Changing production infrastructure, publishing crates, creating tags/releases, or committing/pushing changes.

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1,13 +1,31 @@
 # GOAP State Snapshot
 
-- **Last Updated**: 2026-07-08 (3 PRs created for issues #773, #771, #772; release drift at 30+ commits)
-- **Version**: `0.1.33` (workspace — tag v0.1.33 exists; ~30 commits since release)
-- **Branch**: `main`
-- **Validation**: `plans/STATUS/VALIDATION_LATEST.md`
-- **Gap Analysis**: `plans/STATUS/GAP_ANALYSIS_LATEST.md`
-- **Primary ADRs**: ADR-052 (v0.1.29), ADR-037 (CSM workflow adoption), ADR-053 (Accepted), **ADR-055 (Accepted — v0.1.32 missing-impl remediation; resolved)**, **ADR-056 (Accepted — Local Storage No Connection Pooling)**, **ADR-057 (Accepted — CI Health: PR #616 merged; slow test bounded by PR #620)**, **ADR-058 (Accepted — Scheduled gitleaks false positives, release drift)**
+- **Last Updated**: 2026-07-15 (CLI UX patch #829-#832 on branch `fix/0.1.35-patch-issues`)
+- **Version**: `0.1.35` (workspace; tag v0.1.34 latest released)
+- **Branch**: `fix/0.1.35-patch-issues`
+- **Plan**: `plans/GOAP_CLI_UX_PATCH_0.1.35_2026-07-15.md`
+- **Validation**: CLI skill smoke + targeted nextest (see plan)
 
 ---
+
+## Sprint 2026-07-15: CLI UX Patch v0.1.35 ✅ CODE COMPLETE
+
+**Open issues closed in code** (verify after merge/release):
+
+| Issue | Fix | Verified via CLI |
+|-------|-----|------------------|
+| #831 Pattern list empty after complete | Postcard-compatible Pattern + get_all_patterns lazy load | create→complete→list=1, search finds pattern |
+| #830 --db-path ignored | Always set redb_path; default local when no Turso | Opens custom.redb / env.redb |
+| #829 Undocumented config | config init/show-template + serde default + example.toml | partial.toml loads |
+| #832 storage_mode placement | [database] canonical; [storage] alias normalized | config show → Storage Mode: local |
+| #828 Release drift | Workspace 0.1.35 (not 0.2.0) | Version in Cargo.toml |
+
+**Prevention tasks landed**: postcard Pattern test, redb trait list test, e2e pattern list assert, loader partial/alias tests, example config, CHANGELOG.
+
+**Next**: commit → PR → CI green → merge → `release.yml` for v0.1.35 (never manual release).
+
+---
+
 
 ## Sprint 2026-07-08: PR Batch Merge & Mutation Testing
 

--- a/plans/GOAP_SWARM_0.1.35_PATCH_2026-07-15.md
+++ b/plans/GOAP_SWARM_0.1.35_PATCH_2026-07-15.md
@@ -1,0 +1,102 @@
+# GOAP Swarm Orchestration — v0.1.35 CLI Patch
+
+**Date**: 2026-07-15  
+**Coordinator**: goap-agent + agent-coordination  
+**Strategy**: Hybrid (Swarm validation + Sequential quality gates)  
+**Branch**: `fix/0.1.35-patch-issues`  
+**PR**: #834  
+**Issues**: #828, #829, #830, #831, #832  
+
+---
+
+## Goal Hierarchy
+
+```
+G0: Ship verified fix for open CLI UX issues (#829–#832) + version align (#828)
+├── G1: Implementation complete & correct vs issue repros
+├── G2: Regression guards prevent recurrence
+├── G3: Quality gates (fmt, clippy, tests)
+├── G4: External CLI verification (issue parity)
+└── G5: PR readiness (CI CLEAN, plans updated)
+```
+
+## World State (pre-swarm)
+
+| Fact | Value |
+|------|-------|
+| Commit | `caab0e5d fix: resolve 0.1.35 patch issues #828-#832` |
+| PR | #834 OPEN |
+| Issues | #828–#832 still OPEN (close on merge) |
+| Risk | #830 may need always-override redb_path if partial fix landed |
+
+## Swarm Assignment
+
+| Agent | Role | Tasks | Depends |
+|-------|------|-------|---------|
+| **W1 explore** | Gap analysis | Diff issue requirements vs tree; flag missing pieces | — |
+| **W2 debugger** | #830 path override | Ensure `--db-path` always sets redb_path; unit/CLI proof | W1 findings |
+| **W3 feature-implementer** | Prevention + CLI skill | Harden missing guards; update do-memory-cli-ops docs | W1 |
+| **W4 test-runner** | Quality | fmt, clippy, targeted nextest | W2, W3 |
+| **W5 general-purpose** | External CLI | Reproduce each GitHub issue outside repo | W2, W4 |
+| **W6 code-reviewer** | Review | Diff review against AGENTS.md | W2, W3 |
+| **W7 general-purpose** | Plans + PR | Update plans/, PR body Fixes, CI poll | W4, W5, W6 |
+
+## Execution Strategy
+
+```
+Phase A (SWARM parallel):  W1
+Phase B (SWARM parallel):  W2, W3  (after W1)
+Phase C (SEQUENTIAL):      W4 → W5 → W6
+Phase D (CONVERGE):        W7 synthesize + PR readiness
+```
+
+## Success Criteria
+
+1. Exact issue #830: `--db-path /tmp/.../memory.db` opens that path (not XDG)
+2. Exact issue #831: create → complete → `pattern list` ≥ 1 in fresh process
+3. Exact issue #829: `config init` + partial TOML load
+4. Exact issue #832: `[storage].storage_mode = "local"` works
+5. clippy clean; regression tests pass
+6. PR #834 body references Fixes; plans/ reflect completion
+
+## Quality Gates
+
+| Gate | Check |
+|------|-------|
+| QG1 | W1 gap report: no critical missing code |
+| QG2 | W2+W3: edits compile |
+| QG3 | W4: nextest targeted pass |
+| QG4 | W5: all 4 issue CLI repros pass |
+| QG5 | W6: no high-severity review findings |
+| QG6 | W7: mergeStateStatus path clear or documented |
+
+---
+
+## Swarm Log
+
+### Phase A — W1 explore (gap analysis)
+- **Result**: No critical missing impl for #829–#832. Medium: #830 unit test + CHANGELOG drift.
+- **QG1**: PASS
+
+### Phase B — W2 fix + W3 docs
+- **W2**: Extracted `apply_db_path_override` in `config/cli_overrides.rs` — always override XDG; redb-only uses exact path; turso feature uses siblings. 3 unit tests.
+- **W3**: Updated do-memory-cli-ops skill + LESSON-017.
+- **QG2**: PASS (compiles)
+
+### Phase C — W4 tests + W5 CLI + W6 review
+- **W4**: fmt/clippy/143 cli lib tests/postcard/redb list — all PASS
+- **W5**: External #829–#832 all PASS on 0.1.35 release binary
+- **W6**: Requested sibling mapping for turso + unit test — addressed in W2 follow-up
+- **QG3–QG5**: PASS
+
+### Phase D — W7 converge
+- Plans updated; commit follow-up to PR #834; CI re-run expected
+
+### Final world state
+| Goal | Status |
+|------|--------|
+| G1 Implementation | ✅ |
+| G2 Prevention | ✅ (cli_overrides tests + skill/LESSON) |
+| G3 Quality | ✅ |
+| G4 External CLI | ✅ |
+| G5 PR push | 🟡 this commit |

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -1,10 +1,27 @@
 # Active Development Roadmap
 
-**Last Updated**: 2026-07-09 (v0.1.34 release)
-**Released Version**: v0.1.34 (crates.io + GitHub Release, 2026-07-09)
-**Active Sprint**: v0.1.34 — CI Health + Benchmark Fixes + Lint Hygiene (WG-175..184)
-**Branch**: `main`
-**Epic**: [#373](https://github.com/d-o-hub/rust-self-learning-memory/issues/373) — ALL ISSUES CLOSED
+**Last Updated**: 2026-07-15 (CLI UX patch sprint)
+**Released Version**: v0.1.34 (crates.io + GitHub Release)
+**Workspace Version**: 0.1.35 (unreleased — branch `fix/0.1.35-patch-issues`)
+**Active Sprint**: v0.1.35 — CLI UX Patch (#829–#832, #828)
+**Branch**: `fix/0.1.35-patch-issues`
+**Plan**: `plans/GOAP_CLI_UX_PATCH_0.1.35_2026-07-15.md`
+
+---
+
+## Sprint v0.1.35 — CLI UX Patch ✅ CODE COMPLETE (2026-07-15)
+
+**Focus**: Fix user-reported v0.1.34 CLI/config bugs; prevent recurrence with postcard/list/config tests.
+
+| Priority | Issue | Description | Status |
+|----------|-------|-------------|--------|
+| 1 (critical) | #831 | Pattern list/search empty after complete | ✅ Fixed + CLI verified |
+| 2 (critical) | #830 | `--db-path` / `MEMORY_DB_PATH` ignored | ✅ Fixed + CLI verified |
+| 3 (UX) | #829 | Config format undocumented / hard to discover | ✅ Fixed + CLI verified |
+| 4 (UX) | #832 | `storage_mode` vs config file unclear | ✅ Fixed + CLI verified |
+| 5 (release) | #828 | Release drift after v0.1.34 | 🟡 Version 0.1.35 ready; tag after merge |
+
+**Prevention**: postcard Pattern roundtrip, redb get_all_patterns trait test, e2e cross-process pattern list, config partial/alias unit tests, example.toml.
 
 ---
 

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -1,13 +1,25 @@
 # Project Status — Self-Learning Memory System
 
-**Last Updated**: 2026-07-11 (v0.1.34 released)
-**Released Version**: v0.1.34 (GitHub Release tag exists, 2026-07-11)
-**Workspace Version**: 0.1.34
-**Active Sprint**: v0.1.34 — COMPLETE
-**Branch**: `main`
-**PR**: [#806](https://github.com/d-o-hub/rust-self-learning-memory/pull/806) — MERGED
-**Release**: [v0.1.34](https://github.com/d-o-hub/rust-self-learning-memory/releases/tag/v0.1.34)
+**Last Updated**: 2026-07-15 (CLI UX patch v0.1.35)
+**Released Version**: v0.1.34 (GitHub Release tag exists)
+**Workspace Version**: 0.1.35 (unreleased)
+**Active Sprint**: v0.1.35 — CLI UX Patch ✅ code complete
+**Branch**: `fix/0.1.35-patch-issues`
 **Edition**: Rust 2024
+
+## v0.1.35 Sprint — CLI UX Patch ✅ CODE COMPLETE
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| #831 | Pattern extraction not listable across processes | ✅ Fixed |
+| #830 | `--db-path` / `MEMORY_DB_PATH` ignored for redb | ✅ Fixed |
+| #829 | Config file format hard to discover | ✅ Fixed |
+| #832 | `storage_mode` config placement unclear | ✅ Fixed |
+| #828 | Release drift | 🟡 Ready to tag after merge |
+
+**Plan**: `plans/GOAP_CLI_UX_PATCH_0.1.35_2026-07-15.md`
+
+---
 
 ## v0.1.34 Sprint — COMPLETE ✅ (Released)
 

--- a/plans/adr/ADR-072-Authority-Evidence-Enforcement-Governance.md
+++ b/plans/adr/ADR-072-Authority-Evidence-Enforcement-Governance.md
@@ -1,0 +1,176 @@
+# ADR-072: Authority, Evidence, and Enforcement Governance
+
+- **Status**: Proposed
+- **Date**: 2026-07-14
+- **Deciders**: Project maintainers
+- **Related**: ADR-022, ADR-034, ADR-039, ADR-042, ADR-045, ADR-058, ADR-059
+- **Plan**: `plans/GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md`
+
+## Context
+
+The repository currently has multiple contradictory descriptions of the same facts:
+
+- Cargo metadata reports workspace version `0.2.0`, while canonical plans report `0.1.33` or `0.1.34`.
+- AGENTS describes 90% coverage, `quality-gates.sh` and its Rust tests default to 70%, and Codecov has separate targets.
+- AGENTS requires automated releases, while active plans and release skills still prescribe direct `gh release create`.
+- Workflow prose claims publishing improvements that are absent from `publish-crates.yml`.
+- ADR-039 defines a small canonical active plan set, but dated analyses and historical status remain active.
+- ADR numbers 025 and 054 are duplicated, ADR-061 is referenced but absent, and WG identifiers have been reused.
+- Test, coverage, performance, and release claims often omit the command, scope, commit, time, and artifact that produced them.
+
+Documentation cannot override executable behavior, but executable behavior can also be incorrect. The project needs a declared authority hierarchy, explicit evidence requirements, one release path, and blocking drift checks.
+
+## Decision
+
+### 1. Authority matrix
+
+When sources disagree, use this order and reconcile lower authorities promptly:
+
+| Fact | Authoritative source | Non-authoritative mirrors |
+|---|---|---|
+| Workspace package/version set | `cargo metadata` derived from Cargo manifests | README, plans, generated VERSION text |
+| Feature flags/dependencies | Owning crate `Cargo.toml` plus compile checks | README and skill summaries |
+| CLI contract | Clap definitions and executable help snapshots | README/skills examples |
+| MCP tool contract | Tool registry/definitions and protocol tests | README/skills summaries |
+| CI behavior | Checked-in workflow/action/script executed at a commit | Status prose and old run links |
+| Local quality command | Versioned canonical scripts and their tests | Copied commands in docs/skills |
+| Released version | Matching immutable git tag plus successful automated GitHub release for the same commit | Workspace version alone |
+| Published crate version | crates.io API/index evidence for exact package/version | Release plan claims |
+| Metrics | Generated evidence artifact with required metadata | Hand-written totals or estimates |
+| Architecture intent | Accepted ADR | Proposed ADR or roadmap item |
+| Implementation state | Current code and executable tests | ADR status text and completed checkboxes |
+
+A `VERSION` file, if retained for consumers, is generated from Cargo metadata and is never co-canonical.
+
+### 2. Evidence schema
+
+Every canonical metric or completion claim must include or link to:
+
+```text
+value/result
+command or workflow job
+scope/features/platform
+commit SHA
+UTC timestamp
+tool version when material
+artifact or durable run URL
+```
+
+Claims without this data are labeled `target`, `estimate`, `historical`, or `unverified`; they are not presented as current measurements.
+
+### 3. Separate current, blocking, and target values
+
+Coverage, performance, ignored-test count, LOC, and similar controls expose three fields:
+
+- **Measured**: latest reproducible result.
+- **Required**: the currently blocking floor/ceiling.
+- **Target**: the planned ratchet objective.
+
+ADR-042’s 70→75→80 coverage progression remains a target sequence until a fresh baseline and blocking implementation are recorded. A 90% aspiration must not be described as the current default unless the executable gate enforces it and the workspace passes it.
+
+### 4. One release authority
+
+The only supported release-creation path is:
+
+1. approve and merge through normal branch protection;
+2. validate the exact release commit with required gates;
+3. bump Cargo workspace version and changelog/status as required;
+4. push an approved matching tag; and
+5. let `.github/workflows/release.yml` create the GitHub release.
+
+Humans and agents do not call `gh release create` directly. Its use inside the controlled release workflow is an implementation detail, not a manual fallback. Release and skill documentation must reference this path. Publishing is a separate automated stage with explicit package policy, `--locked`, exact-version dependency propagation, and blocking preflight.
+
+### 5. Canonical plan roles
+
+ADR-039’s consolidation intent is retained and clarified:
+
+- `plans/STATUS/CURRENT.md`: concise current state and evidence links.
+- `plans/ROADMAPS/ROADMAP_ACTIVE.md`: future work only.
+- `plans/GOALS.md`, `ACTIONS.md`, `GOAP_STATE.md`: active execution state only.
+- one latest validation report and one latest gap/codebase analysis.
+- dated GOAP documents are working snapshots and are archived after synthesis or supersession.
+- ADRs record decisions, not sprint status journals.
+
+Canonical files that describe one sprint/state are updated atomically in the same change.
+
+### 6. Identifier registry
+
+Create a machine-readable or generated registry for ADR and work identifiers.
+
+- New numeric ADR IDs are globally unique and allocated before file creation.
+- Historical duplicate files are not silently renumbered. The registry assigns explicit historical aliases (for example, `ADR-025A`/`ADR-025B` and `ADR-054A`/`ADR-054B`) and requires full filename links until maintainers choose a migration.
+- Missing ADR references fail validation. Existing ADR-061 references must be removed, redirected to an actual decision, or satisfied by a deliberately authored ADR; they cannot remain implied.
+- New work IDs are namespaced by plan (for example, `CBI-2026-07-14-S1.1`) or allocated from a registry. Bare reused `WG-NNN` identifiers are prohibited.
+
+### 7. Lifecycle and revalidation
+
+ADRs use: `Proposed -> Accepted -> Implemented -> Superseded/Rejected`.
+
+- `Accepted` records decision date and deciders.
+- `Implemented` links code/workflow evidence and validation.
+- Material implementation drift moves the ADR to `Accepted (drift detected)` or triggers a superseding ADR; it is not left falsely implemented.
+- High-impact ADRs are revalidated on major/minor releases or when their governing implementation changes.
+
+### 8. Blocking drift validation
+
+A required plans/docs check validates changed active content for:
+
+- Cargo version disagreement in canonical current-state fields;
+- duplicate/new ADR or work identifiers;
+- missing ADR/local links;
+- manual release instructions outside historical archives/workflow implementation;
+- stale `LATEST` records beyond the agreed service level;
+- multiple active documents claiming to be canonical/latest;
+- active dated plans superseded by a newer synthesis;
+- metrics without evidence metadata; and
+- README feature flags/commands that do not exist in manifests or generated contracts.
+
+The validator itself has executable fixtures and cannot reduce failures to warnings in required CI.
+
+## Migration
+
+1. Capture a local and remote truth snapshot at one commit.
+2. Reconcile whether workspace `0.2.0` is released, unreleased, or a release candidate.
+3. Update all canonical files atomically and archive superseded snapshots.
+4. Add the identifier registry and historical duplicate aliases.
+5. Remove or repair ADR-061 references.
+6. Reconcile ADR-034/045/058 release text with the automated-only path.
+7. Implement changed-plan validation as reporting, resolve baseline defects, then make it required.
+
+## Consequences
+
+### Positive
+
+- Executable reality and architecture intent have explicit, noncompeting roles.
+- Release, version, and metric claims become reproducible.
+- Plan drift, duplicate identifiers, and stale skills/docs fail early.
+- Historical ADRs remain auditable rather than being silently rewritten.
+
+### Negative
+
+- Canonical updates and release preparation require evidence artifacts.
+- Initial migration will expose and require cleanup of substantial stale planning content.
+- Some generated indexes and checks add maintenance/tooling cost.
+
+### Neutral
+
+- This ADR does not select a new coverage percentage; it governs how the measured value, blocking floor, and target are represented and enforced.
+- It does not establish remote release state; that requires remote evidence.
+
+## Alternatives considered
+
+1. **Treat plans as authoritative**: rejected because plans currently contradict manifests and workflows.
+2. **Treat code as the only documentation**: rejected because architecture intent, release policy, and user contracts need stable human-readable decisions.
+3. **Adopt a hand-maintained `VERSION` as co-canonical**: rejected because two writable version authorities create drift.
+4. **Renumber duplicate historical ADR files immediately**: rejected because it breaks historical links and obscures provenance; use registry aliases first.
+5. **Keep drift checks nonblocking**: rejected as an end state because current nonblocking checks allowed the present contradictions.
+
+## Acceptance criteria
+
+- One verified workspace/release state appears in all canonical plans.
+- No active instruction permits manual GitHub release creation.
+- Every active ADR reference resolves and every new ADR/work ID is unique.
+- Duplicate historical ADRs have registry aliases and full-filename links.
+- Current quality metrics distinguish measured, required, and target values.
+- Required plan/docs validation fails on representative drift fixtures.
+- ADR-039, ADR-034, ADR-045, and ADR-058 contain supersession notes where this decision changes their governance or release guidance.

--- a/plans/adr/ADR-073-Capability-Enforced-Agent-Code-Execution.md
+++ b/plans/adr/ADR-073-Capability-Enforced-Agent-Code-Execution.md
@@ -1,0 +1,126 @@
+# ADR-073: Capability-Enforced Agent Code Execution
+
+- **Status**: Proposed
+- **Date**: 2026-07-14
+- **Deciders**: Project maintainers and security owners
+- **Related**: ADR-024, ADR-072; `memory-mcp/src/sandbox/`
+- **Plan**: `plans/GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md` action S1.1
+
+## Context
+
+The repository describes agent code execution as a secure Wasmtime/WASM sandbox, but the current `memory-mcp` manifest has no `wasmtime-backend` feature. A legacy `CodeSandbox` implementation still starts a host Node.js process, but it is disconnected from a usable MCP tool: the handler marks execution deprecated and returns “Code execution is no longer available,” and current tool registration does not expose a working `execute_agent_code` definition.
+
+The disconnected Node code contains regex screening, a JavaScript wrapper, global shadowing/deletion, a child-process timeout, and `kill_on_drop`. An OS isolation helper exists in `sandbox/isolation.rs`, but that Node command does not apply it. Network, filesystem, and subprocess settings select source-pattern checks rather than runtime capability enforcement, and the configured memory limit is not applied to the child process.
+
+The current unavailable MCP behavior is appropriately fail closed. The risks are stale public claims, a misleading/dead implementation that could be accidentally reconnected, and any future attempt to restore execution without a real capability boundary. Static screening can remain defense in depth but cannot become the security boundary for adversarial code.
+
+## Decision
+
+### 1. Preserve fail-closed behavior and report capabilities
+
+While no approved backend exists, `execute_agent_code` remains absent from tool discovery and direct calls are rejected. Stale README/tool metadata is corrected, and disconnected executor code is removed or explicitly quarantined as experimental trusted-development code.
+
+A future `execute_agent_code` is not registered as a production-safe MCP tool unless startup self-tests establish an approved backend and its required controls. If introduced, tool discovery and health output report:
+
+- backend and version;
+- execution language/compiler path;
+- filesystem, network, clock, randomness, and environment capabilities;
+- memory/fuel/CPU/output/process limits;
+- artifact/plugin identity; and
+- self-test result.
+
+If capability attestation fails, the tool is unavailable while all memory tools remain operational.
+
+### 2. Conditional production backend
+
+If code execution is reintroduced, run a bounded feasibility/security spike and use Wasmtime with WASI/component capabilities as the preferred production boundary. A rejected spike leaves execution unavailable and closes without exposing a replacement tool.
+
+- No network, filesystem, subprocess, or inherited environment capability is supplied by default.
+- Optional capabilities are explicit per request/policy, least-privilege, and auditable.
+- Execution uses fuel and/or epoch interruption, wall-clock timeout, memory/table limits, output limits, and instance concurrency limits.
+- Host functions are allowlisted and validate input/output bounds.
+- JavaScript/TypeScript execution requires an explicit compiler pipeline (for example, a pinned Javy component). Compiler/plugin artifacts have version, digest, maximum-size, and provenance checks.
+- A failed compile is an execution error; it does not fall back to host Node.
+
+Exact Wasmtime/Javy versions are selected during implementation and pinned through normal dependency/artifact policy.
+
+### 3. Legacy Node classification
+
+The existing disconnected Node executor is removed or retained only as explicitly enabled **trusted-development executor** code. It must not be reconnected to MCP production unless maintainers implement and validate equivalent OS-level isolation on every supported platform.
+
+- It is disabled by default in MCP production configuration.
+- It is never called a sandbox or used as fallback for the production backend.
+- Regex scanning and wrapper restrictions remain supplementary safeguards, not capability enforcement.
+- Configuration and health prominently report `trusted-development` and the residual risk.
+
+### 4. Runtime policy and observability
+
+Each execution records a bounded audit event with request ID, backend identity, granted capabilities, limits, duration, termination reason, and truncated output sizes. User code and sensitive context are not logged by default.
+
+Termination reasons are typed: compile failure, capability denial, fuel/CPU exhaustion, memory limit, wall timeout, output limit, runtime failure, and internal backend failure.
+
+### 5. Security test contract
+
+The test suite includes attempts using direct, aliased, computed, dynamic, encoded, and reflective access to:
+
+- network endpoints and DNS;
+- host and parent filesystem paths;
+- subprocess/process APIs;
+- environment variables and secrets;
+- excessive memory, CPU, processes, output, and execution time; and
+- host-function input/output limits.
+
+Tests assert runtime denial/termination even when static screening is bypassed. Platform-specific implementation claims require platform CI coverage; otherwise the capability is reported unsupported.
+
+## Consequences
+
+### Positive
+
+- Security depends on capabilities and resource controls rather than source spelling.
+- MCP advertises only execution modes that passed startup verification.
+- Compiler/runtime artifact trust becomes explicit.
+- Typed failures improve operations and testing.
+
+### Negative
+
+- Wasmtime/Javy integration increases binary size, build time, and maintenance.
+- Existing JavaScript behavior may be unavailable until a compiler component is installed and verified.
+- Some host functionality requires carefully designed allowlisted interfaces.
+
+### Neutral
+
+- Disabling code execution does not disable episodic memory, retrieval, patterns, embeddings, or other MCP tools.
+- Static analysis remains useful as an early rejection and telemetry layer.
+
+## Alternatives considered
+
+1. **Keep regex + Node wrapper as the production sandbox**: rejected; lexical checks do not enforce runtime capabilities or memory limits.
+2. **Apply only the existing shell/ulimit helper**: rejected as the cross-platform primary design; it improves resource control but does not provide a complete capability model and introduces shell complexity.
+3. **Run Node in containers**: viable for deployments with a trusted container runtime, but too environment-dependent as the library/MCP default and still requires capability/resource policy.
+4. **Remove code execution permanently**: safest and acceptable fallback, but rejects a useful conditional feature before evaluating a capability-safe backend.
+5. **Automatically fall back from Wasmtime to Node**: rejected because fallback would silently weaken the security boundary.
+
+## Migration
+
+1. Preserve and test the current unavailable MCP behavior; correct docs/tool metadata.
+2. Remove the disconnected Node executor or quarantine it behind explicit trusted-development configuration and source-reachability checks.
+3. Run a bounded Wasmtime/WASI feasibility and threat-model spike.
+4. If rejected, record the decision and keep execution unavailable. If approved, build the backend behind a new accurately named feature.
+5. Add pinned compiler component handling, startup self-tests, and runtime bypass/resource tests before registration.
+6. Promote a backend only after platform/security validation and update generated tool docs.
+
+## Acceptance criteria
+
+**No-backend branch:**
+
+- Tool discovery omits `execute_agent_code`, direct calls fail closed, and public docs state that execution is unavailable.
+- No production-safe path reaches the legacy Node executor.
+
+**Approved-backend branch:**
+
+- The selected production backend denies ungranted network/filesystem/process access at runtime.
+- Memory, CPU/fuel, timeout, output, and concurrency limits have adversarial tests.
+- Compiler/runtime artifacts are pinned and digest-verified.
+- There is no silent Node fallback.
+- README, feature flags, health, tool discovery, and runtime behavior agree.
+- An independent security review signs off before production enablement.

--- a/plans/adr/ADR-074-Retrieval-Provenance-Deterministic-Cache-Identity.md
+++ b/plans/adr/ADR-074-Retrieval-Provenance-Deterministic-Cache-Identity.md
@@ -1,0 +1,122 @@
+# ADR-074: Retrieval Provenance and Deterministic Cache Identity
+
+- **Status**: Proposed
+- **Date**: 2026-07-14
+- **Deciders**: Project maintainers
+- **Related**: ADR-024, ADR-072; `memory-core/src/memory/retrieval/context.rs`; `memory-core/src/retrieval/cache/`
+- **Plan**: `plans/GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md` actions S1.2 and F4.1
+
+## Context
+
+`SelfLearningMemory::retrieve_relevant_context` currently builds a query-cache key from task description, domain, and result limit. Retrieval and ranking also depend on language, framework, tags, complexity, retrieval mode, ranking configuration, semantic provider/model, and index contents.
+
+Two requests can therefore share a cache entry even though they should produce different rankings. Provider/model or index changes can also reuse an entry created under an older retrieval state. The cached response has no structured provenance explaining which tier, model, index generation, score components, or cache state produced it.
+
+This is both a correctness defect and an observability gap. Correct identity and explainability should be designed together so the cache and diagnostics cannot drift into separate notions of “same request.”
+
+## Decision
+
+### 1. Introduce a versioned typed request identity
+
+Create `RetrievalRequestIdentityV1` containing every input that can alter membership, ordering, or scoring:
+
+- normalized query text;
+- domain, language, framework, complexity, task type, and normalized tags;
+- time/scope filters and result limit;
+- retrieval mode and enabled tier/feature set;
+- ranking/scoring configuration version and relevant weights/thresholds;
+- embedding provider, model, dimensions, and provider configuration revision;
+- index/schema generation or snapshot identity; and
+- tenant/namespace identity if multi-tenancy is introduced.
+
+The cache uses the full typed value as an equality key, not a digest alone. New behavior that affects results must add a field or increment the identity version.
+
+### 2. Canonical normalization
+
+- Tags are trimmed, normalized according to the existing tag contract, sorted, and deduplicated.
+- Optional empty values normalize consistently to `None` where semantically equivalent.
+- Query normalization is intentionally conservative: normalize line endings and agreed surrounding whitespace, but do not case-fold or rewrite semantic content without retrieval-quality evidence.
+- Floating weights/thresholds are represented by stable configuration revision or canonical fixed/bit representation, not locale-formatted strings.
+
+Canonical identity bytes use a versioned deterministic representation consistent with project serialization policy (postcard). A standard cryptographic digest of those bytes may be emitted as an opaque diagnostic fingerprint, but cache correctness relies on full typed equality.
+
+### 3. Track index and provider generation
+
+Relevant data mutations advance an index/cache generation or explicitly invalidate affected entries. Provider/model/config changes produce a new provider identity. Cache entries cannot survive an identity generation they do not declare.
+
+Broad invalidation is acceptable initially; domain/namespace-scoped generations may be added after measurement.
+
+### 4. Attach structured retrieval provenance
+
+Internal retrieval results carry a `RetrievalProvenance` envelope with:
+
+- request identity version and opaque fingerprint;
+- cache hit/miss and entry generation;
+- selected retrieval tier/backend and fallback sequence;
+- provider/model and index generation;
+- candidate counts before/after filtering;
+- score component names/versions and final score;
+- truncation/limit decisions; and
+- bounded stage/total latency.
+
+Public CLI/MCP diagnostics expose a redacted subset. Raw query/context and sensitive identifiers are not logged by default. Provenance is additive and can initially be optional to preserve API compatibility.
+
+### 5. Test and benchmark contract
+
+Tests cover:
+
+- same text/domain/limit with Rust/Axum versus Python/Django contexts, in both request orders;
+- tag order and duplicate-tag normalization;
+- changes in complexity, framework, retrieval mode, ranking config, provider/model, and index generation;
+- invalidation after episode/embedding mutation;
+- stable canonical serialization/fingerprint fixtures; and
+- redaction/no raw-query logging.
+
+Benchmarks measure identity construction, cache lookup, provenance collection, memory overhead, and P95 retrieval latency. The initial promotion budget is less than 2% P95 overhead for provenance-enabled retrieval, unless maintainers accept a measured tradeoff.
+
+## Consequences
+
+### Positive
+
+- Cache hits cannot cross result-affecting contexts.
+- Provider/index changes do not silently serve stale rankings.
+- Explainability and debugging use the same identity contract as caching.
+- Versioning makes future ranking changes explicit.
+
+### Negative
+
+- Keys and cache entries become larger.
+- Mutation paths need generation/invalidation wiring.
+- Provider and ranking configurations need stable identities.
+- Provenance can increase latency and telemetry volume if not bounded.
+
+### Neutral
+
+- Exact hashing/digest crate selection is an implementation detail, provided the diagnostic digest is standard, deterministic, and tested.
+- Broad invalidation may reduce hit rate until scoped generations are justified.
+
+## Alternatives considered
+
+1. **Add only language/framework/tags to the existing key**: rejected because mode, configuration, provider, and index changes would remain unsafe.
+2. **Disable query caching**: correct but discards a valuable performance feature and does not solve provenance.
+3. **Use only a hash digest as the cache key**: rejected because collision handling and debugging are weaker than full typed equality.
+4. **Shorten TTL**: rejected; shorter incorrectness is still incorrectness and provider/index drift can occur immediately.
+5. **Log ad hoc score details without identity**: rejected because observability could not prove which cache/request state produced a result.
+
+## Migration
+
+1. Add the typed identity and parity tests without changing public output.
+2. Replace current key construction and add conservative invalidation/generation.
+3. Add internal provenance and debug/metrics hooks.
+4. Expose an opt-in redacted CLI/MCP explanation.
+5. Benchmark overhead and cache hit-rate changes; optimize/scoped-invalidate only from evidence.
+6. Version the identity on any later result-affecting contract change.
+
+## Acceptance criteria
+
+- Every result-affecting current input is represented by identity or generation.
+- Context-distinct queries cannot share a cache entry.
+- Provider/model/index/ranking changes cannot reuse stale entries.
+- Canonical tag normalization and serialization fixtures are deterministic.
+- Provenance explains tier, model/index generation, candidate filtering, scoring, cache status, and latency without leaking raw sensitive context.
+- Targeted tests and benchmarks pass within the accepted overhead budget.

--- a/scripts/check-pr-readiness.sh
+++ b/scripts/check-pr-readiness.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # scripts/check-pr-readiness.sh — Check all open PRs for merge readiness
-# Verifies merge state, CI status, conflicts, and cancelled checks.
+# Verifies merge state, CI status, conflicts, cancelled checks, AND PR comments.
+# See .agents/skills/pr-readiness/SKILL.md for the full agent procedure.
 #
 # Usage:
 #   ./scripts/check-pr-readiness.sh          # Check all open PRs
@@ -74,6 +75,33 @@ for i in $(seq 0 $((PR_COUNT - 1))); do
   echo "  CI: $SUCCESS pass, $FAILURE fail, $CANCELLED cancelled, $PENDING pending, $SKIPPED skipped (of $TOTAL)"
   echo "  Codacy: $CODACY"
 
+  # ── PR comments / reviews (human + bots) ───────────────────
+  INLINE_COUNT=$(gh api "repos/$REPO/pulls/$NUMBER/comments" --paginate 2>/dev/null | jq 'length' 2>/dev/null || echo 0)
+  REVIEWS_JSON=$(gh api "repos/$REPO/pulls/$NUMBER/reviews" --paginate 2>/dev/null || echo '[]')
+  REVIEW_CHANGES=$(echo "$REVIEWS_JSON" | jq '[.[] | select(.state == "CHANGES_REQUESTED")] | length' 2>/dev/null || echo 0)
+  REVIEW_APPROVED=$(echo "$REVIEWS_JSON" | jq '[.[] | select(.state == "APPROVED")] | length' 2>/dev/null || echo 0)
+  REVIEW_COMMENTED=$(echo "$REVIEWS_JSON" | jq '[.[] | select(.state == "COMMENTED")] | length' 2>/dev/null || echo 0)
+  ISSUE_JSON=$(gh api "repos/$REPO/issues/$NUMBER/comments" --paginate 2>/dev/null || echo '[]')
+  ISSUE_COUNT=$(echo "$ISSUE_JSON" | jq 'length' 2>/dev/null || echo 0)
+  # Flag known bot feedback that is often actionable
+  HAS_CODECOV=$(echo "$ISSUE_JSON" | jq '[.[] | select(.user.login | test("codecov"; "i"))] | length' 2>/dev/null || echo 0)
+  CODECOV_FAIL=$(echo "$ISSUE_JSON" | jq -r '[.[] | select(.user.login | test("codecov"; "i")) | .body] | join("\n")' 2>/dev/null | grep -cE 'Patch coverage is|:x: Patch|Missing :warning:' || true)
+  CODECOV_FAIL=${CODECOV_FAIL:-0}
+  INLINE_COUNT=${INLINE_COUNT:-0}
+  REVIEW_CHANGES=${REVIEW_CHANGES:-0}
+  REVIEW_APPROVED=${REVIEW_APPROVED:-0}
+  REVIEW_COMMENTED=${REVIEW_COMMENTED:-0}
+  ISSUE_COUNT=${ISSUE_COUNT:-0}
+  HAS_CODECOV=${HAS_CODECOV:-0}
+
+  echo "  Comments: inline=$INLINE_COUNT  reviews(approved=$REVIEW_APPROVED changes_requested=$REVIEW_CHANGES commented=$REVIEW_COMMENTED)  conversation=$ISSUE_COUNT"
+  if [ "$HAS_CODECOV" -gt 0 ]; then
+    echo "  ℹ️  Codecov conversation comment present (check for missing-lines / low patch %)"
+  fi
+  if [ "$CODECOV_FAIL" -gt 0 ]; then
+    echo "  ⚠️  Codecov reports missing coverage / low patch % — address before merge (see skill)"
+  fi
+
   # Determine verdict
   VERDICT="✅ READY"
   ACTIONS=""
@@ -145,6 +173,25 @@ for i in $(seq 0 $((PR_COUNT - 1))); do
     ALL_READY=false
   fi
 
+  # Review feedback gates (script cannot auto-fix code; flags for agents)
+  if [ "${REVIEW_CHANGES:-0}" -gt 0 ]; then
+    VERDICT="❌ CHANGES REQUESTED"
+    ACTIONS="Address review feedback (gh api repos/$REPO/pulls/$NUMBER/comments + reviews); fix, push, request re-review"
+    ALL_READY=false
+    ((ISSUES_FOUND++))
+  fi
+
+  if [ "${INLINE_COUNT:-0}" -gt 0 ] && [ "$VERDICT" = "✅ READY" ]; then
+    echo "  ℹ️  $INLINE_COUNT inline review comment(s) — agent must verify each is resolved"
+  fi
+
+  if [ "${CODECOV_FAIL:-0}" -gt 0 ] && [ "$VERDICT" = "✅ READY" ]; then
+    VERDICT="⚠️ CODECOV FEEDBACK"
+    ACTIONS="Address Codecov missing lines / patch coverage (add tests); see .agents/skills/pr-readiness/SKILL.md"
+    ALL_READY=false
+    ((ISSUES_FOUND++))
+  fi
+
   echo "  Verdict: $VERDICT"
   if [ -n "$ACTIONS" ]; then
     echo "  Action: $ACTIONS"
@@ -153,8 +200,10 @@ for i in $(seq 0 $((PR_COUNT - 1))); do
 done
 
 echo "═══════════════════════════════════════════════════════"
+echo "Note: Agents must still load .agents/skills/pr-readiness/SKILL.md,"
+echo "      read full comment bodies, implement fixes, and reply on the PR."
 if [ "$ALL_READY" = true ]; then
-  echo "✅ All $PR_COUNT PR(s) are ready to merge."
+  echo "✅ All $PR_COUNT PR(s) pass automated readiness gates."
   exit 0
 else
   echo "⚠️  $ISSUES_FOUND issue(s) found across $PR_COUNT PR(s)."

--- a/tests/e2e/cli_workflows.rs
+++ b/tests/e2e/cli_workflows.rs
@@ -636,7 +636,26 @@ async fn test_pattern_discovery() {
     assert!(success, "Pattern analyze should succeed");
     println!("  ✓ Analyzed patterns");
 
-    // Search patterns
+    // List patterns (separate process: must read from durable storage, not in-memory cache)
+    let (list_result, list_success) =
+        run_cli(&cli_path, &config_path, &["pattern", "list"]).expect("Failed to list patterns");
+
+    assert!(list_success, "Pattern list should succeed");
+    let listed = list_result
+        .get("patterns")
+        .and_then(|v| v.as_array())
+        .map(|v| v.len())
+        .unwrap_or(0);
+    assert!(
+        listed > 0,
+        "pattern list should return extracted patterns across processes (found {listed})"
+    );
+    println!("  ✓ Listed {listed} patterns");
+
+    // Search patterns (semantic search requires embeddings; with embeddings
+    // disabled the e2e config returns success with an empty result set, which
+    // is expected. The cross-process retrieval fix is validated by the
+    // `pattern list` assertion above.)
     let (search_result, success) = run_cli(
         &cli_path,
         &config_path,
@@ -645,12 +664,14 @@ async fn test_pattern_discovery() {
     .expect("Failed to search patterns");
 
     assert!(success, "Pattern search should succeed");
-    let patterns = search_result
-        .get("patterns")
-        .and_then(|v| v.as_array())
-        .map(|v| v.len())
-        .unwrap_or(0);
-    println!("  ✓ Found {patterns} patterns");
+    println!(
+        "  ✓ Pattern search succeeded (count={})",
+        search_result
+            .get("patterns")
+            .and_then(|v| v.as_array())
+            .map(|v| v.len())
+            .unwrap_or(0)
+    );
 
     // Get pattern recommendations
     let (_rec_result, success) = run_cli(&cli_path, &config_path, &["pattern", "recommend"])


### PR DESCRIPTION
## Summary

GOAP-orchestrated patch for v0.1.35 UX/correctness issues found on the 0.1.34 line:

| Issue | Fix |
|-------|-----|
| **#831** | `Pattern` enum is externally tagged (Postcard-compatible); `StorageBackend::get_all_patterns` + multi-backend hydration so `pattern list` works across processes; redb `SCHEMA_VERSION` → 4; skip undecodable rows |
| **#830** | `--db-path` / `MEMORY_DB_PATH` also set redb path via sibling files (never share path with Turso SQLite); default `storage_mode=local` when no Turso URL |
| **#829** / **#832** | `config init` / `config show-template`, example TOML, `[storage].storage_mode` alias → `[database]`, `#[serde(default)]` partial configs |
| **#828** | Workspace version relabeled `0.2.0` → `0.1.35` (patch on 0.1.x) |

## Test plan

- [x] `./scripts/code-quality.sh fmt`
- [x] `./scripts/code-quality.sh clippy --workspace` (zero warnings)
- [x] `cargo nextest run -p do-memory-core` (postcard + pattern suite)
- [x] `cargo nextest run -p do-memory-storage-redb --lib`
- [x] `cargo nextest run -p do-memory-cli --lib` + config property roundtrips
- [x] `cargo nextest run -p e2e-tests -E 'test(test_pattern_discovery)'` (cross-process list assertion)
- [ ] Full CI required checks green on this PR (`mergeStateStatus=CLEAN`)

## Notes

- Pattern JSON shape changes with the serde tag removal (pre-1.0); Turso stores a separate DTO. Documented in CHANGELOG.
- Nextest override extends timeout for `test_pattern_discovery` under load.

Fixes #828
Fixes #829
Fixes #830
Fixes #831
Fixes #832