### PR TITLE
docs(plans): mark v0.1.35 released; post-release backlog

### DIFF
--- a/.agents/skills/github-release-best-practices/SKILL.md
+++ b/.agents/skills/github-release-best-practices/SKILL.md
@@ -16,10 +16,11 @@ Do **not** invent a second release path. This file is supporting context only.
 ## Prep before ship (via PR to main)
 
 1. Bump workspace `version` in root `Cargo.toml` (all members follow workspace).
-2. Update `CHANGELOG.md` with `## [X.Y.Z] - YYYY-MM-DD`.
+2. Update `CHANGELOG.md` with **exactly one** `## [X.Y.Z] - YYYY-MM-DD` (unique version headers — cargo-dist/parse-changelog fails silently on duplicates → empty GitHub Release body).
 3. Set **Released Version** in `plans/ROADMAPS/ROADMAP_ACTIVE.md` and `plans/STATUS/CURRENT.md` to `vX.Y.Z`.
 4. Merge PR; wait for main CI green.
 5. Run: `./scripts/release-manager.sh ship --execute`
+6. Confirm notes: `gh release view vX.Y.Z` shows `## Release Notes` content (v0.1.34/v0.1.35 format).
 
 ## Semver (0.x)
 

--- a/.agents/skills/release-guard/SKILL.md
+++ b/.agents/skills/release-guard/SKILL.md
@@ -73,9 +73,24 @@ Dry-run first if unsure:
 - **Git tag** is always `vX.Y.Z` (leading `v`).
 - **release.yml** rejects tag/version mismatch.
 - **ROADMAP_ACTIVE** and **STATUS/CURRENT** first `Released Version` line must equal `X.Y.Z` before ship (verify-release-state).
-- CHANGELOG must have `## [X.Y.Z]` section.
+- CHANGELOG must have **exactly one** `## [X.Y.Z]` section (unique version headers).
 
 Semver for this 0.x line: prefer **patch** for fixes, **minor** for features (team convention).
