### PR TITLE
fix(ci): set GH_REPO env in maintain-issue job so gh CLI resolves repo without checkout

### DIFF
--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -1,4 +1,3 @@
----
 name: Release Drift Check
 
 on:
@@ -73,6 +72,8 @@ jobs:
     permissions:
       contents: read
       issues: write
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Create or update drift issue
         if: needs.check-drift.outputs.severity != 'clean'


### PR DESCRIPTION
## Problem

The `maintain-issue` job in `.github/workflows/release-drift.yml` has no `actions/checkout` step. The `gh` CLI uses Git to auto-detect the repository, so without a working tree it fails with:

```
fatal: not a git repository
```

## Fix

Add `GH_REPO: ${{ github.repository }}` as a job-level env var. This tells the `gh` CLI the target repository explicitly, eliminating the need for a checkout just to run `gh issue` and `gh label` commands.

```yaml
    env:
      GH_REPO: ${{ github.repository }}
```

The single env var covers **all** steps in the job (`Create or update drift issue` and `Close resolved drift issue`) with no other changes required.

## References

Fixes the failure observed in run [#29582999142](https://github.com/d-o-hub/rust-self-learning-memory/actions/runs/29582999142/job/87893031689).