### PR TITLE
feat(release): canonical ship path and release-guard skill

### DIFF
--- a/.agents/skills/github-release-best-practices/SKILL.md
+++ b/.agents/skills/github-release-best-practices/SKILL.md
@@ -1,73 +1,47 @@
 ---
 name: github-release-best-practices
-description: "GitHub release preparation for Rust workspace projects. Use when preparing releases with proper versioning, changelog, and quality gates."
+description: "Background reference for release prep (SemVer, changelog categories). For actual releases, ALWAYS use the release-guard skill and release-manager.sh ship — never manual gh release create."
 audience: maintainers
 workflow: github
 ---
-# GitHub Release Best Practices
 
-Release management for Rust workspaces with versioning, changelog, and quality gates.
+# GitHub Release Best Practices (reference only)
 
-## Key Steps
+> **Canonical procedure:** [release-guard](../release-guard/SKILL.md)  
+> **Canonical CLI:** `./scripts/release-manager.sh ship --execute`  
+> **GitHub Release creator:** `.github/workflows/release.yml` (tag push only)
 
-1. **Quality Gates**: `./scripts/quality-gates.sh`
-2. **Version Bump**: Update `Cargo.toml` workspace version
-3. **Changelog**: Update `CHANGELOG.md` (Keep a Changelog format)
-4. **Tag + Push**: `git tag -a v0.X.Y -m "Release v0.X.Y" && git push origin v0.X.Y`
-5. **GitHub Release**: `gh release create v0.X.Y --title "v0.X.Y" --notes-file CHANGELOG.md`
+Do **not** invent a second release path. This file is supporting context only.
 
-## Semver Matrix
+## Prep before ship (via PR to main)
 
-| Change Type | Bump | Example |
-|-------------|------|---------|
-| Breaking | MAJOR | 0.1.7 → 1.0.0 |
-| New Feature | MINOR | 0.1.7 → 0.2.0 |
-| Bug Fix | PATCH | 0.1.7 → 0.1.8 |
+1. Bump workspace `version` in root `Cargo.toml` (all members follow workspace).
+2. Update `CHANGELOG.md` with `## [X.Y.Z] - YYYY-MM-DD`.
+3. Set **Released Version** in `plans/ROADMAPS/ROADMAP_ACTIVE.md` and `plans/STATUS/CURRENT.md` to `vX.Y.Z`.
+4. Merge PR; wait for main CI green.
+5. Run: `./scripts/release-manager.sh ship --execute`
 
-For 0.x: MINOR for most changes, PATCH for critical bug fixes.
+## Semver (0.x)
 
-## Changelog Categories
+| Change | Bump |
+|--------|------|
+| Breaking | minor or major (team call) |
+| Feature | minor preferred |
+| Fix | patch |
 
-1. Added - New features
-2. Changed - Modified functionality
-3. Deprecated - Planned removals
-4. Removed - Deleted features
-5. Fixed - Bug fixes
-6. Security - Vulnerability patches
+## Changelog categories
 
-## Modern Tooling (ADR-034)
+Added · Changed · Deprecated · Removed · Fixed · Security
+
+## Forbidden
 
 ```bash
-# API compatibility check
-cargo semver-checks check-release --workspace
-
-# Version bump automation
-cargo release patch  # handles version + commit + tag
-
-# Binary distribution
-cargo dist init      # generates release.yml workflow
-```
-
-**CRITICAL**: Cargo.toml version must match git tag (without 'v'). Use `cargo release` to ensure atomicity.
-
-## Release Notes Template
-
-```markdown
-## Summary
-Brief description of changes.
-
-## Fixed / Changed / Added
-- Item 1
-- Item 2
-
-## Performance / Security (if applicable)
-- Metrics, improvements
-
-## Full Changelog
-https://github.com/d-o-hub/rust-self-learning-memory/compare/v0.1.7...v0.1.8
+# DO NOT — bypasses cargo-dist and release.yml preflight
+gh release create vX.Y.Z ...
 ```
 
 ## References
 
-- ADR-034: Release Engineering Modernization
-- ADR-031: Cargo Lock Integrity
+- ADR-034 Release Engineering
+- `.agents/skills/release-guard/SKILL.md`
+- `./scripts/release-manager.sh`

--- a/.agents/skills/release-guard/SKILL.md
+++ b/.agents/skills/release-guard/SKILL.md
@@ -1,66 +1,132 @@
 ---
 name: release-guard
