### PR TITLE
fix(release): restore cargo-dist changelog notes format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2431,7 +2431,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - quality fixes and MCP protocol upgrade ([5b96562](https://github.com/d-o-hub/rust-self-learning-memory/commit/5b9656292fda84d1e51ca56bf5d7da7486359090))
 
 
-## [0.1.11] - 2026-01-04
+## [0.1.11-2026-01-04] - 2026-01-04
 
 
 
@@ -2542,7 +2542,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bump version to v0.1.10 ([5b7808d](https://github.com/d-o-hub/rust-self-learning-memory/commit/5b7808d3ab6ea15ace731db5c2e7c6e120b4b493))
 
 
-## [0.1.10] - 2026-01-02
+## [0.1.10-2026-01-02] - 2026-01-02
 
 
 

--- a/scripts/verify-release-state.sh
+++ b/scripts/verify-release-state.sh
@@ -173,6 +173,10 @@ if [[ "$CHECK_UNRELEASED" == "true" ]]; then
 fi
 
 # ─── 7. Check CHANGELOG.md has entry for current version ───
+# cargo-dist (release.yml) uses parse-changelog on root CHANGELOG.md.
+# Duplicate ## [X.Y.Z] headings make parse-changelog fail, so GitHub Releases
+# only get download tables and NO "## Release Notes" section (see v0.1.35).
+# Required format matches v0.1.34: ## Release Notes + version section + downloads.
 echo ""
 echo "── Checking CHANGELOG.md ──"
 if [[ -f "CHANGELOG.md" ]]; then
@@ -181,6 +185,33 @@ if [[ -f "CHANGELOG.md" ]]; then
   else
     echo "  ❌ CHANGELOG.md missing entry for v$WORKSPACE_VERSION"
     failures=$((failures + 1))
+  fi
+
+  # Unique Keep-a-Changelog version headings (exclude Unreleased and dated suffixes)
+  DUP_VERS=$(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md \
+    | sed 's/^## \[//;s/\]$//' \
+    | sort | uniq -d || true)
+  if [[ -n "$DUP_VERS" ]]; then
+    echo "  ❌ CHANGELOG.md has duplicate version headings (breaks cargo-dist notes):"
+    echo "$DUP_VERS" | sed 's/^/       /'
+    failures=$((failures + 1))
+  else
+    echo "  ✅ No duplicate ## [X.Y.Z] version headings"
+  fi
+
+  if command -v parse-changelog >/dev/null 2>&1; then
+    if parse-changelog CHANGELOG.md >/dev/null 2>&1 \
+      && parse-changelog CHANGELOG.md "$WORKSPACE_VERSION" >/dev/null 2>&1; then
+      echo "  ✅ parse-changelog accepts CHANGELOG.md and extracts v$WORKSPACE_VERSION"
+    else
+      echo "  ❌ parse-changelog cannot parse CHANGELOG.md / v$WORKSPACE_VERSION"
+      echo "     cargo-dist will ship download tables only (no Release Notes)."
+      parse-changelog CHANGELOG.md 2>&1 | head -3 | sed 's/^/       /' || true
+      failures=$((failures + 1))
+    fi
+  else
+    echo "  ⚠️  parse-changelog not installed (cargo install parse-changelog-cli)"
+    warnings=$((warnings + 1))
   fi
 else
   echo "  ⚠️  CHANGELOG.md not found"


### PR DESCRIPTION
## Summary

**Why v0.1.35 had no changelog:** cargo-dist uses `parse-changelog` on root `CHANGELOG.md`. Duplicate `## [0.1.11]` and `## [0.1.10]` headings made parsing fail, so GitHub Releases only got download tables.

**v0.1.34 format (required every time):**
1. `## Release Notes` + CHANGELOG section body  
2. Per-package download tables  

### Fixes
- Rename historical duplicate headings (`0.1.11-2026-01-04`, `0.1.10-2026-01-02`)
- `verify-release-state.sh` fails on duplicate versions / unparseable CHANGELOG
- Live `v0.1.35` release notes already patched via `gh release edit` to match v0.1.34

## Test plan
- [x] `parse-changelog CHANGELOG.md 0.1.35` succeeds
- [x] `./scripts/verify-release-state.sh` reports unique headings
- [x] `gh release view v0.1.35` shows `## Release Notes`