### PR TITLE
docs(release): finalize documentation for v0.1.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.36] - 2026-07-20
+
 ### Added
 
 - **CLI** `storage journal` — operator view of F4.2 operation journal

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -1,8 +1,8 @@
 # Active Development Roadmap
 
 **Last Updated**: 2026-07-20  
-**Released Version**: v0.1.35  
-**Workspace Version**: 0.1.36 (unreleased development)  
+**Released Version**: v0.1.36
+**Workspace Version**: 0.1.36
 **Active Sprint**: Recommendations backlog + release readiness  
 **Plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
 **Branch**: `main`  

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -1,8 +1,8 @@
 # Project Status — Self-Learning Memory System
 
 **Last Updated**: 2026-07-20  
-**Released Version**: v0.1.35  
-**Workspace Version**: 0.1.36 (unreleased; 18 commits since tag)  
+**Released Version**: v0.1.36
+**Workspace Version**: 0.1.36
 **Edition**: Rust 2024  
 **Active plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
 **Branch**: `main` @ `2e0a2b89`  


### PR DESCRIPTION
Finalize release preparation documentation files (CHANGELOG.md, ROADMAP_ACTIVE.md, CURRENT.md) for version 0.1.36.

Fixes #879

---
*PR created automatically by Jules for task [12403904408979380796](https://jules.google.com/task/12403904408979380796) started by @d-o-hub*