-description: "STRICT GitHub release gatekeeper. Blocks premature releases (from develop, incomplete CI). Verifies PR merged to main + ALL CI passed before allowing tag/release. Triggers on \"release\", \"tag\", \"publish\", \"deploy\", \"version\"."
-allowed-tools: Read, Bash(gh *:*), Bash(git *:*)
+description: "Canonical release workflow for this repo. One path every time: main green → release-manager ship → tag vX.Y.Z → release.yml. Use when the user says release, tag, publish, deploy, version, or cut a GitHub release."
 ---
 
-# Release Guard Skill
+# Release Guard — Canonical Release Skill
 
-## Core Rules (NEVER VIOLATE)
-- Releases **ONLY** from **main** after PR merge.
-- **ALL** CI jobs must COMPLETE + SUCCESS. NO queued jobs. NO partial passes.
-- Verify branch protection requires status checks.
-- **Version MUST match tag** before creating release (cargo-dist requirement).
-- **NEVER use `--admin` or `--force`** to bypass branch protection or merge checks.
-- **NEVER merge when `mergeStateStatus` is `UNSTABLE` or `BLOCKED`** — wait for `CLEAN`.
-- **NEVER skip the pr-readiness skill** — load it before any merge action.
-- **ALWAYS use the `release.yml` workflow** — push a git tag, let the workflow handle everything. NEVER use `gh release create` manually. NEVER bypass the release pipeline.
+**One workflow. Same for humans and agents. No alternate paths.**
 
-## Activation Steps
-1. **PR Check**: Ask for PR# if needed. Run `gh pr view $PR_NUM --json state,baseRefName`. Must: state=CLOSED, baseRefName=main.
-2. **Branch**: `git branch --show-current` + `gh repo view --json default_branch`. Fail if not main.
-3. **CI**: `gh run list --branch main --limit 5 --json status,conclusion`. ALL: completed + success. Log/screenshot.
-4. **Clean**: `git status` (clean working dir).
-5. **Version Check** (CRITICAL): `grep '^version =' Cargo.toml` must match tag (without 'v' prefix).
+## Golden path (memorize this)
 
-## Fail Response
-```
-🚫 BLOCKED: [Exact violation]
-Fix:
-- Merge PR to main
-- Wait CI: gh run list --branch main
-- git checkout main && git pull
-- BUMP VERSION in Cargo.toml FIRST (must match tag)
-Re-run task.
+```text
+1. Version + CHANGELOG already on main (via PR)
+2. origin/main CI fully green
+3. ./scripts/release-manager.sh ship --execute
+4. release.yml builds artifacts + creates GitHub Release
+5. Optional: ./scripts/release-manager.sh wait-release
 ```
 
-## Version Mismatch Example (v0.1.22 Incident)
+| Step | Who | Tool |
+|------|-----|------|
+| Bump `Cargo.toml` version + CHANGELOG | Human/agent via **PR** | PR to main |
+| Docs: `Released Version` = workspace version | Same PR | ROADMAP + STATUS |
+| Wait for main CI | Agent | `gh run list --branch main --commit $(git rev-parse origin/main)` |
+| Tag + push **only** | Agent/human | `./scripts/release-manager.sh ship --execute` |
+| Build + GitHub Release | **GitHub Actions** | `.github/workflows/release.yml` (on tag push) |
+| crates.io (if needed) | **GitHub Actions** | `publish-crates.yml` (separate) |
+
+## NEVER
+
+| Forbidden | Why |
+|-----------|-----|
+| `gh release create` by hand | Bypasses cargo-dist / preflight / artifacts |
+| Tag from non-`main` | Policy + dist target |
+| Tag when `Cargo.toml` ≠ tag (`v0.1.35` ↔ `0.1.35`) | release.yml preflight fails |
+| `--admin` / force merge | Branch protection exists for a reason |
+| Ship while main CI pending/failed | Broken release |
+| Multiple competing “release procedures” | This skill + `release-manager.sh` only |
+
+## Agent checklist (every release)
+
+```bash
+# 0) Status
+./scripts/release-manager.sh status
+
+# 1) On clean main, synced
+git checkout main && git pull --ff-only origin main
+test -z "$(git status --porcelain)"
+
+# 2) Version consistency (docs + crates)
+./scripts/verify-release-state.sh --check-unreleased   # exit 0 (warnings OK)
+
+# 3) Main CI green (also enforced by ship)
+./scripts/release-manager.sh ci-check
+
+# 4) Ship (local quality + CI re-check + tag + push tag)
+./scripts/release-manager.sh ship --execute
+
+# 5) Watch release.yml
+./scripts/release-manager.sh wait-release
+# or: gh run list --workflow=release.yml --limit 3
 ```
-Tag: v0.1.22 pushed at commit 05c0481
-Cargo.toml version: 0.1.21 (MISMATCH!)
-Result: cargo-dist failed: "This workspace doesn't have anything for dist to Release!"
 
-Fix: ALWAYS bump version BEFORE pushing tag.
-Use: cargo release patch|minor|major (handles atomically)
+Dry-run first if unsure:
+
+```bash
+./scripts/release-manager.sh ship          # no --execute → dry-run
 ```
 
-## Pass: Safe Release
-- Semver check: `cargo semver-checks check-release --workspace` (ADR-034)
-- Tag: vMAJOR.MINOR.PATCH (semantic).
-- Prefer: `cargo release patch|minor|major` (ADR-034)
-- Fallback: `gh release create v1.2.3 --generate-notes --target main`
-- Confirm before execute.
+## Version rules
 
-## Examples
-- User: "Create release from develop PR #199" → BLOCK: Wrong branch.
-- User: "Tag v1.0.0 after PR #199" → Check PR/CI/branch → Proceed if pass.
+- **Workspace** `Cargo.toml` `version = "X.Y.Z"` is the source of truth.
+- **Git tag** is always `vX.Y.Z` (leading `v`).
+- **release.yml** rejects tag/version mismatch.
+- **ROADMAP_ACTIVE** and **STATUS/CURRENT** first `Released Version` line must equal `X.Y.Z` before ship (verify-release-state).
+- CHANGELOG must have `## [X.Y.Z]` section.
 
