### PR TITLE
docs(release): set Released Version to v0.1.35

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@
 <div align="center">
 
 ![Rust](https://img.shields.io/badge/Rust-000000?logo=Rust&logoColor=white)
+![Version](https://img.shields.io/badge/version-v0.1.35-orange)
 ![License](https://img.shields.io/badge/License-MIT-blue.svg)
 ![Quick Check](https://github.com/d-o-hub/rust-self-learning-memory/actions/workflows/quick-check.yml/badge.svg)
 ![Security](https://github.com/d-o-hub/rust-self-learning-memory/actions/workflows/security.yml/badge.svg)
 
-A self-learning episodic memory system with semantic pattern search, embeddings, MCP server, and optional sandboxed code execution.
+A self-learning episodic memory system with semantic pattern search, embeddings, MCP server, and a full-featured CLI.
 
 [Overview](#overview) • [Features](#features) • [Quick Start](#quick-start) • [Documentation](#documentation) • [Contributing](#contributing) • [Quality Gates](#quality-gates) • [License](#license)
 
@@ -21,13 +22,14 @@ The Rust Self-Learning Memory System provides persistent memory across agent int
 - **do-memory-core**: Core memory operations, pattern extraction, and reward scoring
 - **do-memory-storage-turso**: Primary database storage (libSQL)
 - **do-memory-storage-redb**: Fast embedded cache layer
-- **do-memory-mcp**: MCP server with secure WASM sandbox
+- **do-memory-mcp**: MCP server (lazy tool loading; code-exec fail-closed)
 - **do-memory-cli**: Full-featured command-line interface (episode, pattern, storage, playbook, feedback, and more)
 - **do-memory-test-utils**: Shared testing utilities
 - **do-memory-benches**: Comprehensive benchmark suite
 - **do-memory-examples**: Usage examples and demonstrations
 
-**Tech Stack:** Rust 2024 edition / Tokio + Turso/libSQL + redb cache + Wasmtime WASM + optional embeddings (OpenAI, Mistral, local)
+**Tech Stack:** Rust 2024 edition / Tokio + Turso/libSQL + redb cache + optional embeddings (OpenAI, Mistral, local)  
+**Latest release:** [v0.1.35](https://github.com/d-o-hub/rust-self-learning-memory/releases/tag/v0.1.35) (workspace version `0.1.35`)
 
 ## Features
 
@@ -65,11 +67,10 @@ The Rust Self-Learning Memory System provides persistent memory across agent int
 - Multi-signal ranking: semantic similarity, context match, effectiveness, recency, success rate
 - Minimum success rate filtering (default 70%)
 
-### 🔒 Secure Code Sandbox (conditional)
-- Wasmtime WASM sandbox for safe code execution when enabled/available
-- Resource limits (timeout, memory, CPU)
-- Defense-in-depth security with access controls
-- Support for concurrent executions (20 parallel by default)
+### 🔒 Agent Code Execution (fail-closed)
+- `execute_agent_code` is **not** a working execution backend; calls fail closed
+- Prefer episode lifecycle tools and external runners for agent code
+- Historical WASM/Javy sandbox paths are removed from the supported feature set
 
 ### 📊 Advanced Analysis
 - Statistical analysis (ETS forecasting, MSTL decomposition)
@@ -79,7 +80,7 @@ The Rust Self-Learning Memory System provides persistent memory across agent int
 
 ### 🔍 MCP Server
 - MCP protocol implementation (v2025-11-25) with lazy tool loading
-- **MCP tools** for memory operations, pattern search, and code execution
+- **MCP tools** for memory operations, pattern search, episodes, and embeddings
 - **`search_patterns`** - Semantic pattern search with configurable ranking
 - **`recommend_patterns`** - Task-specific pattern recommendations
 - **`recommend_playbook`** - Actionable step-by-step guidance
@@ -90,11 +91,12 @@ The Rust Self-Learning Memory System provides persistent memory across agent int
 
 ### 🛠️ Full-Featured CLI
 - Top-level command groups include: episode, pattern, storage, config, health, backup, monitor, logs, eval, embedding, completion, tag, relationship, playbook, feedback
-- Episode management (create, list, view, search, complete, delete, update, bulk, filter)
-- Pattern analysis and effectiveness tracking (list, view, analyze, decay, batch)
+- Episode management (create, list, view, search, log-step, complete, **fail**, delete, update, bulk, filter)
+- Pattern analysis and effectiveness tracking (list, view, search, analyze, decay, batch)
+- Discoverable config (`config init` / `config show-template`) and documented precedence (flags → env → config → defaults)
 - Tag management (add, remove, search, rename, stats)
 - Relationship management (add, remove, list, graph, validate)
-- Storage operations (stats, sync, vacuum, health, connections)
+- Storage operations (stats, sync, vacuum, health, connections) — **sync** is Turso↔redb only, not pattern extraction
 - Backup and restore capabilities
 - Multiple output formats (human, JSON, YAML)
 
@@ -106,13 +108,13 @@ The Rust Self-Learning Memory System provides persistent memory across agent int
 - Automatic embedding caching and batch processing
 
 ### 🛡️ Quality Assurance
-- Automated quality gates (`./scripts/quality-gates.sh`)
-- ~2,900 test functions across all crates (cargo-nextest)
+- Automated quality gates (`./scripts/quality-gates.sh`; see `plans/GATE_CONTRACT.md`)
+- Large nextest suite across crates; doctests via `cargo test --doc`
 - Property-based testing (proptest) and snapshot testing (insta)
 - Mutation testing (cargo-mutants) in nightly CI
-- Security auditing and semver checking in CI
-- Zero clippy warnings policy
-- Pre-commit hooks for code quality
+- Blocking advisory gate via `cargo deny`; semver checks in CI
+- Zero clippy warnings policy (`-D warnings`)
+- Skill eval contract: `./scripts/run-evals.sh` (strict non-noop tests)
 
 ## Quick Start
 
@@ -293,17 +295,22 @@ Configuration Wizard provides interactive step-by-step setup with sensible defau
 # Create an episode
 do-memory-cli episode create --task "Implement user authentication" --context '{"language": "rust", "domain": "auth"}'
 
-# List episodes
-do-memory-cli episode list --limit 10
+# Log steps (needed for tool-sequence pattern extraction)
+do-memory-cli episode log-step <episode-id> --tool cargo --action "run tests" --success true
 
-# Search episodes
+# Complete with outcome (success | partial-success | failure)
+do-memory-cli episode complete <episode-id> success
+
+# Force-fail abandoned in_progress rows (operator path; ADR-075)
+do-memory-cli episode fail <episode-id>
+
+# List / search episodes
+do-memory-cli episode list --limit 10
 do-memory-cli episode search "authentication" --limit 5
 
-# Search patterns semantically
-do-memory-cli pattern search --query "How to build REST API" --limit 5
-
-# Analyze patterns
+# Patterns (populated after complete with steps; empty list explains why)
 do-memory-cli pattern list --min-confidence 0.8
+do-memory-cli pattern search --query "How to build REST API" --limit 5
 
 # Tag management
 do-memory-cli tag add <episode-id> "important"
@@ -522,9 +529,8 @@ EMBEDDING_MODEL=text-embedding-3-small
 EMBEDDING_SIMILARITY_THRESHOLD=0.7
 EMBEDDING_BATCH_SIZE=32
 
-# Sandbox settings (MCP server only)
-MCP_USE_WASM=true
-JAVY_PLUGIN=./memory-mcp/javy-plugin.wasm
+# MCP OAuth (production HMAC verification)
+# MCP_OAUTH_TOKEN_SECRET=...
 ```
 
 ### TOML Configuration
@@ -565,8 +571,8 @@ batch_size = 100
 ┌─────────────────────────────────────────────────────────────┐
 │                 do-memory-mcp                               │
 │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐          │
-│  │  MCP Tools  │  │  WASM       │  │  Advanced   │          │
-│  │  Interface  │  │  Sandbox    │  │  Analysis   │          │
+│  │  MCP Tools  │  │  Lazy Tool  │  │  Advanced   │          │
+│  │  Interface  │  │  Loading    │  │  Analysis   │          │
 │  └─────────────┘  └─────────────┘  └─────────────┘          │
 └─────────────────────────────────────────────────────────────┘
                                │
@@ -599,6 +605,7 @@ The MCP server exposes tools via lazy loading (ADR-024):
 - **search_by_embedding** / **embedding_provider_status** — Semantic search and provider monitoring
 - **Episode lifecycle tools** — create, complete, log steps, get, timeline
 - **Advanced analysis** — Statistical analysis, forecasting, anomaly detection, causal inference
+- **Unavailable / fail-closed** — `execute_agent_code` (no working WASM execution backend)
 
 ## Performance
 
@@ -611,7 +618,6 @@ All operations meet or exceed performance targets:
 | Episode Completion | < 500ms | ~3.8 µs (130,890x faster) |
 | Pattern Extraction | < 1000ms | ~10.4 µs (95,880x faster) |
 | Memory Retrieval | < 100ms | ~721 µs (138x faster) |
-| WASM Execution | < 200ms | ~50-200ms (typical) |
 
 Typical performance numbers are from internal benchmarks on a warm cache; results vary by hardware and configuration. Run `cargo bench` for local measurements and see `docs/QUALITY_GATES.md` for the performance regression gate.
 

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -1,25 +1,25 @@
 # Active Development Roadmap
 
-**Last Updated**: 2026-07-17 (open issues analysis #845–#849)
-**Released Version**: v0.1.34 (crates.io + GitHub Release)
-**Workspace Version**: 0.1.35 (unreleased; **27 commits** since tag)
-**Active Sprint**: Open Issues GOAP (ADR-075 / ADR-076)
+**Last Updated**: 2026-07-17 (v0.1.35 release prep)
+**Released Version**: v0.1.35 (crates.io + GitHub Release)
+**Workspace Version**: 0.1.35
+**Active Sprint**: Post-release backlog (K3.1b / W2.1b / S1.7)
 **Branch**: `main`
-**Plan**: `plans/GOAP_OPEN_ISSUES_ANALYSIS_2026-07-17.md`
-**Backlog**: `plans/GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md`
+**Plan**: `plans/GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md`
+**Backlog**: K3.1b, W2.1b, S1.7, W2.4/W2.5, S1.2 provenance remainder
 
 ---
 
-## Sprint 2026-07-17 — Open GitHub Issues ✅ ANALYZED
+## Sprint 2026-07-17 — Open GitHub Issues ✅ MERGED (#850)
 
-**Focus**: Codebase-verify all open issues; ADR + GOAP execution queue.
+**Focus**: Codebase-verify all open issues; ADR + GOAP execution; ship in v0.1.35.
 
 | Priority | Issue | Verdict | Status |
 |----------|-------|---------|--------|
-| P0 | #849 Release due (27 commits / 6 days) | Tag `v0.1.35` via release.yml | 🟡 |
-| P0 | #847 `episode complete failure` no-op | Silent durable write / no verify — **ADR-075** | 🟡 implement |
-| P1 | #845 pattern list empty after ingest | Mostly fixed by #831 on main; residual UX — **ADR-076** | 🟡 after/with release |
-| P2 | #846 config format undocumented | Fixed by #829 on main; needs release | 🟡 close after tag |
+| P0 | #849 Release due | Tag `v0.1.35` via release.yml | 🟡 tagging |
+| P0 | #847 `episode complete failure` no-op | ADR-075 durable complete + `episode fail` | ✅ #850 |
+| P1 | #845 pattern list empty after ingest | ADR-076 empty diagnostics | ✅ #850 |
+| P2 | #846 config format undocumented | Precedence docs + config init | ✅ #850 |
 
 **ADRs**: `plans/adr/ADR-075-CLI-Episode-Complete-Durability-and-Operator-Fail.md`, `plans/adr/ADR-076-Pattern-Extraction-Discoverability-and-Empty-Result-Semantics.md`
 

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -1,20 +1,21 @@
 # Project Status — Self-Learning Memory System
 
-**Last Updated**: 2026-07-17 (pre-release v0.1.35)
-**Released Version**: v0.1.34 (tag); **cutting v0.1.35**
+**Last Updated**: 2026-07-17 (v0.1.35 release)
+**Released Version**: v0.1.35
 **Workspace Version**: 0.1.35
-**Active Sprint**: Release v0.1.35 after PR #850 + #851 merge
+**Active Sprint**: Tag + `release.yml` for v0.1.35
 **Branch**: `main`
 **Edition**: Rust 2024
-**Open GitHub issues**: release-drift #849 (closes on matching tag)
+**Open GitHub issues**: #849 closes when tag `v0.1.35` is pushed
 
-## Release v0.1.35 — READY TO TAG
+## Release v0.1.35 — TAGGING
 
 | Item | Status |
 |------|--------|
 | PR #850 ADR-075/076 open-issue fixes | ✅ Merged |
 | PR #851 K3.1 skill evals + W2.1 gate contract | ✅ Merged |
-| CHANGELOG folded Unreleased → `[0.1.35]` | ✅ |
+| PR #852 CHANGELOG / status fold | ✅ Merged |
+| CHANGELOG `[0.1.35] - 2026-07-17` | ✅ |
 | Tag via `release-manager` + `release.yml` only | 🟡 Next |
 
 ## Open Issues vs Codebase — 2026-07-17


### PR DESCRIPTION
## Summary

`verify-release-state.sh` requires `Released Version` in ROADMAP_ACTIVE and STATUS/CURRENT to equal workspace `0.1.35` before `release-manager` can tag.

## Test plan
- [x] `./scripts/verify-release-state.sh --check-unreleased` passes (warn only for unreleased commits)

After merge + main CI green: `./scripts/release-manager.sh full --execute`