+
+### CHANGELOG / GitHub Release notes (mandatory)
+
+`release.yml` (cargo-dist) uses **parse-changelog** to fill the GitHub Release body from `CHANGELOG.md`. Format must stay consistent with published releases (e.g. v0.1.34 / v0.1.35):
+
+1. **Unique** `## [X.Y.Z] - YYYY-MM-DD` headings — duplicate historical versions make parse-changelog fail and produce an **empty** release body.
+2. Ship notes under standard Keep a Changelog sections (`### Added`, `### Fixed`, …).
+3. After `wait-release`, confirm: `gh release view vX.Y.Z` shows `## Release Notes` content (not blank).
+4. If notes were empty: fix CHANGELOG uniqueness → `gh release edit vX.Y.Z --notes-file …` (or re-run notes step); land verify gate (PR #858 pattern) so it cannot regress.
+
+```bash
+# Pre-ship: changelog must parse for the version being tagged
+parse-changelog CHANGELOG.md "$VERSION" >/dev/null
+./scripts/verify-release-state.sh --check-unreleased
+```
 
 ## What `ship` does
 
@@ -102,6 +117,7 @@ Semver for this 0.x line: prefer **patch** for fixes, **minor** for features (te
 | ci-check failed | Fix main CI first |
 | Tag already on remote | Do not retag; inspect `gh release view` |
 | release.yml failed preflight | Version/tag mismatch — delete bad tag only after review |
+| GitHub Release body empty / no notes | Duplicate `## [X.Y.Z]` in CHANGELOG (parse-changelog fails). Make versions unique; `gh release edit` to restore notes; keep gate in verify-release-state |
 | Want crates.io | Use publish workflow / team process after GitHub Release |
 
 ## Relationship to other skills

--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -1,11 +1,23 @@
 # GOAP Actions Backlog
 
-- **Last Updated**: 2026-07-17 (merge main + K3.1/W2.1)
+- **Last Updated**: 2026-07-18 (v0.1.35 shipped)
 - **Archived Plans**: `plans/archive/2026-03-consolidation/`
-- **Active plan**: `plans/GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md` (K3.1/W2.1)
+- **Active plan**: `plans/GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md` (post-release: K3.1b / W2.1b / S1.7)
 - **ADRs**: ADR-075, ADR-076 (merged via PR #850)
+- **Release path**: `release-guard` + `./scripts/release-manager.sh ship --execute` only
 
-## Active Actions (2026-07-17b K3.1 + W2.1)
+## Active Actions (2026-07-18 Post-Release)
+
+| ID | Action | Status |
+|----|--------|--------|
+| ACT-250 | Merge PR #858 (unique CHANGELOG versions + parse-changelog gate) | 🟡 Open |
+| ACT-251 | Close or supersede optional PR #856 if #858 covers notes | ⏳ |
+| ACT-252 | K3.1b CI job for changed skill evals | ⏳ Backlog |
+| ACT-253 | W2.1b full gate-contract CI parity | ⏳ Backlog |
+| ACT-254 | S1.7 / W2.4 / W2.5 / S1.2 provenance remainder | ⏳ Backlog |
+| ACT-255 | When next version ready: bump workspace + ship via release-guard | ⏳ Not started |
+
+## Completed Actions (2026-07-17b K3.1 + W2.1 — PR #851 ✅ MERGED)
 
 | ID | Action | Status |
 |----|--------|--------|
@@ -13,10 +25,10 @@
 | ACT-241 | Migrate skill evals off noop true / legacy evals | ✅ Done |
 | ACT-242 | Gate contract matrix (W2.1a) | ✅ Done |
 | ACT-243 | validate-gate-contract.sh | ✅ Done |
-| ACT-244 | Open PR for K3.1/W2.1 | 🟡 PR #851 |
-| ACT-245 | CI wire K3.1b / W2.1b | ⏳ |
+| ACT-244 | Open PR for K3.1/W2.1 | ✅ PR #851 merged |
+| ACT-245 | CI wire K3.1b / W2.1b | ⏳ follow-up (ACT-252/253) |
 
-## Completed Actions (2026-07-17 Open Issues — PR #850 ✅ MERGED)
+## Completed Actions (2026-07-17 Open Issues — PR #850 + v0.1.35 ✅)
 
 | ID | Action | Issue / ADR | Status |
 |----|--------|-------------|--------|
@@ -25,14 +37,16 @@
 | ACT-222 | CLI verify-after-write; never false-green complete | #847 / ADR-075 | ✅ Done |
 | ACT-223 | `episode fail` operator path | #847 / ADR-075 | ✅ Done |
 | ACT-224 | Tests: durability mock backends + CLI command tests | #847 | ✅ Done |
-| ACT-225 | Cut v0.1.35 via release-manager + release.yml | #849 | ⏳ After release ready |
+| ACT-225 | Cut v0.1.35 via release-manager + release.yml | #849 | ✅ Done (published 2026-07-17) |
 | ACT-226 | Pattern empty-list human diagnostics | #845 / ADR-076 | ✅ Done |
 | ACT-227 | storage sync local-only messaging (not extraction) | #845 / ADR-076 | ✅ Done |
 | ACT-228 | Config precedence table polish | #846 | ✅ Done |
-| ACT-229 | Close/comment #845/#846 after release verification | #845, #846 | ⏳ After ACT-225 |
+| ACT-229 | Close/comment #845/#846 after release verification | #845, #846 | ✅ Closed |
 | ACT-230 | Open PR + all CI green + merge | swarm | ✅ PR #850 merged |
+| ACT-231 | Canonical release path (ship + release-guard skill) | PR #855 | ✅ Merged |
+| ACT-232 | Restore GitHub release notes to v0.1.34 format | release | ✅ Done on live release |
 
-## Active Actions (2026-07-16b S1.3–S1.6 + W2.2)
+## Completed Actions (2026-07-16b S1.3–S1.6 + W2.2)
 
 | ID | Action | Status |
 |----|--------|--------|
@@ -43,7 +57,7 @@
 | ACT-214 | W2.2 cargo deny blocking; remove audit soft-pass | ✅ Done |
 | ACT-215 | Tests + plans update | ✅ Done |
 | ACT-216 | Open PR + CI green + review | ✅ Code on main |
-| ACT-217 | Cut v0.1.35 via release.yml (superseded by ACT-225 / #849) | ⏳ |
+| ACT-217 | Cut v0.1.35 via release.yml (superseded by ACT-225 / #849) | ✅ Done (ACT-225) |
 
 ## Completed Actions (2026-07-16 Missing Tasks Swarm — PR #840)
 
@@ -56,9 +70,9 @@
 | ACT-204 | S1.1a/D3.2 fail-closed execute_agent_code + README fixes | ✅ Done |
 | ACT-205 | Update plans/ + CHANGELOG for swarm | ✅ Done |
 | ACT-206 | Open PR + CI green + review | ✅ Done (PR #840) |
-| ACT-207 | Cut v0.1.35 via release.yml (closes #828/#838) | ⏳ After release ready |
+| ACT-207 | Cut v0.1.35 via release.yml (closes #828/#838) | ✅ Done (ACT-225) |
 
-## Completed Actions (v0.1.35 CLI UX Patch — on main)
+## Completed Actions (v0.1.35 CLI UX Patch — shipped)
 
 | ID | Action | Status |
 |----|--------|--------|
@@ -69,7 +83,7 @@
 | ACT-194 | Prevention tests (postcard, redb list, loader, snapshot) | ✅ Done |
 | ACT-195 | Update plans/ + CHANGELOG for 0.1.35 | ✅ Done |
 | ACT-196 | Open PR + CI green + merge | ✅ Done (merged) |
-| ACT-197 | Cut v0.1.35 via release.yml (closes #828) | ⏳ After release ready |
+| ACT-197 | Cut v0.1.35 via release.yml (closes #828) | ✅ Done (ACT-225) |
 
 ### Prevention permanently (do not regress)
 - Never `#[serde(tag=)]` on postcard types

--- a/plans/GOALS.md
+++ b/plans/GOALS.md
@@ -1,20 +1,31 @@
 # GOAP Goals Index
 
-- **Last Updated**: 2026-07-17 (open issues analysis)
-- **Status**: Active — open-issue GOAP planned; implement #847 + release #849 next
-- **Plan**: `plans/GOAP_OPEN_ISSUES_ANALYSIS_2026-07-17.md`
+- **Last Updated**: 2026-07-18 (v0.1.35 shipped)
+- **Status**: Active — post-release backlog (K3.1b / W2.1b / S1.7) + PR #858 hygiene
+- **Plan**: `plans/GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md`
+- **Completed sprint plan**: `plans/GOAP_OPEN_ISSUES_ANALYSIS_2026-07-17.md`
 
-## 2026-07-17 Goals (Open Issues → Code)
+## 2026-07-18 Goals (Post-Release)
+
+| Goal | Ref | Status |
+|------|-----|--------|
+| Merge parse-changelog uniqueness gate | PR #858 | 🟡 |
+| K3.1b skill-eval CI for changed skills | improvements K3.1b | ⏳ |
+| W2.1b gate-contract CI parity | improvements W2.1b | ⏳ |
+| S1.7 + remaining correctness backlog | improvements | ⏳ |
+| Keep release path single (`release-guard` + ship) | PR #855 | ✅ |
+
+## 2026-07-17 Goals (Open Issues → Code) ✅ COMPLETE
 
 | Goal | Issues | ADR | Status |
 |------|--------|-----|--------|
-| G1 Cut v0.1.35 via release.yml | #849 | ADR-058 / #843 plan | 🟡 P0 |
-| G2 Durable complete + operator fail path | #847 | ADR-075 | 🟡 P0 |
-| G3 Pattern empty-result UX + docs | #845 residual | ADR-076 | 🟡 P1 |
-| G4 Close config discoverability after release | #846 | (done #829) | 🟡 P2 |
-| G5 Verify #845/#846 against released binary | #845, #846 | — | ⏳ After G1 |
+| G1 Cut v0.1.35 via release.yml | #849 | ADR-058 / #843 plan | ✅ Shipped 2026-07-17 |
+| G2 Durable complete + operator fail path | #847 | ADR-075 | ✅ Merged + closed |
+| G3 Pattern empty-result UX + docs | #845 residual | ADR-076 | ✅ Merged + closed |
+| G4 Close config discoverability after release | #846 | (done #829) | ✅ Closed |
+| G5 Verify #845/#846 against released binary | #845, #846 | — | ✅ Closed on release |
 
-## 2026-07-16b Goals (S1.3–S1.6 + W2.2)
+## 2026-07-16b Goals (S1.3–S1.6 + W2.2) ✅ SHIPPED IN v0.1.35
 
 | Goal | Plan ref | Status |
 |------|----------|--------|
@@ -23,7 +34,7 @@
 | Embedding health truthful (mock ≠ available) | S1.5 | ✅ |
 | Retry queue timeout + first attempt free of permits | S1.6 | ✅ |
 | Advisory audit cannot soft-pass | W2.2 | ✅ |
-| Open PR + CI green + review | B8 | 🟡 |
+| Open PR + CI green + review | B8 | ✅ on main / in release |
 
 ## 2026-07-16 Missing Tasks Goals (PR #840 ✅)
 
@@ -36,7 +47,7 @@
 | Docs match fail-closed code execution | S1.1a / D3.2 | ✅ |
 | Open PR + review | A7 | ✅ PR #840 |
 
-## v0.1.35 Goals (CLI UX Patch — on main)
+## v0.1.35 Goals (CLI UX Patch) ✅ SHIPPED
 
 | Goal | Issues | Status |
 |------|--------|--------|
@@ -44,7 +55,7 @@
 | Project-local DB via --db-path / MEMORY_DB_PATH | #830 | ✅ |
 | Discoverable config (init, template, partial TOML) | #829 | ✅ |
 | Clear storage_mode story | #832 | ✅ |
-| Align version to 0.1.35 and cut release | #828 / #838 | 🟡 tag via release.yml after PR merges |
+| Align version to 0.1.35 and cut release | #828 / #838 / #849 | ✅ tag `v0.1.35` via release-manager + release.yml |
 
 ---
 

--- a/plans/GOAP_OPEN_ISSUES_ANALYSIS_2026-07-17.md
+++ b/plans/GOAP_OPEN_ISSUES_ANALYSIS_2026-07-17.md
@@ -1,25 +1,26 @@
 # GOAP: Open GitHub Issues vs Codebase — 2026-07-17
 
-- **Status**: Active planning (analysis complete; implementation queued)
-- **Date**: 2026-07-17
+- **Status**: ✅ COMPLETE (implemented PR #850; shipped `v0.1.35` 2026-07-17; all four issues closed)
+- **Date**: 2026-07-17 (analysis); closeout 2026-07-18
 - **Analyst**: GOAP agent (codebase-verified)
-- **Workspace**: `0.1.35` on `main` (tag `v0.1.34` still latest release)
-- **Open issues**: 4 (`#845`, `#846`, `#847`, `#849`)
+- **Workspace**: `0.1.35` on `main` (tag `v0.1.35` published)
+- **Original open issues**: 4 (`#845`, `#846`, `#847`, `#849`) — all **closed**
 - **Related ADRs**: ADR-075, ADR-076, ADR-058 / release-drift plan for #843→#849
 - **Prior related closed**: `#831` (patterns), `#829` (config), `#830` (db-path), `#832` (storage_mode), `#843` (drift automation)
+- **Ship path**: `release-guard` + `./scripts/release-manager.sh ship --execute` → `release.yml`
 
 ---
 
 ## Executive Summary
 
-| Issue | Title (short) | Labels | Codebase verdict | Priority |
-|-------|---------------|--------|------------------|----------|
-| [#849](https://github.com/d-o-hub/rust-self-learning-memory/issues/849) | Release due: 27 commits / 6 days since v0.1.34 | `release-drift` | **Action required** — cut `v0.1.35` via `release.yml` | **P0** |
-| [#847](https://github.com/d-o-hub/rust-self-learning-memory/issues/847) | `episode complete … failure` no-op for stuck `in_progress` | `bug` | **Open defect on main** — silent durability / operator path | **P0** |
-| [#845](https://github.com/d-o-hub/rust-self-learning-memory/issues/845) | Pattern list empty after create→complete ingest | `bug` | **Mostly fixed on main (#831)**; residual UX/docs + release | **P1** |
-| [#846](https://github.com/d-o-hub/rust-self-learning-memory/issues/846) | Config format undocumented / hard to discover | `bug` | **Fixed on main (#829)**; needs release + minor doc polish | **P2** |
+| Issue | Title (short) | Labels | Codebase verdict | Final status |
+|-------|---------------|--------|------------------|--------------|
+| [#849](https://github.com/d-o-hub/rust-self-learning-memory/issues/849) | Release due: 27 commits / 6 days since v0.1.34 | `release-drift` | Cut `v0.1.35` via `release.yml` | ✅ Closed (tag shipped) |
+| [#847](https://github.com/d-o-hub/rust-self-learning-memory/issues/847) | `episode complete … failure` no-op for stuck `in_progress` | `bug` | ADR-075 durable complete + `episode fail` | ✅ Closed (PR #850) |
+| [#845](https://github.com/d-o-hub/rust-self-learning-memory/issues/845) | Pattern list empty after create→complete ingest | `bug` | ADR-076 empty diagnostics (+ #831) | ✅ Closed |
+| [#846](https://github.com/d-o-hub/rust-self-learning-memory/issues/846) | Config format undocumented / hard to discover | `bug` | Precedence docs (+ #829) | ✅ Closed |
 
-All four issues cite **v0.1.34** binaries. Workspace `main` already carries the v0.1.35 CLI UX patch and subsequent GOAP sprints, but **no `v0.1.35` tag exists**. Shipping the release unblocks #845/#846 for users and clears #849; #847 still needs code work on top of that.
+All four issues cited **v0.1.34** binaries. They were fixed on main (CLI UX + ADR-075/076) and **shipped in GitHub Release `v0.1.35`** (2026-07-17).
 
 ---
 
@@ -281,8 +282,6 @@ Older backlog issues (#770, #753, #749, #746, #743, #800, #799, etc.) are **not 
 
 ## Next Immediate Actions
 
-1. Accept ADR-075 and ADR-076  
-2. Choose release order (a) tag-now vs (b) #847-then-tag  
-3. Implement WP-B (#847)  
-4. Execute WP-A (#849)  
-5. WP-C / WP-D closeout comments on GitHub  
+~~1–5 completed:~~ ADR-075/076 accepted; WP-B (#847) in PR #850; WP-A (#849) tag shipped; issues #845–#849 closed.
+
+**Post-closeout (2026-07-18)**: post-release backlog in `GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md`; merge PR #858 for parse-changelog uniqueness gate; keep single ship path (`release-guard`). 

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1,27 +1,31 @@
 # GOAP State Snapshot
 
-- **Last Updated**: 2026-07-17 (post #850/#851 merge; cutting v0.1.35)
-- **Version**: `0.1.35` (workspace; tagging next)
+- **Last Updated**: 2026-07-18 (v0.1.35 released; post-release backlog)
+- **Version**: `0.1.35` (workspace = tag `v0.1.35`)
 - **Branch**: `main`
-- **Active plan**: release v0.1.35 → then improvements backlog
+- **Active plan**: post-release backlog (K3.1b / W2.1b / S1.7) + open PR hygiene
 - **ADRs**: ADR-075/076 on main (PR #850); K3.1/W2.1 on main (PR #851)
 - **Source backlog**: `plans/GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md`
+- **Release path**: `release-guard` skill + `./scripts/release-manager.sh ship --execute` only
 
 ---
 
-## Release v0.1.35 🟡 IN PROGRESS
+## Release v0.1.35 ✅ SHIPPED
 
 | Step | Status |
 |------|--------|
-| Merge #850 open issues | ✅ |
+| Merge #850 open issues (ADR-075/076) | ✅ |
 | Merge #851 K3.1/W2.1 | ✅ |
-| CHANGELOG + STATUS for tag | 🟡 |
-| Main CI green on release SHA | ⏳ |
-| `./scripts/release-manager.sh full --execute` | ⏳ |
-| `release.yml` GitHub Release | ⏳ |
-| Close #849 | ⏳ |
+| CHANGELOG + STATUS for tag | ✅ |
+| Main CI green on release SHA | ✅ |
+| `./scripts/release-manager.sh ship --execute` | ✅ |
+| `release.yml` GitHub Release | ✅ published 2026-07-17 |
+| Close #849 | ✅ |
+| Close #845 / #846 / #847 | ✅ |
+| Canonical release path (PR #855) | ✅ `release-manager` ship + release-guard skill |
+| Release notes format | ✅ restored to match v0.1.34 (`## Release Notes` + downloads); open PR #858 hardens parse-changelog uniqueness gate |
 
-**Deferred after tag**: K3.1b, W2.1b, S1.7, W2.4/W2.5, K3.2, S1.2 provenance, F4 pilots.
+**Next (post-release)**: K3.1b, W2.1b, S1.7, W2.4/W2.5, K3.2, S1.2 provenance remainder, F4 pilots. Open PRs: #858 (changelog parse gate), optional #856.
 
 ---
 
@@ -38,16 +42,16 @@
 
 ---
 
-## Sprint 2026-07-17: Open Issues Analysis + Implementation ✅ MERGED (PR #850)
+## Sprint 2026-07-17: Open Issues Analysis + Implementation ✅ MERGED + RELEASED
 
-**Goal**: Map open issues to codebase; implement ADR-075/076; land PR with CI green.
+**Goal**: Map open issues to codebase; implement ADR-075/076; land PR with CI green; ship v0.1.35.
 
 | Package | Issue | Codebase verdict | Status |
 |---------|-------|------------------|--------|
-| I1 | #849 release drift | Tag `v0.1.35` via `release.yml` | ⏳ After release ready |
-| I2 | #847 complete failure no-op | ADR-075 hard-fail store + CLI verify + `episode fail` | ✅ Merged |
-| I3 | #845 pattern list empty after ingest | ADR-076 empty diagnostics + sync messaging | ✅ Merged |
-| I4 | #846 config format undocumented | Precedence table README + CONFIGURATION_GUIDE | ✅ Merged |
+| I1 | #849 release drift | Tag `v0.1.35` via `release.yml` | ✅ Released + closed |
+| I2 | #847 complete failure no-op | ADR-075 hard-fail store + CLI verify + `episode fail` | ✅ Merged + closed |
+| I3 | #845 pattern list empty after ingest | ADR-076 empty diagnostics + sync messaging | ✅ Merged + closed |
+| I4 | #846 config format undocumented | Precedence table README + CONFIGURATION_GUIDE | ✅ Merged + closed |
 
 **Plan**: `plans/GOAP_OPEN_ISSUES_ANALYSIS_2026-07-17.md`
 
@@ -66,9 +70,9 @@
 | B5 W2.2 false-green audit | improvements W2.2 | ✅ cargo deny blocking; no soft-pass |
 | B6 tests | — | ✅ s13/s14 + retry + local embedding |
 | B7 plans | — | ✅ |
-| B8 PR + CI + review | — | 🟡 |
+| B8 PR + CI + review | — | ✅ on main / shipped in v0.1.35 |
 
-**Deferred** (next PRs): S1.7, W2.1 remainder, W2.4/W2.5, K3 skill evals, F4 pilots, S1.2 provenance remainder, v0.1.35 tag via `release.yml`.
+**Deferred** (next PRs): S1.7, W2.1b, W2.4/W2.5, K3.1b skill-eval CI, F4 pilots, S1.2 provenance remainder.
 
 ---
 
@@ -102,7 +106,7 @@
 
 **Prevention tasks landed**: postcard Pattern test, redb trait list test, e2e pattern list assert, loader partial/alias tests, example config, CHANGELOG.
 
-**Next**: commit → PR → CI green → merge → `release.yml` for v0.1.35 (never manual release).
+**Outcome**: merged to main; shipped in `v0.1.35` via release-manager ship + `release.yml`.
 
 ---
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,8 +1,8 @@
 # Plans Directory
 
-**Version**: workspace `0.1.35` (released tag `v0.1.34`)  
-**Sprint**: Open Issues GOAP 2026-07-17 (ADR-075 / ADR-076)  
-**Last Updated**: 2026-07-17
+**Version**: workspace `0.1.35` (released tag `v0.1.35`)  
+**Sprint**: Post-release backlog (K3.1b / W2.1b / S1.7)  
+**Last Updated**: 2026-07-18
 
 ## Quick Navigation
 
@@ -15,7 +15,8 @@
 | [GOALS.md](GOALS.md) | GOAP goal index |
 | [ACTIONS.md](ACTIONS.md) | Action backlog |
 | [GOAP_STATE.md](GOAP_STATE.md) | GOAP phase snapshot and execution plan state |
-| [GOAP_OPEN_ISSUES_ANALYSIS_2026-07-17.md](GOAP_OPEN_ISSUES_ANALYSIS_2026-07-17.md) | **Active**: open issues vs codebase + execution plan |
+| [GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md](GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md) | **Active**: post-release improvements backlog |
+| [GOAP_OPEN_ISSUES_ANALYSIS_2026-07-17.md](GOAP_OPEN_ISSUES_ANALYSIS_2026-07-17.md) | Completed: open issues vs codebase (v0.1.35) |
 
 ## Architecture
 

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -1,49 +1,62 @@
 # Active Development Roadmap
 
-**Last Updated**: 2026-07-17 (v0.1.35 release prep)
-**Released Version**: v0.1.35 (crates.io + GitHub Release)
+**Last Updated**: 2026-07-18 (v0.1.35 shipped)
+**Released Version**: v0.1.35 (GitHub Release published 2026-07-17)
 **Workspace Version**: 0.1.35
-**Active Sprint**: Post-release backlog (K3.1b / W2.1b / S1.7)
+**Active Sprint**: Post-release backlog (K3.1b / W2.1b / S1.7) + PR #858
 **Branch**: `main`
 **Plan**: `plans/GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md`
 **Backlog**: K3.1b, W2.1b, S1.7, W2.4/W2.5, S1.2 provenance remainder
+**Release path**: `release-guard` skill + `./scripts/release-manager.sh ship --execute` → `release.yml`
 
 ---
 
-## Sprint 2026-07-17 — Open GitHub Issues ✅ MERGED (#850)
+## Sprint 2026-07-18 — Post-Release Hygiene 🟡
+
+| Priority | Item | Status |
+|----------|------|--------|
+| P0 | PR #858 unique CHANGELOG versions + parse-changelog gate | 🟡 open |
+| P1 | K3.1b CI job for changed skill evals | ⏳ |
+| P1 | W2.1b full gate-contract CI parity | ⏳ |
+| P2 | S1.7, W2.4/W2.5, S1.2 remainder, F4 pilots | ⏳ |
+
+---
+
+## Sprint 2026-07-17 — Open GitHub Issues ✅ RELEASED (#850 + v0.1.35)
 
 **Focus**: Codebase-verify all open issues; ADR + GOAP execution; ship in v0.1.35.
 
 | Priority | Issue | Verdict | Status |
 |----------|-------|---------|--------|
-| P0 | #849 Release due | Tag `v0.1.35` via release.yml | 🟡 tagging |
-| P0 | #847 `episode complete failure` no-op | ADR-075 durable complete + `episode fail` | ✅ #850 |
-| P1 | #845 pattern list empty after ingest | ADR-076 empty diagnostics | ✅ #850 |
-| P2 | #846 config format undocumented | Precedence docs + config init | ✅ #850 |
+| P0 | #849 Release due | Tag `v0.1.35` via release.yml | ✅ Closed (shipped) |
+| P0 | #847 `episode complete failure` no-op | ADR-075 durable complete + `episode fail` | ✅ #850 + closed |
+| P1 | #845 pattern list empty after ingest | ADR-076 empty diagnostics | ✅ #850 + closed |
+| P2 | #846 config format undocumented | Precedence docs + config init | ✅ #850 + closed |
 
 **ADRs**: `plans/adr/ADR-075-CLI-Episode-Complete-Durability-and-Operator-Fail.md`, `plans/adr/ADR-076-Pattern-Extraction-Discoverability-and-Empty-Result-Semantics.md`
 
 ---
 
-## Release Engineering 2026-07-17 — Drift Prevention #843 ✅ CODE COMPLETE
+## Release Engineering 2026-07-17 — Drift Prevention #843 ✅ CODE COMPLETE + EXERCISED
 
 **Focus**: Replace alert-only release drift with enforceable cadence and one
-stable tracking issue.
+stable tracking issue. Canonical ship path consolidated in PR #855.
 
 | Item | Description | Status |
 |------|-------------|--------|
 | State model | Distinguish next development version from invalid tag state | ✅ |
 | Cadence gate | Warn at 20 commits/10 days; block at 30 commits/14 days | ✅ |
-| Issue lifecycle | Upsert one canonical issue; close it on matching tag push | ✅ |
+| Issue lifecycle | Upsert one canonical issue; close it on matching tag push | ✅ exercised (#849) |
 | Least privilege | PR calculation is read-only; issue writes use a separate job | ✅ |
-| Release safety | Tag clean, synchronized `main`; push only the exact tag | ✅ |
+| Release safety | Tag clean, synchronized `main`; push only the exact tag | ✅ used for v0.1.35 |
+| Single skill/CLI path | `release-guard` + `release-manager.sh ship` only | ✅ PR #855 |
 | Regression suite | Clean/warning/critical/SemVer/divergent-tag scenarios | ✅ |
 
 **Plan**: `plans/GOAP_RELEASE_DRIFT_ISSUE_843_2026-07-17.md`
 
 ---
 
-## Sprint 2026-07-16b — S1.3–S1.6 + W2.2 ✅ CODE COMPLETE
+## Sprint 2026-07-16b — S1.3–S1.6 + W2.2 ✅ SHIPPED IN v0.1.35
 
 **Focus**: Next deferred P0 correctness and gate tasks from the 2026-07-14 improvements plan.
 
@@ -54,7 +67,7 @@ stable tracking issue.
 | 3 | S1.5 | Embedding health Real / DegradedMock / Unavailable | ✅ |
 | 4 | S1.6 | Retry queue timeout + first-attempt free permits | ✅ |
 | 5 | W2.2 | Remove soft-pass cargo audit; deny blocking | ✅ |
-| 6 | Release | Tag v0.1.35 via release.yml | ⏳ After merge |
+| 6 | Release | Tag v0.1.35 via release.yml | ✅ Shipped |
 
 **Deferred**: S1.7, W2.1 remainder, W2.4/W2.5, K3 skill evals, F4 pilots, S1.2 provenance remainder.
 
@@ -74,35 +87,34 @@ stable tracking issue.
 
 ---
 
-## Sprint v0.1.35 — CLI UX Patch ✅ CODE COMPLETE (2026-07-15)
+## Sprint v0.1.35 — CLI UX Patch ✅ SHIPPED (2026-07-15 → tag 2026-07-17)
 
 **Focus**: Fix user-reported v0.1.34 CLI/config bugs; prevent recurrence with postcard/list/config tests.
 
 | Priority | Issue | Description | Status |
 |----------|-------|-------------|--------|
-| 1 (critical) | #831 | Pattern list/search empty after complete | ✅ Fixed + CLI verified |
-| 2 (critical) | #830 | `--db-path` / `MEMORY_DB_PATH` ignored | ✅ Fixed + CLI verified |
-| 3 (UX) | #829 | Config format undocumented / hard to discover | ✅ Fixed + CLI verified |
-| 4 (UX) | #832 | `storage_mode` vs config file unclear | ✅ Fixed + CLI verified |
-| 5 (release) | #828 | Release drift after v0.1.34 | 🟡 Version 0.1.35 ready; tag after merge |
+| 1 (critical) | #831 | Pattern list/search empty after complete | ✅ Fixed + shipped |
+| 2 (critical) | #830 | `--db-path` / `MEMORY_DB_PATH` ignored | ✅ Fixed + shipped |
+| 3 (UX) | #829 | Config format undocumented / hard to discover | ✅ Fixed + shipped |
+| 4 (UX) | #832 | `storage_mode` vs config file unclear | ✅ Fixed + shipped |
+| 5 (release) | #828 / #849 | Release drift after v0.1.34 | ✅ Tag `v0.1.35` shipped |
 
 **Prevention**: postcard Pattern roundtrip, redb get_all_patterns trait test, e2e cross-process pattern list, config partial/alias unit tests, example.toml.
 
 ---
 
-## Sprint v0.1.34 — IN PROGRESS (2026-07-08)
+## Sprint v0.1.34 — COMPLETE ✅ (Released; superseded by v0.1.35)
 
 **Focus**: Bug fix + CI modernization + release
-**PRs**: #787, #788, #789
-**Issues**: #773, #772, #771, #784, #770
+**PRs**: #787, #788, #789 (merged); tag `v0.1.34` published then superseded by `v0.1.35`
 
 | Priority | Issue | PR | Description | Status |
 |----------|-------|----|-------------|--------|
-| 1 (critical) | #773 | #787 | Fix local storage persistence bug | 🟡 In Review |
-| 2 (easy) | #771 | #788 | Document build dependencies | 🟡 In Review |
-| 3 (enabling) | #772 | #789 | CI publish pipeline: --locked, polling, deps | 🟡 In Review |
-| 4 (release) | #784 | — | Cut v0.1.34 release | ⏳ Blocked on #787 |
-| 5 (publish) | #770 | — | Publish to crates.io | ⏳ Blocked on #789 + release |
+| 1 (critical) | #773 | #787 | Fix local storage persistence bug | ✅ Merged |
+| 2 (easy) | #771 | #788 | Document build dependencies | ✅ Merged |
+| 3 (enabling) | #772 | #789 | CI publish pipeline: --locked, polling, deps | ✅ Merged |
+| 4 (release) | #784 | — | Cut v0.1.34 release | ✅ Done |
+| 5 (publish) | #770 | — | Publish to crates.io | ✅ Done |
 
 **2026 Best Practices Applied**:
 - `cargo publish --locked` for reproducible builds

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -1,14 +1,14 @@
 # Project Status — Self-Learning Memory System
 
-**Last Updated**: 2026-07-17 (v0.1.35 release)
+**Last Updated**: 2026-07-18 (v0.1.35 shipped; post-release backlog)
 **Released Version**: v0.1.35
 **Workspace Version**: 0.1.35
-**Active Sprint**: Tag + `release.yml` for v0.1.35
+**Active Sprint**: Post-release backlog (K3.1b / W2.1b / S1.7) + PR hygiene (#858)
 **Branch**: `main`
 **Edition**: Rust 2024
-**Open GitHub issues**: #849 closes when tag `v0.1.35` is pushed
+**Open GitHub issues**: #857 (release-drift after post-tag commits; expected until next bump)
 
-## Release v0.1.35 — TAGGING
+## Release v0.1.35 — ✅ SHIPPED (2026-07-17)
 
 | Item | Status |
 |------|--------|
@@ -16,21 +16,26 @@
 | PR #851 K3.1 skill evals + W2.1 gate contract | ✅ Merged |
 | PR #852 CHANGELOG / status fold | ✅ Merged |
 | CHANGELOG `[0.1.35] - 2026-07-17` | ✅ |
-| Tag via `release-manager` + `release.yml` only | 🟡 Next |
+| Tag via `release-manager ship` + `release.yml` only | ✅ `v0.1.35` published |
+| PR #855 canonical ship path + release-guard skill | ✅ Merged |
+| GitHub Release notes format (v0.1.34 parity) | ✅ restored; PR #858 hardens parse gate |
+| Issues #849 / #847 / #845 / #846 | ✅ Closed |
 
-## Open Issues vs Codebase — 2026-07-17
+**Ship path (canonical)**: `.agents/skills/release-guard/SKILL.md` → `./scripts/release-manager.sh ship --execute` → `.github/workflows/release.yml`
+
+## Open Issues vs Codebase — 2026-07-17 ✅ COMPLETE
 
 | Issue | Verdict | Status |
 |-------|---------|--------|
-| #849 | Release cadence critical | 🟡 Tag v0.1.35 |
-| #847 | ADR-075 durable complete + `episode fail` | ✅ Merged #850 |
-| #845 | ADR-076 pattern empty diagnostics | ✅ Merged #850 |
-| #846 | Config precedence docs | ✅ Merged #850 |
+| #849 | Release cadence critical | ✅ Closed (tag shipped) |
+| #847 | ADR-075 durable complete + `episode fail` | ✅ Closed (merged #850 + release) |
+| #845 | ADR-076 pattern empty diagnostics | ✅ Closed |
+| #846 | Config precedence docs | ✅ Closed |
 
 **Plan**: `plans/GOAP_OPEN_ISSUES_ANALYSIS_2026-07-17.md`  
 **ADRs**: ADR-075, ADR-076
 
-## Release Drift Prevention #843 — ✅ CODE COMPLETE
+## Release Drift Prevention #843 — ✅ CODE COMPLETE + EXERCISED
 
 | Item | Status |
 |------|--------|
@@ -38,12 +43,12 @@
 | PR cadence warning/blocking thresholds | ✅ Implemented |
 | 30-commit / 14-day hard limit | ✅ Implemented |
 | Trusted release-preparation escape hatch | ✅ Implemented |
-| Exact-tag-only release manager | ✅ Implemented |
+| Exact-tag-only release manager | ✅ Implemented + used for v0.1.35 |
 | Shell regression suite | ✅ Passing |
 
 **Plan**: `plans/GOAP_RELEASE_DRIFT_ISSUE_843_2026-07-17.md`
 
-## Sprint 2026-07-16b — S1.3–S1.6 + W2.2 ✅ CODE COMPLETE
+## Sprint 2026-07-16b — S1.3–S1.6 + W2.2 ✅ SHIPPED IN v0.1.35
 
 | Item | Description | Status |
 |------|-------------|--------|
@@ -52,7 +57,7 @@
 | S1.5 | `EmbeddingHealth` Real/DegradedMock/Unavailable; mock fail-closed | ✅ Fixed |
 | S1.6 | Retry queue timeout; first attempt free; reject zero concurrency | ✅ Fixed |
 | W2.2 | cargo deny blocking; cargo audit no longer soft-passes | ✅ Fixed |
-| #843 | Release drift (25 commits since v0.1.34) | 🟡 Prevention complete; v0.1.35 release still required |
+| #843 / #849 | Release drift cleared by v0.1.35 tag | ✅ Released |
 
 **Plan**: `plans/GOAP_MISSING_TASKS_S13_S16_W22_2026-07-16.md`
 
@@ -76,7 +81,7 @@
 | #830 | `--db-path` / `MEMORY_DB_PATH` ignored for redb | ✅ Fixed |
 | #829 | Config file format hard to discover | ✅ Fixed |
 | #832 | `storage_mode` config placement unclear | ✅ Fixed |
-| #828 | Release drift | 🟡 Ready to tag after merge |
+| #828 | Release drift | ✅ Closed with v0.1.35 |
 
 **Plan**: `plans/GOAP_CLI_UX_PATCH_0.1.35_2026-07-15.md`
 
@@ -95,7 +100,7 @@
 | Feature | #746 | WASM compile-check CI job | ✅ Merged (PR #806) |
 | Publish | #770 | CLI crates.io publish prep | ✅ Merged (PR #806) |
 
-**All 6 open issues resolved.** Release tag v0.1.34 pending.
+**All 6 open issues resolved.** Tag `v0.1.34` published (superseded by `v0.1.35`).
 
 ## v0.1.33 Sprint — COMPLETE ✅ (Released)
 
@@ -117,21 +122,21 @@
 | Metric | Value | Target | Status |
 |--------|-------|--------|--------|
 | Workspace members | 9 | — | — |
-| Workspace version | 0.1.33 | — | ✅ Released (tag v0.1.33 exists) |
-| Latest GitHub release | v0.1.33 | — | ✅ Published |
-| Publishable workspace crates | 6 | — | ✅ All at `0.1.33` in workspace  |
-| Commits since v0.1.34 | 0 | 0 | ✅ Released |
+| Workspace version | 0.1.35 | — | ✅ Matches tag `v0.1.35` |
+| Latest GitHub release | v0.1.35 | — | ✅ Published 2026-07-17 |
+| Publishable workspace crates | 6 | — | ✅ Workspace `0.1.35` |
+| Commits since v0.1.35 | small (post-tag hygiene) | keep low | 🟡 #857 tracks until next bump |
 | Clippy (default features) | Clean | Clean | ✅ |
-| Clippy (--all-features) | Clean | 0 | ✅ Fixed in PR #675 |
-| Production src files >500 LOC | 0 | 0 | ✅ Fixed in PR #675 (wrapper_backend.rs split) |
+| Clippy (--all-features) | Clean | 0 | ✅ |
+| Production src files >500 LOC | 0 | 0 | ✅ |
 | Push CI (main) | Green | Green | ✅ |
-| Scheduled Security | Fixed | Green | ✅ WG-176 done (PR #675) |
-| Nightly Full Tests | Fixed | Green | ✅ WG-177 done (PR #675 disk cleanup) |
-| Mutation Testing | Fixed | Completes | ✅ WG-178 done (scoped to memory-core) |
+| Scheduled Security | Fixed | Green | ✅ |
+| Nightly Full Tests | Fixed | Green | ✅ |
+| Mutation Testing | Fixed | Completes | ✅ |
 | Fuzzing | Green | Green | ✅ |
-| Security audit (`cargo deny`) | Clean | Clean | ✅ Fixed in PR #682 |
-| Open issues | 10 | 0 | 🟡 (#773, #772, #771, #784, #770, +5 others) |
-| Open PRs | 3 | 0 | 🟡 PRs #787, #788, #789 |
+| Security audit (`cargo deny`) | Clean | Clean | ✅ |
+| Open issues | 1 (#857 drift after post-tag commits) | 0 | 🟡 expected until 0.1.36 prep |
+| Open PRs | #858 (+ optional #856) | 0 | 🟡 merge #858 for parse-changelog gate |
 | Fuzz harness | Present | Present | ✅ |
 | Property test files | 17 | ≥13 | ✅ |
 | MSRV | Rust 2024 / stable 1.95.0 | — | ✅ |


### PR DESCRIPTION
## Summary
- Mark **v0.1.35** as shipped across `plans/` (GOAP_STATE, STATUS/CURRENT, ACTIONS, GOALS, ROADMAP_ACTIVE, README, open-issues analysis).
- Close out ACT-225 / open issues #845–#849 in plan trackers; set active work to post-release backlog (K3.1b / W2.1b / S1.7) and PR #858 hygiene.
- Skills: `release-guard` + `github-release-best-practices` document unique CHANGELOG headers (parse-changelog) so GitHub Release notes always match v0.1.34 format.

## Test plan
- [x] Docs-only; no code paths changed
- [ ] CI green on PR
- [ ] After merge: plans on main reflect released state