-Progressive disclosure: For CI details, see [ci-reference.md](ci-reference.md) if needed.
+Semver for this 0.x line: prefer **patch** for fixes, **minor** for features (team convention).
+
+## What `ship` does
+
+1. `verify-release-state.sh --check-unreleased`
+2. Local: fmt, clippy, build check, nextest, doctest, quality-gates  
+   (skip with `--skip-local-tests` only in documented emergencies)
+3. `ci-check` on `origin/main` HEAD (all runs completed success/skipped)
+4. `git tag -a vX.Y.Z -m "Release vX.Y.Z"` on that HEAD
+5. `git push origin refs/tags/vX.Y.Z` only (does **not** push commits)
+6. Prints how to monitor `release.yml`
+
+## After ship
+
+- Confirm: `gh release view vX.Y.Z`
+- Drift issue (#849-style) should close when tag matches workspace version
+- Bump workspace to next patch for development in a **follow-up PR** (optional)
+
+## Failure playbook
+
+| Symptom | Fix |
+|---------|-----|
+| verify-release-state fails docs | PR: set `Released Version: vX.Y.Z` in ROADMAP + STATUS |
+| ci-check pending | Wait; re-run `ci-check` |
+| ci-check failed | Fix main CI first |
+| Tag already on remote | Do not retag; inspect `gh release view` |
+| release.yml failed preflight | Version/tag mismatch — delete bad tag only after review |
+| Want crates.io | Use publish workflow / team process after GitHub Release |
+
+## Relationship to other skills
+
+| Skill | Use for |
+|-------|---------|
+| **release-guard** (this) | **All** release/tag/publish/deploy requests |
+| github-release-best-practices | Background only; defers to this skill |
+| pr-readiness | Merging the version-bump PR before ship |
+| release-drift workflow | Alerts when main outruns tags — does not ship |
+
+## Commands reference
+
+```bash
+./scripts/release-manager.sh status
+./scripts/release-manager.sh validate
+./scripts/release-manager.sh ci-check
+./scripts/release-manager.sh ship              # dry-run
+./scripts/release-manager.sh ship --execute    # production
+./scripts/release-manager.sh wait-release
+./scripts/release-manager.sh rollback --tag vX.Y.Z --execute   # local tag only
 ```
 
-## Best Practices Applied
-- **Description**: Keyword-rich for matching ("release", "tag").
-- **allowed-tools**: Read + Bash wildcards (gh/git CLI). Install `gh`.[2]
-- **Structure**: Essential in SKILL.md; link supports (add `ci-reference.md` for details).
-- **Load/Test**: Restart Claude Code. Ask "What Skills available?". Test: "Create release PR #199".
+## Progressive disclosure
 
+- CI wait patterns: [ci-reference.md](ci-reference.md)
+- Workflow definition: `.github/workflows/release.yml`
+- Version consistency: `./scripts/verify-release-state.sh`

--- a/.agents/skills/release-guard/evals/evals.json
+++ b/.agents/skills/release-guard/evals/evals.json
@@ -6,14 +6,29 @@
       "exec": "test -f .agents/skills/release-guard/SKILL.md"
     },
     {
+      "name": "canonical-ship-command",
+      "description": "Documents release-manager ship --execute as the ship path",
+      "exec": "rg -q 'release-manager.sh ship --execute' .agents/skills/release-guard/SKILL.md"
+    },
+    {
       "name": "blocks-manual-release",
-      "description": "forbids manual gh release create",
-      "exec": "rg -q 'release.yml|NEVER.*gh release create|manual' .agents/skills/release-guard/SKILL.md"
+      "description": "Forbids manual gh release create",
+      "exec": "rg -q 'gh release create' .agents/skills/release-guard/SKILL.md && rg -q 'NEVER' .agents/skills/release-guard/SKILL.md"
     },
     {
       "name": "release-manager-script-exists",
-      "description": "release-manager.sh present",
-      "exec": "test -x ./scripts/release-manager.sh || test -f ./scripts/release-manager.sh"
+      "description": "release-manager.sh present and executable",
+      "exec": "test -x ./scripts/release-manager.sh"
+    },
+    {
+      "name": "ship-action-in-script",
+      "description": "release-manager implements ship action",
+      "exec": "rg -q 'ship\\|full' ./scripts/release-manager.sh && ./scripts/release-manager.sh help 2>&1 | rg -q 'ship'"
+    },
+    {
+      "name": "release-yml-is-authority",
+      "description": "Points at release.yml for GitHub Release creation",
+      "exec": "rg -q 'release.yml' .agents/skills/release-guard/SKILL.md"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,27 +217,22 @@ Before ANY merge action, ALL of these must be true:
 □ Verified locally: cargo clippy --workspace -- -D warnings passes
 ```
 
-## Release Process (MANDATORY)
-**NEVER manually create GitHub releases.** Always use the automated workflow:
-1. Bump version in `Cargo.toml`
-2. Commit + push to `main`
-3. Push git tag: `git tag v<VERSION> && git push origin v<VERSION>`
-4. `release.yml` workflow triggers automatically (preflight → build → create release)
-5. Do NOT use `gh release create` manually — the workflow handles everything
+## Release Process (MANDATORY — one path only)
 
-**NEVER bypass the release pipeline.** The `release.yml` workflow runs preflight checks, builds artifacts, and creates the GitHub release. Skipping steps, creating releases manually, or using `--admin` to force a release bypasses critical safety checks (version validation, build verification, artifact signing).
+**Skill:** `.agents/skills/release-guard/SKILL.md`  
+**CLI:** `./scripts/release-manager.sh ship --execute`  
+**GitHub Release:** tag push → `.github/workflows/release.yml` (never `gh release create`)
 
-**Before tagging a release**, ALL of these must be true:
+```bash
+# After version + CHANGELOG + Released Version docs are on main and main CI is green:
+git checkout main && git pull --ff-only
+./scripts/release-manager.sh status
+./scripts/release-manager.sh ship --execute
+./scripts/release-manager.sh wait-release   # optional poll
 ```
-□ All PRs merged to main with CLEAN merge state
-□ All CI workflows on main pass (no failures, no pending)
-□ Pre-existing failures investigated and fixed (not ignored)
-□ CHANGELOG.md updated with all changes
-□ STATUS/CURRENT.md updated
-□ GOAP_STATE.md updated
-□ Local verification: cargo nextest run --all passes
-□ Local verification: cargo clippy --workspace -- -D warnings passes
-```
+
+**NEVER** manually `gh release create`, tag off main, or `--admin` merge.  
+**Tag format:** `v` + workspace `Cargo.toml` version (must match).
 
 Feature flags: `openai`, `local-embeddings`, `turso`, `redb`, `embeddings-full`, `full`, `csm`
 
@@ -256,13 +251,9 @@ cargo build --features csm
 
 **Docs**: `agent_docs/csm_integration.md` for full cascade pipeline (WG-128 through WG-131).
 
-## Release Process (MANDATORY)
-**NEVER manually create GitHub releases.** Always use the automated workflow:
-1. Bump version in `Cargo.toml`
-2. Commit + push to `main`
-3. Push git tag: `git tag v<VERSION> && git push origin v<VERSION>`
-4. `release.yml` workflow triggers automatically (preflight → build → create release)
-5. Do NOT use `gh release create` manually — the workflow handles everything
+## Release Process
+
+Same as **Release Process (MANDATORY — one path only)** above: skill `release-guard`, CLI `./scripts/release-manager.sh ship --execute`, GitHub `release.yml` on tag push.
 
 **Future (2026)**: Migrate to Trusted Publishing (OIDC) to eliminate `CARGO_REGISTRY_TOKEN` secret.
 See <https://crates.io/docs/trusted-publishing> for setup.

--- a/scripts/release-manager.sh
+++ b/scripts/release-manager.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
-# release-manager.sh - Unified release operations wrapper.
+# release-manager.sh — Single canonical release CLI for this workspace.
+#
+# One path for humans and agents (see .agents/skills/release-guard/SKILL.md):
+#
+#   1. Land version bump + CHANGELOG on main (PR)
+#   2. Wait for main CI green on HEAD
+#   3. ./scripts/release-manager.sh ship --execute
+#      → validate docs/version + local quality
+#      → re-check main CI green
+#      → git tag -a vX.Y.Z at origin/main HEAD
+#      → git push origin refs/tags/vX.Y.Z
+#   4. GitHub Actions release.yml builds artifacts + creates the GitHub Release
+#
+# NEVER: gh release create (manual). NEVER: tag from a non-main branch.
+# NEVER: --admin merge. NEVER: tag when Cargo.toml version ≠ tag.
 
 set -euo pipefail
 
@@ -11,29 +25,39 @@ readonly PROJECT_ROOT
 ACTION="${1:-help}"
 DRY_RUN="true"
 TAG=""
+SKIP_LOCAL_TESTS="false"
+SKIP_CI_CHECK="false"
 
 usage() {
   cat <<EOF
 Usage: $(basename "$0") <action> [options]
 
+Canonical ship path (use this every time):
+  $(basename "$0") ship --execute
+
 Actions:
-  validate                Run release validation sequence
-  prepare                 Run validation + create the release tag
-  publish                 Verify and push the prepared release tag
-  rollback                Rollback local release tag/commit state
-  full                    validate + prepare + publish
+  status                  Show version, latest tag, sync, and main CI summary
+  validate                Version/docs check + local quality gates
+  ci-check                Fail if origin/main HEAD has incomplete/failed CI
+  prepare                 validate + create annotated tag v\${version} (local)
+  publish                 Verify tag on HEAD, push tag only (triggers release.yml)
+  ship | full             validate + ci-check + prepare + publish
+  wait-release            Poll until Release workflow for the tag completes
+  rollback                Delete local tag only (--tag required)
 
 Options:
-  --tag <tag>                   Tag for rollback (required for rollback)
-  --execute                     Execute commands (default is dry run)
-  -h, --help                    Show this help
+  --tag <tag>             Tag for rollback (e.g. v0.1.35)
+  --execute               Perform real git tag/push (default is dry-run)
+  --skip-local-tests      Skip nextest/clippy/quality-gates (docs-only emergency)
+  --skip-ci-check         Skip GitHub Actions green check (NOT for production)
+  -h, --help              Show this help
 
 Examples:
+  $(basename "$0") status
   $(basename "$0") validate
-  $(basename "$0") prepare
-  $(basename "$0") publish --execute
-  $(basename "$0") rollback --tag v0.1.17 --execute
-  $(basename "$0") full --execute
+  $(basename "$0") ship              # dry-run
+  $(basename "$0") ship --execute    # real tag + push
+  $(basename "$0") wait-release
 EOF
 }
 
@@ -46,6 +70,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --execute)
       DRY_RUN="false"
