### PR TITLE
docs(plans): refresh tracker for open PRs and release gaps

### DIFF
--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -1,10 +1,10 @@
 # GOAP Actions Backlog
 
-- **Last Updated**: 2026-07-20  
+- **Last Updated**: 2026-07-21  
 - **Active plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
 - **Archived plans**: `plans/archive/2026-07-consolidation/`
 
-## Active actions (2026-07-20)
+## Active actions (2026-07-21)
 
 | ID | Action | Rec | Status |
 |----|--------|-----|--------|
@@ -12,14 +12,16 @@
 | ACT-300b | Generate `.agents/SKILLS.md` inventory (HARNESS link target) | R-C3 | ✅ Done |
 | ACT-304 | Split provider configs ≤500 LOC + tests | R-B1 | ✅ Done |
 | ACT-305 | ADR-025 / ADR-054 alias registry (`plans/adr/README.md`) | R-B5 | ✅ Done |
-| ACT-306 | Expand `skill-rules.json` to all 34 skills | R-C1 | ✅ Done |
+| ACT-306 | Expand `skill-rules.json` to all catalog skills | R-C1 | ✅ Done |
 | ACT-307 | Add `ci-poll` evals + SKILLS.md sync | R-C2, R-C3 | ✅ Done |
 | ACT-308 | F4 operator UX: `storage journal` CLI (`--pending`/`--repair`) | R-B2, R-C5 | ✅ Done |
 | ACT-309 | Align AGENTS skill table + TECH_DEBT + vision title | R-D*, R-B3 | ✅ Done |
-| ACT-301 | Prepare CHANGELOG for v0.1.36 (Unreleased notes ready) | R-A1 | ✅ partial |
-| ACT-302 | `./scripts/release-manager.sh ship --execute` for `v0.1.36` | R-A1 | 🟡 After merge to main |
+| ACT-301 | Prepare CHANGELOG + release docs for v0.1.36 | R-A1 | 🟡 PR #880 |
+| ACT-302 | `./scripts/release-manager.sh ship --execute` for `v0.1.36` | R-A1 | 🟡 After #880 merge + main green |
 | ACT-303 | Post-release workspace bump to 0.1.37 | R-A2 | 🟡 After ACT-302 |
