### PR TITLE
docs(release): prepare CHANGELOG and status for v0.1.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.35] - 2026-07-17
+
 ### Added
 
 - **K3.1 skill eval contract**: `scripts/run-evals.sh` enforces a strict
@@ -71,11 +73,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **S1.1a / D3.2 docs contract**: document `execute_agent_code` as unavailable /
   fail-closed; remove false `wasmtime-backend` feature claims; fix README
   `TaskContext` example fields.
-
-## [0.1.35] - 2026-07-15
-
-### Fixed
-
 - **#831 Pattern retrieval across processes**: `Pattern` enum was internally
   tagged (`#[serde(tag = "type")]`), which Postcard cannot deserialize. Patterns
   were written to storage but never read back, so `pattern list` / `pattern search`
@@ -86,9 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from durable storage. Bumped redb `SCHEMA_VERSION` to 4 so stale caches are
   cleared on upgrade; undecodable pattern rows are skipped rather than failing
   the whole list. **Note:** JSON shape of `Pattern` also changes (externally
-  tagged); Turso stores a separate JSON DTO and is unaffected. Related UX/docs for
-  empty results and config precedence: #845 / #846 / ADR-075 / ADR-076 (see
-  Unreleased).
+  tagged); Turso stores a separate JSON DTO and is unaffected.
 
 - **#830 `--db-path` / `MEMORY_DB_PATH` ignored for redb**: always override
   `redb_path` (never only-when-None — `Config::default()` pre-fills XDG).

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1,15 +1,31 @@
 # GOAP State Snapshot
 
-- **Last Updated**: 2026-07-17 (merge main into K3.1/W2.1 PR #851)
-- **Version**: `0.1.35` (workspace; tag v0.1.34 latest released)
-- **Branch**: `feat/goap-k31-w21-deferred-2026-07-17`
-- **Active plan**: `plans/GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md` (K3.1, W2.1)
-- **ADRs**: ADR-075/076 on main via PR #850
+- **Last Updated**: 2026-07-17 (post #850/#851 merge; cutting v0.1.35)
+- **Version**: `0.1.35` (workspace; tagging next)
+- **Branch**: `main`
+- **Active plan**: release v0.1.35 → then improvements backlog
+- **ADRs**: ADR-075/076 on main (PR #850); K3.1/W2.1 on main (PR #851)
 - **Source backlog**: `plans/GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md`
 
 ---
 
-## Sprint 2026-07-17b: K3.1 + W2.1 🟡 PR #851 (conflict resolve)
+## Release v0.1.35 🟡 IN PROGRESS
+
+| Step | Status |
+|------|--------|
+| Merge #850 open issues | ✅ |
+| Merge #851 K3.1/W2.1 | ✅ |
+| CHANGELOG + STATUS for tag | 🟡 |
+| Main CI green on release SHA | ⏳ |
+| `./scripts/release-manager.sh full --execute` | ⏳ |
+| `release.yml` GitHub Release | ⏳ |
+| Close #849 | ⏳ |
+
+**Deferred after tag**: K3.1b, W2.1b, S1.7, W2.4/W2.5, K3.2, S1.2 provenance, F4 pilots.
+
+---
+
+## Sprint 2026-07-17b: K3.1 + W2.1 ✅ MERGED (PR #851)
 
 | Package | Status |
 |---------|--------|
@@ -17,11 +33,8 @@
 | Migrate skill evals off noop/`evals` key | ✅ 32 skills |
 | W2.1a `plans/GATE_CONTRACT.md` | ✅ |
 | `validate-gate-contract.sh` | ✅ |
-| Merge main (PR #850) into #851 | ✅ this commit |
 | K3.1b CI job for changed skills | ⏳ follow-up |
 | W2.1b full CI parity | ⏳ follow-up |
-
-**Still deferred**: S1.7, W2.4/W2.5, K3.2, S1.2 provenance remainder, F4 pilots, v0.1.35 tag.
 
 ---
 

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -1,21 +1,30 @@
 # Project Status — Self-Learning Memory System
 
-**Last Updated**: 2026-07-17 (open issues analysis)
-**Released Version**: v0.1.34 (GitHub Release tag exists)
-**Workspace Version**: 0.1.35 (unreleased; 27 commits since tag)
-**Active Sprint**: Open Issues GOAP (ADR-075 / ADR-076) — analysis complete
+**Last Updated**: 2026-07-17 (pre-release v0.1.35)
+**Released Version**: v0.1.34 (tag); **cutting v0.1.35**
+**Workspace Version**: 0.1.35
+**Active Sprint**: Release v0.1.35 after PR #850 + #851 merge
 **Branch**: `main`
 **Edition**: Rust 2024
-**Open GitHub issues**: 4 (`#845`, `#846`, `#847`, `#849`)
+**Open GitHub issues**: release-drift #849 (closes on matching tag)
 
-## Open Issues vs Codebase — 2026-07-17 ✅ ANALYZED
+## Release v0.1.35 — READY TO TAG
 
-| Issue | Verdict | Next |
-|-------|---------|------|
-| #849 | Release cadence warning | Tag `v0.1.35` via `release.yml` |
-| #847 | **Open bug** — complete can false-green without durable write | ADR-075 implement |
-| #845 | Fixed on main as #831; residual empty-result UX | Release + ADR-076 |
-| #846 | Fixed on main as #829 | Release + close |
+| Item | Status |
+|------|--------|
+| PR #850 ADR-075/076 open-issue fixes | ✅ Merged |
+| PR #851 K3.1 skill evals + W2.1 gate contract | ✅ Merged |
+| CHANGELOG folded Unreleased → `[0.1.35]` | ✅ |
+| Tag via `release-manager` + `release.yml` only | 🟡 Next |
+
+## Open Issues vs Codebase — 2026-07-17
+
+| Issue | Verdict | Status |
+|-------|---------|--------|
+| #849 | Release cadence critical | 🟡 Tag v0.1.35 |
+| #847 | ADR-075 durable complete + `episode fail` | ✅ Merged #850 |
+| #845 | ADR-076 pattern empty diagnostics | ✅ Merged #850 |
+| #846 | Config precedence docs | ✅ Merged #850 |
 
 **Plan**: `plans/GOAP_OPEN_ISSUES_ANALYSIS_2026-07-17.md`  
 **ADRs**: ADR-075, ADR-076


### PR DESCRIPTION
## Summary

Release prep after PR #850 and #851 landed on main:

- Fold Unreleased into `## [0.1.35] - 2026-07-17`
- Update `plans/STATUS/CURRENT.md` and `plans/GOAP_STATE.md` for tag readiness

## Next

After merge + main CI green: `./scripts/release-manager.sh full --execute` (tag only; `release.yml` creates the GitHub Release).

Closes nothing by itself; enables closing #849 on tag.