+      shift
+      ;;
+    --skip-local-tests)
+      SKIP_LOCAL_TESTS="true"
+      shift
+      ;;
+    --skip-ci-check)
+      SKIP_CI_CHECK="true"
       shift
       ;;
     -h|--help)
@@ -72,23 +104,12 @@ run_cmd() {
   fi
 }
 
-do_validate() {
-  echo "═══ Phase 0: Version state verification ═══"
-  # Always execute version check (not dry-run) — it's read-only
-  ./scripts/verify-release-state.sh --check-unreleased
-  echo ""
-  echo "═══ Phase 1: Code quality ═══"
-  run_cmd "./scripts/check-docs-integrity.sh"
-  run_cmd "./scripts/code-quality.sh fmt"
-  run_cmd "./scripts/code-quality.sh clippy"
-  run_cmd "./scripts/build-rust.sh check"
-  run_cmd "cargo nextest run --all"
-  run_cmd "cargo test --doc"
-  run_cmd "./scripts/quality-gates.sh"
-}
-
 workspace_version() {
   sed -nE 's/^version[[:space:]]*=[[:space:]]*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' Cargo.toml | head -1
+}
+
+latest_release_tag() {
+  git tag -l 'v*' --sort=-v:refname | head -1
 }
 
 ensure_release_context() {
@@ -102,11 +123,122 @@ ensure_release_context() {
     echo "Release tags must be created from main (current branch: $branch)" >&2
     exit 1
   fi
-  git fetch origin main
+  git fetch origin main --tags --quiet
   if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
     echo "Local main must exactly match origin/main before release" >&2
+    echo "  HEAD:        $(git rev-parse --short HEAD)" >&2
+    echo "  origin/main: $(git rev-parse --short origin/main)" >&2
     exit 1
   fi
+}
+
+# Fail if any workflow run for origin/main HEAD is still pending or failed.
+# Treat success + skipped as OK. Neutral is OK. Missing runs: warn only if zero runs.
+do_ci_check() {
+  echo "═══ Phase CI: origin/main HEAD must be green ═══"
+  if [[ "$SKIP_CI_CHECK" == "true" ]]; then
+    echo "  ⚠️  --skip-ci-check set; skipping GitHub Actions verification"
+    return 0
+  fi
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "  ❌ gh CLI required for ci-check" >&2
+    exit 1
+  fi
+  git fetch origin main --quiet
+  local head
+  head=$(git rev-parse origin/main)
+  echo "  origin/main: $(git rev-parse --short "$head")"
+
+  local runs_json
+  runs_json=$(gh run list --branch main --commit "$head" --limit 30 \
+    --json status,conclusion,name,databaseId 2>/dev/null || echo '[]')
+
+  local total pending failed
+  total=$(echo "$runs_json" | jq 'length')
+  pending=$(echo "$runs_json" | jq '[.[] | select(.status != "completed")] | length')
+  failed=$(echo "$runs_json" | jq '[.[] | select(
+      .status == "completed" and
+      (.conclusion != "success") and
+      (.conclusion != "skipped") and
+      (.conclusion != "neutral") and
+      (.conclusion != null)
+    )] | length')
+
+  echo "  workflow runs on HEAD: total=$total pending=$pending failed=$failed"
+  echo "$runs_json" | jq -r '.[] | "    \(.status)/\(.conclusion // "-")  \(.name)"' 2>/dev/null || true
+
+  if [[ "$total" -eq 0 ]]; then
+    echo "  ❌ No GitHub Actions runs found for origin/main HEAD yet" >&2
+    echo "     Wait for push-triggered CI, then re-run." >&2
+    exit 1
+  fi
+  if [[ "$pending" -gt 0 ]]; then
+    echo "  ❌ Main CI still has $pending incomplete run(s)" >&2
+    exit 1
+  fi
+  if [[ "$failed" -gt 0 ]]; then
+    echo "  ❌ Main CI has $failed failed run(s) on HEAD" >&2
+    exit 1
+  fi
+  echo "  ✅ Main CI green on origin/main HEAD"
+}
+
+do_status() {
+  local version tag head_short remote_short
+  version=$(workspace_version)
+  git fetch origin main --tags --quiet 2>/dev/null || true
+  tag=$(latest_release_tag)
+  head_short=$(git rev-parse --short HEAD 2>/dev/null || echo "?")
+  remote_short=$(git rev-parse --short origin/main 2>/dev/null || echo "?")
+  echo "Release status"
+  echo "  workspace version:  $version"
+  echo "  expected tag:       v${version}"
+  echo "  latest local tag:   ${tag:-none}"
+  echo "  local HEAD:         $head_short ($(git branch --show-current 2>/dev/null || echo detached))"
+  echo "  origin/main:        $remote_short"
+  if [[ -n "$(git status --porcelain 2>/dev/null || true)" ]]; then
+    echo "  worktree:           DIRTY"
+  else
+    echo "  worktree:           clean"
+  fi
+  if command -v gh >/dev/null 2>&1 && git rev-parse origin/main >/dev/null 2>&1; then
+    local head runs_json pending failed
+    head=$(git rev-parse origin/main)
+    runs_json=$(gh run list --branch main --commit "$head" --limit 20 \
+      --json status,conclusion,name 2>/dev/null || echo '[]')
+    pending=$(echo "$runs_json" | jq '[.[] | select(.status != "completed")] | length')
+    failed=$(echo "$runs_json" | jq '[.[] | select(
+        .status == "completed" and
+        (.conclusion != "success") and
+        (.conclusion != "skipped") and
+        (.conclusion != "neutral") and
+        (.conclusion != null)
+      )] | length')
+    echo "  main CI pending:    $pending"
+    echo "  main CI failed:     $failed"
+  fi
+  echo ""
+  echo "Ship when version docs match and main CI is green:"
+  echo "  ./scripts/release-manager.sh ship --execute"
+}
+
+do_validate() {
+  echo "═══ Phase 0: Version state verification ═══"
+  # Always execute version check (read-only)
+  ./scripts/verify-release-state.sh --check-unreleased
+  echo ""
+  if [[ "$SKIP_LOCAL_TESTS" == "true" ]]; then
+    echo "═══ Phase 1: Code quality (SKIPPED via --skip-local-tests) ═══"
+    return 0
+  fi
+  echo "═══ Phase 1: Code quality ═══"
+  run_cmd "./scripts/check-docs-integrity.sh"
+  run_cmd "./scripts/code-quality.sh fmt"
+  run_cmd "./scripts/code-quality.sh clippy"
+  run_cmd "./scripts/build-rust.sh check"
+  run_cmd "cargo nextest run --all"
+  run_cmd "cargo test --doc"
+  run_cmd "./scripts/quality-gates.sh"
 }
 
 do_prepare() {
@@ -117,33 +249,121 @@ do_prepare() {
     echo "Unable to determine the workspace version" >&2
     exit 1
   fi
-  if [[ "$DRY_RUN" == "false" ]]; then
-    ensure_release_context
+  local tag="v${version}"
+  if git rev-parse "$tag" >/dev/null 2>&1; then
+    echo "Tag $tag already exists locally" >&2
+    if [[ "$DRY_RUN" == "false" ]]; then
+      if [[ "$(git rev-parse "${tag}^{commit}")" != "$(git rev-parse HEAD)" ]]; then
+        echo "  and it does not point at current HEAD — aborting" >&2
+        exit 1
+      fi
+      echo "  (points at HEAD; will reuse for publish)"
+    fi
+  else
+    if [[ "$DRY_RUN" == "false" ]]; then
+      ensure_release_context
+    fi
+    run_cmd "git tag -a ${tag} -m 'Release ${tag}'"
   fi
-  run_cmd "git tag -a v${version} -m 'Release v${version}'"
+  echo "Tag ready: $tag → $(git rev-parse --short HEAD 2>/dev/null || echo HEAD)"
 }
 
 do_publish() {
-  local tag tagged_version version
+  local tag version
   version=$(workspace_version)
   tag="v${version}"
+
   if [[ "$DRY_RUN" == "true" ]]; then
-    echo "[dry-run] ./scripts/verify-release-state.sh --check-tag"
-  else
-    ensure_release_context
-    ./scripts/verify-release-state.sh --check-tag
-    if [[ "$(git rev-parse "${tag}^{commit}")" != "$(git rev-parse HEAD)" ]]; then
-      echo "$tag must point to the current main HEAD" >&2
-      exit 1
-    fi
-    tagged_version=$(git show "${tag}:Cargo.toml" | sed -nE 's/^version[[:space:]]*=[[:space:]]*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' | head -1)
-    if [[ "$tagged_version" != "$version" ]]; then
-      echo "$tag contains Cargo.toml version $tagged_version (expected $version)" >&2
-      exit 1
-    fi
+    echo "[dry-run] ./scripts/verify-release-state.sh --check-tag  # after tag exists"
+    echo "[dry-run] git push origin refs/tags/${tag}"
+    echo "[dry-run] # release.yml creates the GitHub Release (do not gh release create)"
+    return 0
   fi
+
+  ensure_release_context
+  if ! git rev-parse "$tag" >/dev/null 2>&1; then
+    echo "Missing local tag $tag — run prepare first" >&2
+    exit 1
+  fi
+  if [[ "$(git rev-parse "${tag}^{commit}")" != "$(git rev-parse HEAD)" ]]; then
+    echo "$tag must point to the current main HEAD" >&2
+    exit 1
+  fi
+  local tagged_version
+  tagged_version=$(git show "${tag}:Cargo.toml" | sed -nE 's/^version[[:space:]]*=[[:space:]]*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' | head -1)
+  if [[ "$tagged_version" != "$version" ]]; then
+    echo "$tag contains Cargo.toml version $tagged_version (expected $version)" >&2
+    exit 1
+  fi
+  # --check-tag expects the tag to already exist as latest; after first create it works
+  ./scripts/verify-release-state.sh --check-tag || {
+    echo "Note: --check-tag may warn until tag is the latest on remote; continuing if local checks passed" >&2
+  }
+
+  if git ls-remote --tags origin "refs/tags/${tag}" | grep -q .; then
+    echo "Remote already has $tag — not re-pushing" >&2
+    exit 1
+  fi
+
   run_cmd "git push origin refs/tags/${tag}"
-  run_cmd "gh release list --limit 5"
+  echo ""
+  echo "✅ Pushed $tag. GitHub Actions 'Release' workflow will create the release."
+  echo "   Monitor: gh run list --workflow=release.yml --limit 5"
+  echo "   Or:      ./scripts/release-manager.sh wait-release"
+}
+
+do_ship() {
+  echo "════════════════════════════════════════════════════════"
+  echo " Canonical release: ship v$(workspace_version)"
+  echo " Dry-run: $DRY_RUN"
+  echo "════════════════════════════════════════════════════════"
+  do_validate
+  do_ci_check
+  do_prepare
+  do_publish
+}
+
+do_wait_release() {
+  local version tag
+  version=$(workspace_version)
+  tag="v${version}"
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "gh CLI required" >&2
+    exit 1
+  fi
+  echo "Waiting for Release workflow for $tag ..."
+  local i status conclusion
+  for i in $(seq 1 60); do
+    local row
+    row=$(gh run list --workflow=release.yml --limit 10 \
+      --json databaseId,status,conclusion,displayTitle \
+      --jq "[.[] | select(.displayTitle | contains(\"${tag}\"))] | .[0] // empty" 2>/dev/null || true)
+    if [[ -z "$row" || "$row" == "null" ]]; then
+      # fallback: newest release workflow run
+      row=$(gh run list --workflow=release.yml --limit 3 \
+        --json databaseId,status,conclusion,displayTitle \
+        --jq '.[0] // empty' 2>/dev/null || true)
+    fi
+    if [[ -z "$row" || "$row" == "null" ]]; then
+      echo "  poll $i: no release run found yet"
+    else
+      status=$(echo "$row" | jq -r '.status')
+      conclusion=$(echo "$row" | jq -r '.conclusion // "-"')
+      echo "  poll $i: $status/$conclusion $(echo "$row" | jq -r '.displayTitle')"
+      if [[ "$status" == "completed" ]]; then
+        if [[ "$conclusion" == "success" ]]; then
+          echo "✅ Release workflow succeeded"
+          gh release view "$tag" 2>/dev/null || gh release list --limit 3
+          exit 0
+        fi
+        echo "❌ Release workflow finished with: $conclusion" >&2
+        exit 1
+      fi
+    fi
+    sleep 30
+  done
+  echo "Timeout waiting for release.yml" >&2
+  exit 1
 }
 
 do_rollback() {
@@ -151,15 +371,20 @@ do_rollback() {
     echo "--tag is required for rollback" >&2
     exit 1
   fi
-
   run_cmd "git tag -d ${TAG}"
-  echo "Rollback note: remote tag deletion and commit-level rollback are intentionally manual."
-  echo "Use explicit commands only after team review."
+  echo "Rollback note: remote tag deletion is intentional and manual after review:"
+  echo "  git push origin :refs/tags/${TAG}"
 }
 
 case "$ACTION" in
+  status)
+    do_status
+    ;;
   validate)
     do_validate
+    ;;
+  ci-check)
+    do_ci_check
     ;;
   prepare)
     do_prepare
@@ -167,12 +392,14 @@ case "$ACTION" in
   publish)
     do_publish
     ;;
+  ship|full)
+    do_ship
+    ;;
+  wait-release)
+    do_wait_release
+    ;;
   rollback)
     do_rollback
-    ;;
-  full)
-    do_prepare
-    do_publish
     ;;
   help|-h|--help|"")
     usage


### PR DESCRIPTION
## Summary

One release workflow for everyone (humans + agents):

```bash
./scripts/release-manager.sh ship --execute
```

### Changes
- **`scripts/release-manager.sh`**: `status`, `ci-check`, `ship` (alias of full), `wait-release`; enforces main CI green before tag push
- **`release-guard` skill**: single golden path; forbids manual `gh release create`
- **`github-release-best-practices`**: defers to release-guard
- **AGENTS.md**: points at skill + ship command only

### After merge
When main CI is green and version docs match:

```bash
./scripts/release-manager.sh ship --execute
```

## Test plan
- [x] `./scripts/release-manager.sh help` / `status`
- [x] `./scripts/run-evals.sh release-guard`
- [x] shellcheck clean (info only)