-| ACT-308b | MCP provenance fields on query responses | R-C4 | Backlog |
+| ACT-313 | Land rust-major dependabot (#877) with sha2/lz4/cargo_metadata adapters | deps | 🟡 PR #877 |
+| ACT-314 | Refresh plans tracker truth (open PRs/issues, closed gaps) | R-G* | 🟡 This branch |
+| ACT-308b | MCP provenance fields on query responses (if any remaining gaps) | R-C4 | Backlog |
 | ACT-310 | Medium-risk skill behavioral evals (second wave) | R-E2 | Backlog |
 | ACT-311 | Optional: `validate-plans.sh` warn on excess dated root files | R-G4 | Backlog |
 | ACT-312 | Optional product/research spikes R-F* | R-F* | Backlog |
@@ -40,3 +42,4 @@ Full tables live under:
 - No manual `gh release create`; use release-manager + `release.yml`  
 - No soft-pass on cargo deny / required cancelled checks  
 - Fail-closed `execute_agent_code` unless approved capability backend  
+- sha2 digests: use portable hex encode (not `format!("{:x}", finalize())` on 0.11+)  

--- a/plans/GOALS.md
+++ b/plans/GOALS.md
@@ -1,31 +1,32 @@
 # GOAP Goals Index
 
-- **Last Updated**: 2026-07-20  
-- **Status**: Active — post-v0.1.35 recommendations backlog  
+- **Last Updated**: 2026-07-21  
+- **Status**: Active — release v0.1.36 + open PR hygiene  
 - **Workspace**: `0.1.36` unreleased · **Tag**: `v0.1.35`  
 - **Plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
 - **Archive**: `plans/archive/2026-07-consolidation/`
 
-## Active goals (2026-07-20)
+## Active goals (2026-07-21)
 
 | Goal | Rec IDs | Priority | Status |
 |------|---------|----------|--------|
-| Ship v0.1.36 + post-bump | R-A1, R-A2, R-A3 | P0 | 🟡 Next |
-| Restore production LOC ≤500 | R-B1 | P0 | 🟡 |
-| ADR identifier uniqueness | R-B5 | P0 | 🟡 |
-| Complete skill routes + ci-poll evals + SKILLS.md | R-C1–C3, R-E1 | P1 | 🟡 |
-| Productize F4 (provenance / journal / digests UX) | R-B2, R-C4–C6 | P1 | 🟡 |
-| Docs contract alignment (README, AGENTS, HARNESS, TECH_DEBT) | R-D*, R-B3 | P1 | 🟡 |
-| Plans hygiene (archive + single active plan) | R-G1–G3 | P1 | ✅ Done |
+| Ship v0.1.36 + post-bump | R-A1, R-A2, R-A3 | P0 | 🟡 After #880 + main green |
+| Green open CI (release docs + rust-major deps) | — | P0 | 🟡 #880 / #877 |
+| Restore production LOC ≤500 | R-B1 | P0 | ✅ Done |
+| ADR identifier uniqueness (aliases) | R-B5 | P0 | ✅ Documented |
+| Complete skill routes + ci-poll evals + SKILLS.md | R-C1–C3, R-E1 | P1 | ✅ Done |
+| Productize F4 (provenance / journal / digests UX) | R-B2, R-C4–C6 | P1 | ✅ CLI journal; MCP provenance present |
+| Docs contract alignment (README, AGENTS, HARNESS, TECH_DEBT) | R-D*, R-B3 | P1 | ✅ |
+| Plans hygiene (archive + live tracker truth) | R-G1–G3 | P1 | ✅ 2026-07-21 refresh |
 | Optional research/product spikes | R-F* | P2 | Backlog |
 
 ## Completed goal series (pointer only)
 
 | Series | Outcome | Archive |
 |--------|---------|---------|
+| Recommendations #878 | Merged | — |
 | 2026-07-14 improvements S1/W2/K3/F4 | Implemented; F4 spikes GO; S1.1c NO-GO | `archive/2026-07-consolidation/completed-sprints/` |
 | v0.1.35 CLI UX + ADR-075/076 | Released as `v0.1.35` | same |
 | Harness #861–#869 + release-cadence-manager | Merged | same |
-| v0.1.32–v0.1.34 sprints | Released | older archive trees |
 
 Do not re-list completed WG tables here; see ROADMAP historical sections or archives.

--- a/plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md
+++ b/plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md
@@ -1,16 +1,17 @@
 # Comprehensive Codebase Recommendations — 2026-07-20
 
 - **Status**: Active backlog (post–v0.1.35; workspace `0.1.36` unreleased)
-- **Audit commit**: `2e0a2b89` (`main`)
+- **Audit commit**: `1ebab995` (`main`) — refreshed 2026-07-21
 - **Released tag**: `v0.1.35`
-- **Open PRs / issues**: none
+- **Open PRs**: #880 (release docs), #877 (rust-major deps)
+- **Open issues**: #879 (release drift)
 - **Coordinator**: goap-agent + agent-coordination
 - **Supersedes**: archived `GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md` and dated 2026-06/07 execution plans
 - **Archive**: `plans/archive/2026-07-consolidation/`
 
 ## 1. Executive summary
 
-The 2026-07-14 → 2026-07-18 GOAP campaign closed the high-priority correctness, gate honesty, skill-eval, and F4 pilot packages. PRs **#840–#875** are merged; workspace is **`0.1.36`** with **18 unreleased commits** on top of `v0.1.35`.
+The 2026-07-14 → 2026-07-20 GOAP campaign closed the high-priority correctness, gate honesty, skill-eval, F4 pilot, and recommendations packages. PRs **#840–#878** are merged; workspace is **`0.1.36`** with **26 unreleased commits** on top of `v0.1.35`. Remaining P0 is **ship v0.1.36** (via #880 + release-manager) and land **#877** dep majors.
 
 This plan is the **single active recommendations register**. It covers:
 
@@ -34,16 +35,15 @@ This plan is the **single active recommendations register**. It covers:
 
 | Area | Evidence | Verdict |
 |------|----------|---------|
-| Version | `Cargo.toml` `0.1.36`; tag `v0.1.35` | Unreleased development |
-| Main CI | Recent CI / Security / Storage Matrix / Skill Evals **success** | Green enough to plan release |
-| Open work | `gh issue list` / `gh pr list` → empty open sets | No tracker debt |
-| Production LOC >500 | `provider_config.rs` **511** | One invariant breach |
+| Version | `Cargo.toml` `0.1.36`; tag `v0.1.35`; 26 unreleased commits | Unreleased development |
+| Main CI | Recent CI green on main HEAD | Green enough to plan release |
+| Open work | PRs #880, #877; issue #879 | Release + deps CI in flight |
+| Production LOC >500 (non-test `src`) | No production offenders (`provider_config.rs` 237) | ✅ |
 | `todo!` / `unimplemented!` / “not yet implemented” in prod `src` | 0 matches | Clean surface |
-| Skills | 34 skill dirs; 33 eval files; **`ci-poll` missing evals** | Partial |
-| Skill routes | `skill-rules.json` covers **16 / 34** skills | Partial (K3.3 remainder) |
-| `.agents/SKILLS.md` | Generated 2026-07-20 from catalog | ✅ present; keep in sync |
-| ADR IDs | Duplicate **025** and **054** filenames | Registry debt |
-| F4 pilots | `provenance_api.rs`, `op_journal.rs`, model digests, skill contract compiler | Code present; operator UX incomplete |
+| Skills | Catalog + `ci-poll` evals present; routes complete | ✅ |
+| `.agents/SKILLS.md` | Generated / maintained | ✅ keep in sync |
+| ADR IDs | Duplicate **025** / **054** filenames | Aliased in `plans/adr/README.md` |
+| F4 pilots | provenance, `storage journal`, model digests | ✅ operator surfaces landed |
 | Batch MCP tools | Intentionally deferred / fail-closed | Documented in AGENTS |
 | Code execution | Fail-closed; S1.1c **NO-GO** | Correct |
 
@@ -72,7 +72,7 @@ IDs use prefix **R** (recommendation). Priorities:
 
 | ID | Recommendation | Why | Acceptance |
 |----|----------------|-----|------------|
-| **R-A1** | Cut **v0.1.36** via `./scripts/release-manager.sh ship --execute` after CHANGELOG + Released Version docs | After #878 merge + main green | 🟡 After merge |
+| **R-A1** | Cut **v0.1.36** via `./scripts/release-manager.sh ship --execute` after CHANGELOG + Released Version docs | Merge #880 + main green | 🟡 CI / ship |
 | **R-A2** | Immediately bump workspace to **0.1.37** after tag | AGENTS post-release rule | 🟡 After R-A1 |
 | **R-A3** | Re-run `./scripts/release-manager.sh status` before ship | Status green before ship | 🟡 With R-A1 |
 

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1,40 +1,28 @@
 # GOAP State Snapshot
 
-- **Last Updated**: 2026-07-20  
+- **Last Updated**: 2026-07-21  
 - **Version**: workspace `0.1.36` unreleased (latest tag `v0.1.35`)  
-- **Branch**: `main` @ `2e0a2b89`  
-- **Open PR**: [#878](https://github.com/d-o-hub/rust-self-learning-memory/pull/878)  
+- **Branch**: `main` @ `1ebab995`  
+- **Open PRs**: [#880](https://github.com/d-o-hub/rust-self-learning-memory/pull/880) (release docs), [#877](https://github.com/d-o-hub/rust-self-learning-memory/pull/877) (rust-major deps)  
+- **Open issues**: [#879](https://github.com/d-o-hub/rust-self-learning-memory/issues/879) (release drift)  
 - **Active plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
 - **Archive**: `plans/archive/2026-07-consolidation/`  
-- **Release**: 🟡 after #878 merge (R-A1)  
+- **Release**: 🟡 after #880 merge + main green (R-A1)
 
 ---
 
-## Phase: Recommendations implementation 🟡 PR #878
+## Phase: Release readiness + open PR CI 🟡
 
 | Package | Status |
 |---------|--------|
-| Archive dated GOAP / CI / research plans | ✅ |
-| Single recommendations backlog | ✅ |
-| CURRENT / GOALS / ACTIONS / GAP / VALIDATION / README | ✅ |
+| Recommendations implementation #878 | ✅ Merged |
 | R-B1 LOC split provider configs | ✅ |
 | R-C1–C3 skill routes + ci-poll + SKILLS.md | ✅ |
 | R-B2/C5 `storage journal` CLI | ✅ |
 | R-B3/B5/D docs + ADR aliases | ✅ |
-| R-A1/A2 release v0.1.36 | 🟡 after merge |
-
----
-
-## Next phase: Release + invariants (proposed)
-
-| Package | Rec | Status |
-|---------|-----|--------|
-| v0.1.36 ship | R-A1 | 🟡 |
-| Post-bump 0.1.37 | R-A2 | 🟡 |
-| LOC split `provider_config.rs` | R-B1 | 🟡 |
-| ADR ID aliases 025/054 | R-B5 | 🟡 |
-| Skill routes + ci-poll + SKILLS.md | R-C1–C3 | 🟡 |
-| F4 productization | R-B2 | 🟡 |
+| Release docs PR #880 | 🟡 CI (commitlint fixed) |
+| Dependabot rust-major #877 | 🟡 CI (compat fixes pushed) |
+| R-A1/A2 release v0.1.36 + post-bump | 🟡 blocked on #880 + main green |
 
 ---
 
@@ -42,21 +30,21 @@
 
 | Campaign | Result |
 |----------|--------|
+| 2026-07-20 recommendations #878 | ✅ Merged |
 | 2026-07-18 F4 remainder #874 | ✅ Merged |
 | 2026-07-18 Missing tasks #873 | ✅ Merged |
 | 2026-07-18 Harness #870 | ✅ Merged |
 | 2026-07-18 release-cadence-manager #872 | ✅ Merged |
-| 2026-07-18 S1.7/K3.1b/W2.1b #860 | ✅ Merged |
 | v0.1.35 release | ✅ Shipped |
 
 Details: `plans/archive/2026-07-consolidation/completed-sprints/`.
 
 ---
 
-## Goal-state flags (post-2026-07-14 campaign)
+## Goal-state flags (2026-07-21)
 
 ```text
-truth_reconciled                  ≈ true (plans refreshed 2026-07-20; release lag remains)
+truth_reconciled                  ≈ true (plans refreshed 2026-07-21; release lag remains)
 sandbox_capability_boundary       = true (fail-closed; S1.1c NO-GO)
 retrieval_identity_complete       = true
 storage_awaits_lock_free          = true (step paths)
@@ -64,9 +52,10 @@ durable_eviction                  = true (+ reconciliation)
 embedding_health_truthful         = true
 retry_backpressure_effective      = true
 gates_match_policy                ≈ true (GATE_CONTRACT + ci-parity)
-skill_evals_executable            ≈ true (ci-poll gap)
-skill_routes_complete             = false (16/34)
-docs_match_code                   ≈ partial
-plan_registry_unique              ≈ partial (ADR 025/054 dupes)
+skill_evals_executable            = true
+skill_routes_complete             = true
+docs_match_code                   ≈ true (refresh after release)
+plan_registry_unique              ≈ true (ADR 025/054 aliased)
 feature_pilots_have_baselines     = true (F4 spikes)
+release_current                   = false (v0.1.36 pending)
 ```

--- a/plans/README.md
+++ b/plans/README.md
@@ -2,7 +2,8 @@
 
 **Workspace**: `0.1.36` (unreleased) · **Released tag**: `v0.1.35`  
 **Active plan**: [GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md](GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md)  
-**Last Updated**: 2026-07-20  
+**Last Updated**: 2026-07-21  
+**Open PRs**: #880 (release), #877 (deps) · **Open issue**: #879 (drift)  
 **Policy**: ADR-039 (canonical active set) + ADR-072 (authority / release path)
 
 ## Quick Navigation

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -1,37 +1,35 @@
 # Active Development Roadmap
 
-**Last Updated**: 2026-07-20  
+**Last Updated**: 2026-07-21  
 **Released Version**: v0.1.35  
 **Workspace Version**: 0.1.36 (unreleased development)  
-**Active Sprint**: Recommendations backlog + release readiness  
+**Active Sprint**: Release v0.1.36 + open PR CI hygiene  
 **Plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
 **Branch**: `main`  
-**Open PR**: none  
+**Open PRs**: #880 (release docs), #877 (rust-major deps)  
+**Open issues**: #879 (release drift)
 
 ---
 
-## Sprint 2026-07-20 — Recommendations & plans consolidation
+## Sprint 2026-07-21 — Release + CI
 
 | Priority | Item | Description | Status |
 |----------|------|-------------|--------|
-| 1 | Plans hygiene | Archive superseded GOAP/CI/research plans (ADR-039) | ✅ |
-| 2 | Recommendations register | Single active backlog with R-A…R-G tracks | ✅ |
-| 3 | Canonical status refresh | CURRENT, GOALS, ACTIONS, GOAP_STATE, GAP, VALIDATION | ✅ |
-| 4 | Code / release | No code or tag in this sprint | ⛔ |
+| 1 | Release docs | PR #880 finalize CHANGELOG / ROADMAP / CURRENT for v0.1.36 | 🟡 CI |
+| 2 | Ship v0.1.36 | `release-manager.sh ship --execute` after #880 + main green | 🟡 |
+| 3 | Post-bump | Workspace → 0.1.37 immediately after tag | 🟡 |
+| 4 | rust-major deps | PR #877 sha2 0.11 / lz4_flex 0.14 / cargo_metadata 0.23 | 🟡 CI |
+| 5 | Plans truth | CURRENT / GAP / GOALS / ACTIONS / GOAP_STATE tracker refresh | 🟡 |
 
 ---
 
-## Next sprint (proposed) — Release + invariants
+## Completed last sprint (2026-07-20)
 
-| Priority | Item | Rec | Status |
-|----------|------|-----|--------|
-| 1 | Cut **v0.1.36** via release-manager + `release.yml` | R-A1 | 🟡 |
-| 2 | Immediate workspace bump to **0.1.37** | R-A2 | 🟡 |
-| 3 | Split `provider_config.rs` ≤500 LOC | R-B1 | 🟡 |
-| 4 | ADR-025 / ADR-054 identifier aliases | R-B5 | 🟡 |
-| 5 | Complete skill routes (34/34) + `ci-poll` evals + `.agents/SKILLS.md` | R-C1–C3 | 🟡 |
-| 6 | F4 productization (provenance + journal operator surfaces) | R-B2 | 🟡 |
-| 7 | Docs contract pass (README, AGENTS, HARNESS, TECH_DEBT) | R-D*, R-B3 | 🟡 |
+| Priority | Item | Status |
+|----------|------|--------|
+| Plans hygiene (ADR-039 archive) | ✅ |
+| Recommendations register R-A…R-G | ✅ |
+| Implementation #878 (LOC, skills, journal CLI, docs) | ✅ |
 
 ---
 
@@ -39,8 +37,8 @@
 
 | Priority | Theme | Items | Status |
 |----------|-------|-------|--------|
-| P1 | Skills depth | Medium-risk behavioral evals (R-E2); skill link lint (R-E4) | Backlog |
-| P1 | Operator F4 | MCP provenance fields; journal CLI repair; digest e2e | Backlog |
+| P1 | Skills depth | Medium-risk behavioral evals (R-E2) | Backlog |
+| P1 | Operator F4 | Any remaining MCP provenance gaps (R-C4) | Backlog |
 | P2 | Research | WG-108 version retention; WG-110 SIMD (bench-gated); WG-125 MoE; WG-135 federated HDC | Backlog |
 | P2 | Vision | Distributed sync, multi-tenancy/RBAC, OTel/Prometheus (see `ROADMAP_V030_VISION.md`) | Future |
 | P2 | Release eng | Trusted Publishing (OIDC) for crates.io | Future |

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -1,49 +1,51 @@
 # Project Status — Self-Learning Memory System
 
-**Last Updated**: 2026-07-20  
+**Last Updated**: 2026-07-21  
 **Released Version**: v0.1.35  
-**Workspace Version**: 0.1.36 (unreleased; 18 commits since tag)  
+**Workspace Version**: 0.1.36 (unreleased; 26 commits since tag)  
 **Edition**: Rust 2024  
 **Active plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
-**Branch**: `main` @ `2e0a2b89`  
-**Open PRs / issues**: none  
+**Branch**: `main` @ `1ebab995`  
+
+## Open tracker (live)
+
+| Kind | Items |
+|------|--------|
+| Open PRs | **#880** release docs v0.1.36 · **#877** rust-major deps (sha2/lz4_flex/cargo_metadata) |
+| Open issues | **#879** release drift (`commit_warning`, 26 commits / 2 days) |
 
 ## Snapshot
 
 | Area | State |
 |------|--------|
-| Post-v0.1.35 GOAP campaign (S1/W2/K3/F4/harness) | ✅ Merged (#840–#875) |
-| Release v0.1.36 | 🟡 Recommended next (R-A1) |
-| Production LOC >500 | 1 file (`provider_config.rs` 511) |
-| Skill evals | 33/34 skills (`ci-poll` missing) |
-| Skill routes | 16/34 in `skill-rules.json` |
+| Post-v0.1.35 GOAP campaign (S1/W2/K3/F4/harness) | ✅ Merged (#840–#878) |
+| Recommendations backlog implementation | ✅ Merged (#878) |
+| Release v0.1.36 | 🟡 **Next** — merge #880 → main green → `release-manager.sh ship --execute` |
+| Production LOC >500 (non-test `src`) | ✅ Clean (`provider_config.rs` 237 after R-B1 split) |
+| Skill evals | 34 eval files under `.agents/skills/*/evals/` |
+| Skill routes | `.agents/skills/skill-rules.json` complete for catalog |
 | Code execution | Fail-closed (S1.1c NO-GO) |
-| Plans hygiene | ✅ Consolidated 2026-07-20 |
+| Plans hygiene | ✅ Refreshed 2026-07-21 (open PR/issue truth) |
 
-## Immediate priorities (from recommendations)
+## Immediate priorities
 
 | Priority | Item | ID | Status |
 |----------|------|-----|--------|
-| P0 | Cut v0.1.36 + post-bump 0.1.37 | R-A1 / R-A2 | 🟡 after PR merge |
-| P0 | Split `provider_config.rs` ≤500 LOC | R-B1 | ✅ |
-| P1 | Complete skill routes + `ci-poll` evals + SKILLS.md | R-C1–C3 | ✅ |
-| P1 | F4 operator journal CLI | R-B2 / R-C5 | ✅ `storage journal` |
-| P1 | ADR 025/054 alias registry | R-B5 | ✅ |
-| P1 | Docs (AGENTS, TECH_DEBT, vision) | R-D* | ✅ partial |
+| P0 | Merge #880 (release docs) when CI CLEAN | R-A1 prep | 🟡 CI |
+| P0 | Cut v0.1.36 + post-bump 0.1.37 | R-A1 / R-A2 | 🟡 after #880 + main green |
+| P0 | Land #877 dependabot major bumps (compat fixes pushed) | deps | 🟡 CI |
+| P1 | Close #879 after ship | release-drift | 🟡 auto after release |
 | P2 | MCP provenance fields; research spikes | R-C4 / R-F* | Backlog |
 
 ## Recent completed (do not re-open)
 
 | Wave | Result |
 |------|--------|
+| Recommendations #878 (skills, LOC, journal CLI, plans) | ✅ Merged |
 | CLI UX v0.1.35 (#828–#832 family) | ✅ Shipped in v0.1.35 |
 | ADR-075 durable complete + `episode fail` | ✅ |
 | ADR-076 pattern empty-result UX | ✅ |
-| S1.2–S1.7 correctness | ✅ |
-| W2.1–W2.5 gate honesty | ✅ |
-| K3.1/K3.2 skill evals | ✅ |
-| F4.1–F4.4 pilots + spikes GO | ✅ |
-| S1.1c Wasmtime spike | ✅ NO-GO |
+| S1.2–S1.7 / W2.1–W2.5 / K3.1–K3.2 / F4 pilots | ✅ |
 | Release-cadence-manager + release-guard | ✅ |
 | Harness engineering #861–#869 | ✅ |
 

--- a/plans/STATUS/GAP_ANALYSIS_LATEST.md
+++ b/plans/STATUS/GAP_ANALYSIS_LATEST.md
@@ -1,30 +1,30 @@
-# Gap Analysis — 2026-07-20
+# Gap Analysis — 2026-07-21
 
-**Generated**: 2026-07-20  
-**Audit commit**: `2e0a2b89` (`main`)  
-**Workspace**: `0.1.36` unreleased · **Tag**: `v0.1.35`  
+**Generated**: 2026-07-21  
+**Audit commit**: `1ebab995` (`main`)  
+**Workspace**: `0.1.36` unreleased · **Tag**: `v0.1.35` · **Unreleased commits**: 26  
 **Full backlog**: [`../GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`](../GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md)
 
 ## Method
 
-- Live tree inspection (Cargo version, LOC, skills, ADR IDs, F4 modules)
+- Live tree inspection (Cargo version, production LOC, skills, ADR IDs)
 - `rg` for `todo!` / `unimplemented!` / “not yet implemented” in production `src` → **0**
-- GitHub: no open PRs or issues
-- Prior gap register (2026-04/06) treated as historical; re-verified claims only
+- GitHub: open PRs **#880**, **#877**; open issue **#879** (release drift)
+- Prior gap register (2026-07-20) re-verified; completed rows closed with evidence
 
-## Resolved since prior gap registers
+## Resolved since 2026-07-20 register
 
 | Historical gap | Resolution |
 |----------------|------------|
-| S1.1–S1.7 correctness package | Shipped 2026-07-16…18 |
-| Soft-pass cargo audit / false-green gates | W2.2–W2.5 |
-| Synthetic skill evals (`exec: true`) | K3.1/K3.2 |
-| Pattern list empty after complete (#831) | v0.1.35 |
-| `--db-path` ignored (#830) | v0.1.35 |
-| Episode complete no-op on store failure (#847) | ADR-075 |
-| Release drift tooling | #843 + release-cadence-manager |
-| F4 pilots without spikes | Spikes GO in `STATUS/spikes/` |
-| Plans bloat / contradictory status | Archived → `archive/2026-07-consolidation/` |
+| G-P0-2 `provider_config.rs` >500 LOC | Split → 237 LOC (R-B1 / #878) |
+| G-P0-3 ADR 025/054 collision | Alias registry in `plans/adr/README.md` (R-B5); files retained historically |
+| G-P1-1 Incomplete skill routing | `skill-rules.json` expanded (#878) |
+| G-P1-2 `ci-poll` missing evals | evals present (#878) |
+| G-P1-3 Missing `.agents/SKILLS.md` | Generated + maintained |
+| G-P1-4 F4 journal / provenance UX | `storage journal` CLI; MCP provenance already present |
+| G-P1-5 TECH_DEBT stale | Refreshed with AGENTS (#878) |
+| G-P1-6 Vision title v0.1.9+ | Updated (R-D7) |
+| S1/W2/K3/F4 campaign items | Shipped 2026-07-16…20 |
 
 ## Open gaps (current)
 
@@ -32,26 +32,22 @@
 
 | ID | Gap | Evidence | Track |
 |----|-----|----------|-------|
-| G-P0-1 | v0.1.36 unreleased (18 commits) | `git rev-list --count v0.1.35..HEAD` = 18 | R-A1 |
-| G-P0-2 | Production file >500 LOC | `provider_config.rs` 511 | R-B1 |
-| G-P0-3 | Duplicate ADR numbers 025, 054 | `plans/adr/` filename collision | R-B5 |
+| G-P0-1 | v0.1.36 unreleased (26 commits) | `git rev-list --count v0.1.35..origin/main` = 26; issue #879 | R-A1 |
+| G-P0-4 | Release-prep PR CI must be CLEAN | PR #880 (docs); then ship via release-manager | R-A1 |
+| G-P0-5 | Dependabot rust-major CI | PR #877 — sha2/lz4_flex/cargo_metadata compat fixes | deps |
 
 ### P1
 
 | ID | Gap | Evidence | Track |
 |----|-----|----------|-------|
-| G-P1-1 | Incomplete skill routing | 16/34 skills in `skill-rules.json` | R-C1 |
-| G-P1-2 | `ci-poll` has no evals | Missing `evals/evals.json` | R-C2 |
-| G-P1-3 | ~~Missing `.agents/SKILLS.md`~~ | Generated 2026-07-20; keep in sync with catalog | R-C3 partial (routing still open) |
-| G-P1-4 | F4 pilots not fully exposed via CLI/MCP | Core modules present; limited operator surface | R-B2 / R-C4–C5 |
-| G-P1-5 | TECH_DEBT.md stale (WASM / ignore counts) | `docs/TECH_DEBT.md` | R-B3 |
-| G-P1-6 | Vision roadmap still titled v0.1.9+ | `ROADMAP_V030_VISION.md` | R-D7 |
-| G-P1-7 | Medium-risk skills lack behavioral evals | Beyond K3.2 set | R-E2 |
+| G-P1-7 | Medium-risk skills lack deeper behavioral evals | Beyond K3.2 core set | R-E2 |
+| G-P1-8 | Historical ADR number reuse remains on disk | Filenames still dual 025/054; aliases documented | R-B5 residual |
+| G-P1-9 | Dependabot security alerts on default branch | GitHub reports open Dependabot vulns (separate from #877) | security hygiene |
 
 ### P2 (product / research)
 
 | ID | Gap | Notes | Track |
-|----|-----|-------|-------|
+|----|-----|-------|--------|
 | G-P2-1 | WG-108 version-retained persistence | Backlog epic | R-F5 |
 | G-P2-2 | WG-110 SIMD similarity | Bench-gated | R-F4 |
 | G-P2-3 | WG-125 MoE routing eval | Research only | R-F6 |
@@ -65,10 +61,12 @@
 |-------|---------|
 | `execute_agent_code` working backend | **Not a gap** — intentional fail-closed |
 | Batch MCP tools | Deferred by product decision; document only |
-| 2026-05 telemetry stubs WG-156–162 | Prior campaign treated as remediated; re-open only if `rg` finds constants again |
+| Production `src` LOC >500 | **Closed** — remaining >500 files are `*_tests.rs` / test modules |
+| `todo!` / `unimplemented!` in prod `src` | **0 matches** |
 
 ## Exit criteria for this gap register
 
-- All P0 rows closed or waived with evidence on the thread  
-- P1 skill/docs rows closed or scheduled with owners  
+- G-P0-1 closed by shipping `v0.1.36` and post-bump  
+- G-P0-4 / G-P0-5 closed when #880 and #877 are green and merged as appropriate  
+- P1 skill-depth rows scheduled or waived with owners  
 - P2 rows remain spikes, not silent code stubs  

--- a/plans/STATUS/VALIDATION_LATEST.md
+++ b/plans/STATUS/VALIDATION_LATEST.md
@@ -1,33 +1,41 @@
-# Validation Latest — 2026-07-20 Plans Consolidation
+# Validation Latest — 2026-07-21 Open Tracker + Gap Refresh
 
-**Goal**: Archive superseded plans; publish single recommendations backlog; refresh canonical status.  
-**Workspace**: `0.1.36` unreleased · **Tag**: `v0.1.35` · **HEAD**: `2e0a2b89`  
-**Release**: ⛔ not performed by this validation (R-A1 remains recommended)
+**Goal**: Reconcile plans status with live GitHub open PRs/issues; close completed gap rows; keep single active recommendations plan.  
+**Workspace**: `0.1.36` unreleased · **Tag**: `v0.1.35` · **HEAD**: `1ebab995`  
+**Release**: ⛔ not performed by this validation (R-A1 remains next after #880)
 
 ## Evidence
 
 | Check | Command / observation | Result |
 |-------|----------------------|--------|
-| Active set files present | `./scripts/validate-plans.sh --active-set` | ✅ OK |
-| Version mentioned in CURRENT | workspace `0.1.36` | ✅ |
-| Root dated GOAP bloat | archived to `archive/2026-07-consolidation/` | ✅ |
-| Open PRs | `gh pr list --state open` | 0 |
-| Open issues | `gh issue list --state open` | 0 |
-| Commits since tag | `git rev-list --count v0.1.35..HEAD` | 18 |
-| Prod LOC>500 | `provider_config.rs` | 511 (tracked R-B1) |
-| Skill routes | 16/34 | Partial (R-C1) |
-| `ci-poll` evals | missing | Tracked R-C2 |
-| Prior F4 spikes | `plans/STATUS/spikes/F4.*.json` GO; S1.1c NO-GO | ✅ retained |
+| Active set files present | `./scripts/validate-plans.sh --active-set` | Run on this branch |
+| Version in CURRENT | workspace `0.1.36` | ✅ |
+| Open PRs | `gh pr list --state open` | #880, #877 |
+| Open issues | `gh issue list --state open` | #879 release drift |
+| Commits since tag | `git rev-list --count v0.1.35..origin/main` | **26** |
+| Prod LOC >500 (non-test `src`) | `provider_config.rs` | **237** ✅ |
+| Skill eval files | `find .agents/skills -path '*/evals/evals.json'` | 34 |
+| `todo!` / `unimplemented!` in prod `src` | `rg` | 0 |
+| ADR 025/054 | filenames dual; `plans/adr/README.md` aliases | ✅ documented |
+| #880 commitlint | body-max-line-length; squashed rewrite | ✅ pushed |
+| #877 compile breakers | sha2 0.11 hex; lz4_flex `std`; cargo_metadata `PackageName` | ✅ pushed |
 
-## Prior wave (historical)
+## Prior waves (historical)
 
-F4 remainder and missing-tasks waves completed on PRs #873/#874 (merged 2026-07-18). Details:  
-`plans/archive/2026-07-consolidation/completed-sprints/`.
+- Recommendations implementation: PR **#878** merged  
+- F4 remainder / missing-tasks / harness: #873/#874/#870 (2026-07-18)  
+- Archive: `plans/archive/2026-07-consolidation/`
 
 ## Still open after this validation
 
-See `GAP_ANALYSIS_LATEST.md` P0/P1 and recommendations R-A* / R-B* / R-C*.
+| Item | Next step |
+|------|-----------|
+| G-P0-1 / R-A1 | Merge #880 → main green → `./scripts/release-manager.sh ship --execute` |
+| R-A2 | Immediate post-tag bump to 0.1.37 |
+| #877 | Wait CI green; merge when ready (has `release-preparation`) |
+| #879 | Auto-resolves / updates after release |
+| R-E2 / R-F* | Backlog |
 
 ## Merge / ship note
 
-This is a **docs/plans-only** change set. Code quality gates still required before any subsequent code PR merge. Release of v0.1.36 is a separate release-guard action.
+This change set is **plans/docs tracker refresh only**. Do not ship a release from this PR alone — use release-guard path after #880 lands on main.


### PR DESCRIPTION
## Summary
- Refresh `plans/STATUS/*`, GOAP trio, ROADMAP, and recommendations header for live open tracker
- Reflect completed #878 work (LOC, skills, journal CLI) and open P0: ship v0.1.36 + #877 deps

## Context
Inventory session: open PRs **#880** (release docs), **#877** (rust-major deps), issue **#879** (release drift). Code CI fixes landed on those PRs separately.

## Test plan
- [x] Plans docs only
- [ ] `./scripts/validate-plans.sh --active-set` in CI / local