### PR TITLE
feat(skills): expand medium-risk evals and refresh plans truth

### DIFF
--- a/.agents/skills/agent-coordination/evals/evals.json
+++ b/.agents/skills/agent-coordination/evals/evals.json
@@ -1,9 +1,9 @@
 {
   "tests": [
     {
-      "name": "Goal breakdown",
-      "description": "Verify the agent can break down complex tasks into atomic goals.",
-      "exec": "test -f .agents/skills/agent-coordination/SKILL.md && rg -q . .agents/skills/agent-coordination/SKILL.md"
+      "name": "skill-md-present",
+      "description": "agent-coordination skill exists",
+      "exec": "test -f .agents/skills/agent-coordination/SKILL.md"
     },
     {
       "name": "has-frontmatter-name",
@@ -11,9 +11,14 @@
       "exec": "rg -q '^name:[[:space:]]*agent-coordination' .agents/skills/agent-coordination/SKILL.md"
     },
     {
-      "name": "has-description",
-      "description": "description frontmatter present",
-      "exec": "rg -q '^description:' .agents/skills/agent-coordination/SKILL.md"
+      "name": "documents-strategies",
+      "description": "Documents parallel/sequential/swarm strategies",
+      "exec": "rg -qi 'parallel|sequential|swarm' .agents/skills/agent-coordination/SKILL.md"
+    },
+    {
+      "name": "documents-quality-gates",
+      "description": "Documents quality gates in coordination",
+      "exec": "rg -qi 'quality|gate' .agents/skills/agent-coordination/SKILL.md"
     },
     {
       "name": "no-unguarded-gh-release-create",

--- a/.agents/skills/agents-update/evals/evals.json
+++ b/.agents/skills/agents-update/evals/evals.json
@@ -1,9 +1,29 @@
 {
   "tests": [
     {
-      "name": "Documentation alignment",
-      "description": "Verify agent documentation remains aligned.",
-      "exec": "test -f .agents/skills/agents-update/SKILL.md && rg -q . .agents/skills/agents-update/SKILL.md"
+      "name": "skill-md-present",
+      "description": "agents-update skill exists",
+      "exec": "test -f .agents/skills/agents-update/SKILL.md"
+    },
+    {
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*agents-update' .agents/skills/agents-update/SKILL.md"
+    },
+    {
+      "name": "documents-loc-budget",
+      "description": "Documents AGENTS.md LOC budget",
+      "exec": "rg -q '140' .agents/skills/agents-update/SKILL.md"
+    },
+    {
+      "name": "documents-agent-docs",
+      "description": "Documents moving detail to agent_docs/",
+      "exec": "rg -q 'agent_docs' .agents/skills/agents-update/SKILL.md"
+    },
+    {
+      "name": "no-unguarded-gh-release-create",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/agents-update/SKILL.md"
     }
   ]
 }

--- a/.agents/skills/analysis-swarm/evals/evals.json
+++ b/.agents/skills/analysis-swarm/evals/evals.json
@@ -1,9 +1,9 @@
 {
   "tests": [
     {
-      "name": "Codebase analysis",
-      "description": "Verify the agent can analyze the codebase effectively.",
-      "exec": "test -f .agents/skills/analysis-swarm/SKILL.md && rg -q . .agents/skills/analysis-swarm/SKILL.md"
+      "name": "skill-md-present",
+      "description": "analysis-swarm skill exists",
+      "exec": "test -f .agents/skills/analysis-swarm/SKILL.md"
     },
     {
       "name": "has-frontmatter-name",
@@ -11,9 +11,14 @@
       "exec": "rg -q '^name:[[:space:]]*analysis-swarm' .agents/skills/analysis-swarm/SKILL.md"
     },
     {
-      "name": "has-description",
-      "description": "description frontmatter present",
-      "exec": "rg -q '^description:' .agents/skills/analysis-swarm/SKILL.md"
+      "name": "documents-personas",
+      "description": "Documents multi-persona analysis (RYAN/FLASH/SOCRATES or personas)",
+      "exec": "rg -qi 'RYAN|FLASH|SOCRATES|persona' .agents/skills/analysis-swarm/SKILL.md"
+    },
+    {
+      "name": "documents-tradeoffs",
+      "description": "Documents trade-off / multi-perspective analysis",
+      "exec": "rg -qi 'trade|perspective|decision|analysis' .agents/skills/analysis-swarm/SKILL.md"
     },
     {
       "name": "no-unguarded-gh-release-create",

--- a/.agents/skills/architecture-validation/evals/evals.json
+++ b/.agents/skills/architecture-validation/evals/evals.json
@@ -6,9 +6,24 @@
       "exec": "test -f .agents/skills/architecture-validation/SKILL.md"
     },
     {
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*architecture-validation' .agents/skills/architecture-validation/SKILL.md"
+    },
+    {
       "name": "references-plans",
-      "description": "mentions plans/ directory",
+      "description": "References plans/ directory for architecture",
       "exec": "rg -q 'plans/' .agents/skills/architecture-validation/SKILL.md"
+    },
+    {
+      "name": "documents-drift",
+      "description": "Documents architecture drift detection",
+      "exec": "rg -qi 'drift|compliance|gap' .agents/skills/architecture-validation/SKILL.md"
+    },
+    {
+      "name": "no-unguarded-gh-release-create",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/architecture-validation/SKILL.md"
     }
   ]
 }

--- a/.agents/skills/build-rust/evals/evals.json
+++ b/.agents/skills/build-rust/evals/evals.json
@@ -6,9 +6,24 @@
       "exec": "test -f .agents/skills/build-rust/SKILL.md"
     },
     {
-      "name": "build-script-exists",
-      "description": "build-rust.sh present",
-      "exec": "test -f ./scripts/build-rust.sh"
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*build-rust' .agents/skills/build-rust/SKILL.md"
+    },
+    {
+      "name": "documents-build-script",
+      "description": "References ./scripts/build-rust.sh",
+      "exec": "rg -q 'scripts/build-rust\\.sh' .agents/skills/build-rust/SKILL.md && test -x ./scripts/build-rust.sh"
+    },
+    {
+      "name": "documents-modes",
+      "description": "Documents dev/release/check modes",
+      "exec": "rg -q 'dev' .agents/skills/build-rust/SKILL.md && rg -q 'release' .agents/skills/build-rust/SKILL.md && rg -q 'check' .agents/skills/build-rust/SKILL.md"
+    },
+    {
+      "name": "no-unguarded-gh-release-create",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/build-rust/SKILL.md"
     }
   ]
 }

--- a/.agents/skills/ci-poll/evals/evals.json
+++ b/.agents/skills/ci-poll/evals/evals.json
@@ -6,29 +6,24 @@
       "exec": "test -f .agents/skills/ci-poll/SKILL.md"
     },
     {
-      "name": "prefers-pr-checks-watch",
-      "description": "Documents gh pr checks --watch as primary wait",
-      "exec": "rg -q 'pr checks.*--watch|checks --required --watch' .agents/skills/ci-poll/SKILL.md"
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*ci-poll' .agents/skills/ci-poll/SKILL.md"
     },
     {
-      "name": "documents-run-watch",
-      "description": "Documents gh run watch for single workflows",
-      "exec": "rg -q 'gh run watch' .agents/skills/ci-poll/SKILL.md"
+      "name": "documents-pr-checks-watch",
+      "description": "Documents gh pr checks --watch or gh run watch",
+      "exec": "rg -q 'pr checks --watch|run watch|statusCheckRollup' .agents/skills/ci-poll/SKILL.md"
     },
     {
-      "name": "prefers-update-branch-cli",
-      "description": "Prefers gh pr update-branch over raw API only",
-      "exec": "rg -q 'gh pr update-branch' .agents/skills/ci-poll/SKILL.md"
+      "name": "documents-backoff-or-poll",
+      "description": "Documents polling / wait until complete",
+      "exec": "rg -qi 'poll|watch|backoff|pending' .agents/skills/ci-poll/SKILL.md"
     },
     {
-      "name": "no-force-merge-advice",
-      "description": "Forbids admin merge (may document as NEVER)",
-      "exec": "rg -qi 'never.*admin|do not.*admin|Never.*admin' .agents/skills/ci-poll/SKILL.md"
-    },
-    {
-      "name": "no-hardcoded-sleep-only",
-      "description": "Does not recommend bare sleep as the only wait strategy",
-      "exec": "! rg -q 'just sleep|only sleep [0-9]' .agents/skills/ci-poll/SKILL.md"
+      "name": "no-unguarded-gh-release-create",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/ci-poll/SKILL.md"
     }
   ]
 }

--- a/.agents/skills/codebase-analyzer/evals/evals.json
+++ b/.agents/skills/codebase-analyzer/evals/evals.json
@@ -1,9 +1,29 @@
 {
   "tests": [
     {
-      "name": "Pattern discovery",
-      "description": "Verify the agent can discover code patterns.",
-      "exec": "test -f .agents/skills/codebase-analyzer/SKILL.md && rg -q . .agents/skills/codebase-analyzer/SKILL.md"
+      "name": "skill-md-present",
+      "description": "codebase-analyzer skill exists",
+      "exec": "test -f .agents/skills/codebase-analyzer/SKILL.md"
+    },
+    {
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*codebase-analyzer' .agents/skills/codebase-analyzer/SKILL.md"
+    },
+    {
+      "name": "documents-analysis-modes",
+      "description": "Documents Locator/Analyzer/Consolidator modes",
+      "exec": "rg -q 'Locator|Analyzer|Consolidator' .agents/skills/codebase-analyzer/SKILL.md"
+    },
+    {
+      "name": "documents-data-flow",
+      "description": "Documents data-flow / implementation tracing",
+      "exec": "rg -qi 'data flow|trace|implementation' .agents/skills/codebase-analyzer/SKILL.md"
+    },
+    {
+      "name": "no-unguarded-gh-release-create",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/codebase-analyzer/SKILL.md"
     }
   ]
 }

--- a/.agents/skills/debug-troubleshoot/evals/evals.json
+++ b/.agents/skills/debug-troubleshoot/evals/evals.json
@@ -1,9 +1,34 @@
 {
   "tests": [
     {
-      "name": "Regression fix",
-      "description": "Verify the agent can fix regressions.",
-      "exec": "test -f .agents/skills/debug-troubleshoot/SKILL.md && rg -q . .agents/skills/debug-troubleshoot/SKILL.md"
+      "name": "skill-md-present",
+      "description": "debug-troubleshoot skill exists",
+      "exec": "test -f .agents/skills/debug-troubleshoot/SKILL.md"
+    },
+    {
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*debug-troubleshoot' .agents/skills/debug-troubleshoot/SKILL.md"
+    },
+    {
+      "name": "documents-tokio",
+      "description": "Documents Tokio async debugging context",
+      "exec": "rg -qi 'tokio' .agents/skills/debug-troubleshoot/SKILL.md"
+    },
+    {
+      "name": "documents-rust-log",
+      "description": "Documents RUST_LOG / tracing logging",
+      "exec": "rg -q 'RUST_LOG|tracing' .agents/skills/debug-troubleshoot/SKILL.md"
+    },
+    {
+      "name": "documents-storage-backends",
+      "description": "Mentions Turso and/or redb connection issues",
+      "exec": "rg -qi 'turso|redb' .agents/skills/debug-troubleshoot/SKILL.md"
+    },
+    {
+      "name": "no-unguarded-gh-release-create",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/debug-troubleshoot/SKILL.md"
     }
   ]
 }

--- a/.agents/skills/do-memory-cli-ops/evals/evals.json
+++ b/.agents/skills/do-memory-cli-ops/evals/evals.json
@@ -2,13 +2,33 @@
   "tests": [
     {
       "name": "skill-md-present",
-      "description": "cli ops skill exists",
+      "description": "do-memory-cli-ops skill exists",
       "exec": "test -f .agents/skills/do-memory-cli-ops/SKILL.md"
     },
     {
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*do-memory-cli-ops' .agents/skills/do-memory-cli-ops/SKILL.md"
+    },
+    {
       "name": "documents-cli-binary",
-      "description": "mentions do-memory-cli",
+      "description": "Documents do-memory-cli binary path/name",
       "exec": "rg -q 'do-memory-cli' .agents/skills/do-memory-cli-ops/SKILL.md"
+    },
+    {
+      "name": "documents-output-formats",
+      "description": "Documents human/json/yaml formats",
+      "exec": "rg -q 'json|yaml|human' .agents/skills/do-memory-cli-ops/SKILL.md"
+    },
+    {
+      "name": "documents-config-flag",
+      "description": "Documents --config option",
+      "exec": "rg -q -- '--config|config' .agents/skills/do-memory-cli-ops/SKILL.md"
+    },
+    {
+      "name": "no-unguarded-gh-release-create",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/do-memory-cli-ops/SKILL.md"
     }
   ]
 }

--- a/.agents/skills/do-memory-mcp/evals/evals.json
+++ b/.agents/skills/do-memory-mcp/evals/evals.json
@@ -2,13 +2,33 @@
   "tests": [
     {
       "name": "skill-md-present",
-      "description": "mcp skill exists",
+      "description": "do-memory-mcp skill exists",
       "exec": "test -f .agents/skills/do-memory-mcp/SKILL.md"
     },
     {
-      "name": "documents-mcp-tools",
-      "description": "mentions MCP tools",
-      "exec": "rg -q 'tool' .agents/skills/do-memory-mcp/SKILL.md"
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*do-memory-mcp' .agents/skills/do-memory-mcp/SKILL.md"
+    },
+    {
+      "name": "documents-query-memory",
+      "description": "Documents query_memory tool",
+      "exec": "rg -q 'query_memory' .agents/skills/do-memory-mcp/SKILL.md"
+    },
+    {
+      "name": "documents-fail-closed-exec",
+      "description": "Documents fail-closed execute_agent_code",
+      "exec": "rg -q 'execute_agent_code|fail-closed|fail closed' .agents/skills/do-memory-mcp/SKILL.md"
+    },
+    {
+      "name": "documents-analyze-patterns",
+      "description": "Documents pattern analysis tools",
+      "exec": "rg -q 'analyze_patterns|pattern' .agents/skills/do-memory-mcp/SKILL.md"
+    },
+    {
+      "name": "no-unguarded-gh-release-create",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/do-memory-mcp/SKILL.md"
     }
   ]
 }

--- a/.agents/skills/external-signal-provider/evals/evals.json
+++ b/.agents/skills/external-signal-provider/evals/evals.json
@@ -1,9 +1,34 @@
 {
   "tests": [
     {
-      "name": "Signal integration",
-      "description": "Verify external signals are correctly integrated.",
-      "exec": "test -f .agents/skills/external-signal-provider/SKILL.md && rg -q . .agents/skills/external-signal-provider/SKILL.md"
+      "name": "skill-md-present",
+      "description": "external-signal-provider skill exists",
+      "exec": "test -f .agents/skills/external-signal-provider/SKILL.md"
+    },
+    {
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*external-signal-provider' .agents/skills/external-signal-provider/SKILL.md"
+    },
+    {
+      "name": "documents-trait",
+      "description": "Documents ExternalSignalProvider trait",
+      "exec": "rg -q 'ExternalSignalProvider' .agents/skills/external-signal-provider/SKILL.md"
+    },
+    {
+      "name": "documents-agentfs-or-reward",
+      "description": "Documents AgentFS or reward integration",
+      "exec": "rg -qi 'AgentFS|reward|signal' .agents/skills/external-signal-provider/SKILL.md"
+    },
+    {
+      "name": "references-adr-051",
+      "description": "Links ADR-051 architecture",
+      "exec": "rg -q 'ADR-051' .agents/skills/external-signal-provider/SKILL.md"
+    },
+    {
+      "name": "no-unguarded-gh-release-create",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/external-signal-provider/SKILL.md"
     }
   ]
 }

--- a/.agents/skills/feature-implement/evals/evals.json
+++ b/.agents/skills/feature-implement/evals/evals.json
@@ -1,9 +1,34 @@
 {
   "tests": [
     {
-      "name": "End-to-end feature",
-      "description": "Verify full feature implementation.",
-      "exec": "test -f .agents/skills/feature-implement/SKILL.md && rg -q . .agents/skills/feature-implement/SKILL.md"
+      "name": "skill-md-present",
+      "description": "feature-implement skill exists",
+      "exec": "test -f .agents/skills/feature-implement/SKILL.md"
+    },
+    {
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*feature-implement' .agents/skills/feature-implement/SKILL.md"
+    },
+    {
+      "name": "documents-process-phases",
+      "description": "Documents planning/design/implementation/testing process",
+      "exec": "rg -q 'Planning|Design|Implementation|Testing' .agents/skills/feature-implement/SKILL.md"
+    },
+    {
+      "name": "documents-loc-limit",
+      "description": "Documents \u2264500 LOC file size invariant",
+      "exec": "rg -q '500' .agents/skills/feature-implement/SKILL.md"
+    },
+    {
+      "name": "documents-coverage-target",
+      "description": "Documents coverage target",
+      "exec": "rg -q '90%|coverage' .agents/skills/feature-implement/SKILL.md"
+    },
+    {
+      "name": "no-unguarded-gh-release-create",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/feature-implement/SKILL.md"
     }
   ]
 }

--- a/.agents/skills/git-worktree-manager/evals/evals.json
+++ b/.agents/skills/git-worktree-manager/evals/evals.json
@@ -1,9 +1,29 @@
 {
   "tests": [
     {
-      "name": "Worktree isolation",
-      "description": "Verify worktree usage.",
-      "exec": "test -f .agents/skills/git-worktree-manager/SKILL.md && rg -q . .agents/skills/git-worktree-manager/SKILL.md"
+      "name": "skill-md-present",
+      "description": "git-worktree-manager skill exists",
+      "exec": "test -f .agents/skills/git-worktree-manager/SKILL.md"
+    },
+    {
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*git-worktree-manager' .agents/skills/git-worktree-manager/SKILL.md"
+    },
+    {
+      "name": "documents-worktree",
+      "description": "Documents git worktree commands",
+      "exec": "rg -q 'worktree' .agents/skills/git-worktree-manager/SKILL.md"
+    },
+    {
+      "name": "documents-branch-isolation",
+      "description": "Documents branch/isolation workflow",
+      "exec": "rg -qi 'branch|isolat' .agents/skills/git-worktree-manager/SKILL.md"
+    },
+    {
+      "name": "no-unguarded-gh-release-create",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/git-worktree-manager/SKILL.md"
     }
   ]
 }

--- a/.agents/skills/github-release-best-practices/evals/evals.json
+++ b/.agents/skills/github-release-best-practices/evals/evals.json
@@ -2,13 +2,23 @@
   "tests": [
     {
       "name": "skill-md-present",
-      "description": "github release skill exists",
+      "description": "github-release-best-practices skill exists",
       "exec": "test -f .agents/skills/github-release-best-practices/SKILL.md"
     },
     {
+      "name": "defers-to-release-guard",
+      "description": "Defers shipping to release-guard / release-manager",
+      "exec": "rg -q 'release-guard|release-manager' .agents/skills/github-release-best-practices/SKILL.md"
+    },
+    {
+      "name": "blocks-manual-create",
+      "description": "Does not present bare gh release create as ship path",
+      "exec": "rg -q 'release-manager.sh ship|NEVER|never' .agents/skills/github-release-best-practices/SKILL.md || ! rg -q 'gh release create' .agents/skills/github-release-best-practices/SKILL.md"
+    },
+    {
       "name": "verify-script-exists",
-      "description": "verify-release-state.sh present",
-      "exec": "test -f ./scripts/verify-release-state.sh"
+      "description": "Related release scripts present",
+      "exec": "test -x ./scripts/release-manager.sh || test -f ./scripts/verify-release-state.sh"
     }
   ]
 }

--- a/.agents/skills/github-workflows/evals/evals.json
+++ b/.agents/skills/github-workflows/evals/evals.json
@@ -1,9 +1,29 @@
 {
   "tests": [
     {
-      "name": "Workflow validation",
-      "description": "Verify GH actions workflows.",
-      "exec": "test -f .agents/skills/github-workflows/SKILL.md && rg -q . .agents/skills/github-workflows/SKILL.md"
+      "name": "skill-md-present",
+      "description": "github-workflows skill exists",
+      "exec": "test -f .agents/skills/github-workflows/SKILL.md"
+    },
+    {
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*github-workflows' .agents/skills/github-workflows/SKILL.md"
+    },
+    {
+      "name": "documents-gh-workflow",
+      "description": "Documents gh workflow inspection",
+      "exec": "rg -q 'gh workflow|workflow list|Actions' .agents/skills/github-workflows/SKILL.md"
+    },
+    {
+      "name": "documents-caching-or-ci",
+      "description": "Documents CI/CD or caching guidance",
+      "exec": "rg -qi 'cache|CI/CD|workflow' .agents/skills/github-workflows/SKILL.md"
+    },
+    {
+      "name": "no-unguarded-gh-release-create",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/github-workflows/SKILL.md"
     }
   ]
 }

--- a/.agents/skills/learn/evals/evals.json
+++ b/.agents/skills/learn/evals/evals.json
@@ -1,9 +1,29 @@
 {
   "tests": [
     {
-      "name": "Knowledge acquisition",
-      "description": "Verify learning from task outcomes.",
-      "exec": "test -f .agents/skills/learn/SKILL.md && rg -q . .agents/skills/learn/SKILL.md"
+      "name": "skill-md-present",
+      "description": "learn skill exists",
+      "exec": "test -f .agents/skills/learn/SKILL.md"
+    },
+    {
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*learn' .agents/skills/learn/SKILL.md"
+    },
+    {
+      "name": "documents-agents-md",
+      "description": "Documents writing scoped AGENTS.md learnings",
+      "exec": "rg -q 'AGENTS\\.md' .agents/skills/learn/SKILL.md"
+    },
+    {
+      "name": "documents-non-obvious",
+      "description": "Captures non-obvious learnings only",
+      "exec": "rg -qi 'non-obvious' .agents/skills/learn/SKILL.md"
+    },
+    {
+      "name": "no-unguarded-gh-release-create",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/learn/SKILL.md"
     }
   ]
 }

--- a/.agents/skills/loop-agent/evals/evals.json
+++ b/.agents/skills/loop-agent/evals/evals.json
@@ -1,9 +1,9 @@
 {
   "tests": [
     {
-      "name": "Self-correction",
-      "description": "Verify the agent can correct its own mistakes.",
-      "exec": "test -f .agents/skills/loop-agent/SKILL.md && rg -q . .agents/skills/loop-agent/SKILL.md"
+      "name": "skill-md-present",
+      "description": "loop-agent skill exists",
+      "exec": "test -f .agents/skills/loop-agent/SKILL.md"
     },
     {
       "name": "has-frontmatter-name",
@@ -11,9 +11,14 @@
       "exec": "rg -q '^name:[[:space:]]*loop-agent' .agents/skills/loop-agent/SKILL.md"
     },
     {
-      "name": "has-description",
-      "description": "description frontmatter present",
-      "exec": "rg -q '^description:' .agents/skills/loop-agent/SKILL.md"
+      "name": "documents-iteration",
+      "description": "Documents iterative refinement loop",
+      "exec": "rg -qi 'iterat|loop|refine|converg' .agents/skills/loop-agent/SKILL.md"
+    },
+    {
+      "name": "documents-quality-criteria",
+      "description": "Documents quality criteria / stop conditions",
+      "exec": "rg -qi 'quality|criteria|max iter|until' .agents/skills/loop-agent/SKILL.md"
     },
     {
       "name": "no-unguarded-gh-release-create",

--- a/.agents/skills/memory-context/evals/evals.json
+++ b/.agents/skills/memory-context/evals/evals.json
@@ -1,9 +1,34 @@
 {
   "tests": [
     {
-      "name": "Context retrieval",
-      "description": "Verify memory context is correctly retrieved.",
-      "exec": "test -f .agents/skills/memory-context/SKILL.md && rg -q . .agents/skills/memory-context/SKILL.md"
+      "name": "skill-md-present",
+      "description": "memory-context skill exists",
+      "exec": "test -f .agents/skills/memory-context/SKILL.md"
+    },
+    {
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*memory-context' .agents/skills/memory-context/SKILL.md"
+    },
+    {
+      "name": "documents-cli-binary",
+      "description": "References do-memory-cli for retrieval",
+      "exec": "rg -q 'do-memory-cli' .agents/skills/memory-context/SKILL.md"
+    },
+    {
+      "name": "documents-episode-or-query",
+      "description": "Documents episode/query retrieval operations",
+      "exec": "rg -qi 'episode|query|retrieve|semantic' .agents/skills/memory-context/SKILL.md"
+    },
+    {
+      "name": "documents-local-or-turso-env",
+      "description": "Documents local or Turso database env setup",
+      "exec": "rg -q 'TURSO_|LOCAL_DATABASE|file:' .agents/skills/memory-context/SKILL.md"
+    },
+    {
+      "name": "no-unguarded-gh-release-create",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/memory-context/SKILL.md"
     }
   ]
 }

--- a/.agents/skills/memory-harness/evals/evals.json
+++ b/.agents/skills/memory-harness/evals/evals.json
@@ -6,19 +6,14 @@
       "exec": "test -f .agents/skills/memory-harness/SKILL.md"
     },
     {
-      "name": "eval-script-present",
-      "description": "evaluate-learning.sh exists",
-      "exec": "test -f .agents/skills/memory-harness/evaluate-learning.sh"
-    },
-    {
       "name": "has-frontmatter-name",
       "description": "YAML name frontmatter matches skill",
       "exec": "rg -q '^name:[[:space:]]*memory-harness' .agents/skills/memory-harness/SKILL.md"
     },
     {
-      "name": "has-description",
-      "description": "description frontmatter present",
-      "exec": "rg -q '^description:' .agents/skills/memory-harness/SKILL.md"
+      "name": "documents-record-or-replay",
+      "description": "Documents record/replay/benchmark harness",
+      "exec": "rg -qi 'record|replay|benchmark|fixture|session' .agents/skills/memory-harness/SKILL.md"
     },
     {
       "name": "no-unguarded-gh-release-create",

--- a/.agents/skills/performance/evals/evals.json
+++ b/.agents/skills/performance/evals/evals.json
@@ -6,9 +6,29 @@
       "exec": "test -f .agents/skills/performance/SKILL.md"
     },
     {
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*performance' .agents/skills/performance/SKILL.md"
+    },
+    {
       "name": "documents-criterion",
-      "description": "mentions criterion or bench",
-      "exec": "rg -qi 'criterion|bench' .agents/skills/performance/SKILL.md"
+      "description": "Documents Criterion benchmarks",
+      "exec": "rg -qi 'criterion' .agents/skills/performance/SKILL.md"
+    },
+    {
+      "name": "documents-latency-targets",
+      "description": "Documents episode/retrieval latency targets",
+      "exec": "rg -q '50ms|100ms|Episode' .agents/skills/performance/SKILL.md"
+    },
+    {
+      "name": "documents-profiling",
+      "description": "Documents profiling tools",
+      "exec": "rg -qi 'flamegraph|profiling|perf|tokio-console' .agents/skills/performance/SKILL.md"
+    },
+    {
+      "name": "no-unguarded-gh-release-create",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/performance/SKILL.md"
     }
   ]
 }

--- a/.agents/skills/plan-gap-analysis/evals/evals.json
+++ b/.agents/skills/plan-gap-analysis/evals/evals.json
@@ -1,9 +1,34 @@
 {
   "tests": [
     {
-      "name": "Goal alignment",
-      "description": "Verify plans align with current goals.",
-      "exec": "test -f .agents/skills/plan-gap-analysis/SKILL.md && rg -q . .agents/skills/plan-gap-analysis/SKILL.md"
+      "name": "skill-md-present",
+      "description": "plan-gap-analysis skill exists",
+      "exec": "test -f .agents/skills/plan-gap-analysis/SKILL.md"
+    },
+    {
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*plan-gap-analysis' .agents/skills/plan-gap-analysis/SKILL.md"
+    },
+    {
+      "name": "documents-plans-inventory",
+      "description": "Documents reading plan files",
+      "exec": "rg -q 'plans/' .agents/skills/plan-gap-analysis/SKILL.md"
+    },
+    {
+      "name": "documents-gap-priorities",
+      "description": "Documents Critical/High/Medium prioritization",
+      "exec": "rg -qi 'Critical|High|Medium|priorit' .agents/skills/plan-gap-analysis/SKILL.md"
+    },
+    {
+      "name": "documents-crates",
+      "description": "Mentions workspace crates to analyze",
+      "exec": "rg -q 'do-memory-core|memory-core' .agents/skills/plan-gap-analysis/SKILL.md"
+    },
+    {
+      "name": "no-unguarded-gh-release-create",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/plan-gap-analysis/SKILL.md"
     }
   ]
 }

--- a/.agents/skills/release-cadence-manager/evals/evals.json
+++ b/.agents/skills/release-cadence-manager/evals/evals.json
@@ -6,29 +6,24 @@
       "exec": "test -f .agents/skills/release-cadence-manager/SKILL.md"
     },
     {
-      "name": "documents-detect-resolve",
-      "description": "Skill documents detect and resolve CLI entrypoints",
-      "exec": "rg -q 'detect' .agents/skills/release-cadence-manager/SKILL.md && rg -q 'resolve' .agents/skills/release-cadence-manager/SKILL.md && rg -q 'release-cadence-manager.sh' .agents/skills/release-cadence-manager/SKILL.md"
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*release-cadence-manager' .agents/skills/release-cadence-manager/SKILL.md"
     },
     {
-      "name": "cli-script-executable",
-      "description": "release-cadence-manager.sh present and executable",
-      "exec": "test -x ./scripts/release-cadence-manager.sh"
+      "name": "documents-detect",
+      "description": "Documents detect action / drift detection",
+      "exec": "rg -q 'detect|drift' .agents/skills/release-cadence-manager/SKILL.md"
     },
     {
-      "name": "cli-help-works",
-      "description": "CLI help documents detect/resolve/validate",
-      "exec": "./scripts/release-cadence-manager.sh help 2>&1 | rg -q 'detect|resolve|validate'"
+      "name": "documents-cli-script",
+      "description": "References release-cadence-manager.sh",
+      "exec": "rg -q 'release-cadence-manager\\.sh' .agents/skills/release-cadence-manager/SKILL.md && test -f ./scripts/release-cadence-manager.sh"
     },
     {
-      "name": "no-gha-expr-in-bash-docs",
-      "description": "Integration docs warn not to put GHA expressions inside bash run blocks",
-      "exec": "rg -q 'if:' .agents/skills/release-cadence-manager/integration.md || rg -q 'release-preparation' .agents/skills/release-cadence-manager/SKILL.md"
-    },
-    {
-      "name": "release-drift-label-gate",
-      "description": "release-drift workflow skips enforce when release-preparation label is present",
-      "exec": "rg -q \"release-preparation\" .github/workflows/release-drift.yml && rg -q 'contains\\(github.event.pull_request.labels' .github/workflows/release-drift.yml"
+      "name": "no-manual-ship",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/release-cadence-manager/SKILL.md"
     }
   ]
 }

--- a/.agents/skills/skill-creator/evals/evals.json
+++ b/.agents/skills/skill-creator/evals/evals.json
@@ -1,9 +1,34 @@
 {
   "tests": [
     {
-      "name": "Skill generation",
-      "description": "Verify new skills follow conventions.",
-      "exec": "test -f .agents/skills/skill-creator/SKILL.md && rg -q . .agents/skills/skill-creator/SKILL.md"
+      "name": "skill-md-present",
+      "description": "skill-creator skill exists",
+      "exec": "test -f .agents/skills/skill-creator/SKILL.md"
+    },
+    {
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*skill-creator' .agents/skills/skill-creator/SKILL.md"
+    },
+    {
+      "name": "documents-frontmatter",
+      "description": "Documents YAML frontmatter requirement",
+      "exec": "rg -qi 'frontmatter|YAML' .agents/skills/skill-creator/SKILL.md"
+    },
+    {
+      "name": "documents-skill-md",
+      "description": "Documents SKILL.md required file",
+      "exec": "rg -q 'SKILL\\.md' .agents/skills/skill-creator/SKILL.md"
+    },
+    {
+      "name": "documents-name-field",
+      "description": "Documents name field in frontmatter",
+      "exec": "rg -q 'name:' .agents/skills/skill-creator/SKILL.md"
+    },
+    {
+      "name": "no-unguarded-gh-release-create",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/skill-creator/SKILL.md"
     }
   ]
 }

--- a/.agents/skills/storage-sync/evals/evals.json
+++ b/.agents/skills/storage-sync/evals/evals.json
@@ -6,19 +6,19 @@
       "exec": "test -f .agents/skills/storage-sync/SKILL.md"
     },
     {
-      "name": "documents-backends",
-      "description": "mentions Turso and redb",
-      "exec": "rg -q 'Turso|turso' .agents/skills/storage-sync/SKILL.md && rg -q 'redb' .agents/skills/storage-sync/SKILL.md"
-    },
-    {
       "name": "has-frontmatter-name",
       "description": "YAML name frontmatter matches skill",
       "exec": "rg -q '^name:[[:space:]]*storage-sync' .agents/skills/storage-sync/SKILL.md"
     },
     {
-      "name": "has-description",
-      "description": "description frontmatter present",
-      "exec": "rg -q '^description:' .agents/skills/storage-sync/SKILL.md"
+      "name": "documents-backends",
+      "description": "Mentions Turso and redb",
+      "exec": "rg -q 'Turso|turso' .agents/skills/storage-sync/SKILL.md && rg -q 'redb' .agents/skills/storage-sync/SKILL.md"
+    },
+    {
+      "name": "documents-sync-purpose",
+      "description": "Documents cache sync / stale recovery",
+      "exec": "rg -qi 'sync|stale|cache|maintenance' .agents/skills/storage-sync/SKILL.md"
     },
     {
       "name": "no-unguarded-gh-release-create",

--- a/.agents/skills/test-fix/evals/evals.json
+++ b/.agents/skills/test-fix/evals/evals.json
@@ -1,9 +1,34 @@
 {
   "tests": [
     {
-      "name": "Flaky test repair",
-      "description": "Verify fixes for failing tests.",
-      "exec": "test -f .agents/skills/test-fix/SKILL.md && rg -q . .agents/skills/test-fix/SKILL.md"
+      "name": "skill-md-present",
+      "description": "test-fix skill exists",
+      "exec": "test -f .agents/skills/test-fix/SKILL.md"
+    },
+    {
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*test-fix' .agents/skills/test-fix/SKILL.md"
+    },
+    {
+      "name": "documents-cargo-test",
+      "description": "Documents cargo test reproduction",
+      "exec": "rg -q 'cargo test' .agents/skills/test-fix/SKILL.md"
+    },
+    {
+      "name": "documents-async-or-race",
+      "description": "Documents async/await or race condition patterns",
+      "exec": "rg -qi 'async|race|flaky|tokio' .agents/skills/test-fix/SKILL.md"
+    },
+    {
+      "name": "documents-debug-log",
+      "description": "Documents RUST_LOG debug reproduction",
+      "exec": "rg -q 'RUST_LOG' .agents/skills/test-fix/SKILL.md"
+    },
+    {
+      "name": "no-unguarded-gh-release-create",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/test-fix/SKILL.md"
     }
   ]
 }

--- a/.agents/skills/test-patterns/evals/evals.json
+++ b/.agents/skills/test-patterns/evals/evals.json
@@ -1,9 +1,34 @@
 {
   "tests": [
     {
-      "name": "Test pattern extraction",
-      "description": "Verify patterns are correctly extracted from tests.",
-      "exec": "test -f .agents/skills/test-patterns/SKILL.md && rg -q . .agents/skills/test-patterns/SKILL.md"
+      "name": "skill-md-present",
+      "description": "test-patterns skill exists",
+      "exec": "test -f .agents/skills/test-patterns/SKILL.md"
+    },
+    {
+      "name": "has-frontmatter-name",
+      "description": "YAML name frontmatter matches skill",
+      "exec": "rg -q '^name:[[:space:]]*test-patterns' .agents/skills/test-patterns/SKILL.md"
+    },
+    {
+      "name": "documents-aaa",
+      "description": "Documents Arrange-Act-Assert pattern",
+      "exec": "rg -q 'AAA|Arrange|Act|Assert' .agents/skills/test-patterns/SKILL.md"
+    },
+    {
+      "name": "documents-tokio-test",
+      "description": "Documents #[tokio::test]",
+      "exec": "rg -q 'tokio::test' .agents/skills/test-patterns/SKILL.md"
+    },
+    {
+      "name": "documents-naming",
+      "description": "Documents test naming convention",
+      "exec": "rg -q 'test_<|naming|scenario' .agents/skills/test-patterns/SKILL.md"
+    },
+    {
+      "name": "no-unguarded-gh-release-create",
+      "description": "Does not teach manual gh release create as ship path",
+      "exec": "! rg -q 'gh release create' .agents/skills/test-patterns/SKILL.md"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Skills (R-E2)**: medium-risk skill behavioral eval fixtures (second wave) —
+  presence-only checks replaced with contract tests (frontmatter, domain
+  keywords, ship-path negative guards) across 26 skills.
 - **CLI** `storage journal` — operator view of F4.2 operation journal
   (`--pending`, `--repair` via `reconcile_pending_evictions`).
 - **Skills**: `.agents/SKILLS.md` inventory; full `skill-rules.json` routing;

--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -1,10 +1,10 @@
 # GOAP Actions Backlog
 
-- **Last Updated**: 2026-07-21  
+- **Last Updated**: 2026-07-22  
 - **Active plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
 - **Archived plans**: `plans/archive/2026-07-consolidation/`
 
-## Active actions (2026-07-21)
+## Active actions (2026-07-22)
 
 | ID | Action | Rec | Status |
 |----|--------|-----|--------|
@@ -15,16 +15,16 @@
 | ACT-306 | Expand `skill-rules.json` to all catalog skills | R-C1 | ✅ Done |
 | ACT-307 | Add `ci-poll` evals + SKILLS.md sync | R-C2, R-C3 | ✅ Done |
 | ACT-308 | F4 operator UX: `storage journal` CLI (`--pending`/`--repair`) | R-B2, R-C5 | ✅ Done |
+| ACT-308b | MCP provenance fields on query responses | R-C4 | ✅ Already on main |
 | ACT-309 | Align AGENTS skill table + TECH_DEBT + vision title | R-D*, R-B3 | ✅ Done |
-| ACT-301 | Prepare CHANGELOG + release docs for v0.1.36 | R-A1 | 🟡 PR #880 |
-| ACT-302 | `./scripts/release-manager.sh ship --execute` for `v0.1.36` | R-A1 | 🟡 After #880 merge + main green |
+| ACT-310 | Medium-risk skill behavioral evals (second wave) | R-E2 | ✅ Done |
+| ACT-311 | `validate-plans.sh` warn on excess dated root files | R-G4 | ✅ Done |
+| ACT-301 | Prepare CHANGELOG + release docs for v0.1.36 | R-A1 | ✅ #880 merged |
+| ACT-313 | Land rust-major dependabot (sha2/lz4/cargo_metadata) | deps | ✅ #877 merged |
+| ACT-314 | Refresh plans tracker truth | R-G* | ✅ Done |
+| ACT-302 | `./scripts/release-manager.sh ship --execute` for `v0.1.36` | R-A1 | 🟡 After main green |
 | ACT-303 | Post-release workspace bump to 0.1.37 | R-A2 | 🟡 After ACT-302 |
-| ACT-313 | Land rust-major dependabot (#877) with sha2/lz4/cargo_metadata adapters | deps | 🟡 PR #877 |
-| ACT-314 | Refresh plans tracker truth (open PRs/issues, closed gaps) | R-G* | 🟡 This branch |
-| ACT-308b | MCP provenance fields on query responses (if any remaining gaps) | R-C4 | Backlog |
-| ACT-310 | Medium-risk skill behavioral evals (second wave) | R-E2 | Backlog |
-| ACT-311 | Optional: `validate-plans.sh` warn on excess dated root files | R-G4 | Backlog |
-| ACT-312 | Optional product/research spikes R-F* | R-F* | Backlog |
+| ACT-312 | Optional product/research spikes R-F* | R-F* | ⏸ DEFER |
 
 ## Completed actions (summary)
 

--- a/plans/GOALS.md
+++ b/plans/GOALS.md
@@ -1,24 +1,24 @@
 # GOAP Goals Index
 
-- **Last Updated**: 2026-07-21  
-- **Status**: Active — release v0.1.36 + open PR hygiene  
+- **Last Updated**: 2026-07-22  
+- **Status**: Active — release v0.1.36 readiness  
 - **Workspace**: `0.1.36` unreleased · **Tag**: `v0.1.35`  
 - **Plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
 - **Archive**: `plans/archive/2026-07-consolidation/`
 
-## Active goals (2026-07-21)
+## Active goals (2026-07-22)
 
 | Goal | Rec IDs | Priority | Status |
 |------|---------|----------|--------|
-| Ship v0.1.36 + post-bump | R-A1, R-A2, R-A3 | P0 | 🟡 After #880 + main green |
-| Green open CI (release docs + rust-major deps) | — | P0 | 🟡 #880 / #877 |
+| Ship v0.1.36 + post-bump | R-A1, R-A2, R-A3 | P0 | 🟡 Main green → release-manager ship |
 | Restore production LOC ≤500 | R-B1 | P0 | ✅ Done |
 | ADR identifier uniqueness (aliases) | R-B5 | P0 | ✅ Documented |
 | Complete skill routes + ci-poll evals + SKILLS.md | R-C1–C3, R-E1 | P1 | ✅ Done |
 | Productize F4 (provenance / journal / digests UX) | R-B2, R-C4–C6 | P1 | ✅ CLI journal; MCP provenance present |
+| Medium-risk skill behavioral evals | R-E2 | P1 | ✅ Done (second wave) |
 | Docs contract alignment (README, AGENTS, HARNESS, TECH_DEBT) | R-D*, R-B3 | P1 | ✅ |
-| Plans hygiene (archive + live tracker truth) | R-G1–G3 | P1 | ✅ 2026-07-21 refresh |
-| Optional research/product spikes | R-F* | P2 | Backlog |
+| Plans hygiene (archive + live tracker truth) | R-G1–G3 | P1 | ✅ 2026-07-22 refresh |
+| Optional research/product spikes | R-F* | P2 | ⏸ DEFER |
 
 ## Completed goal series (pointer only)
 

--- a/plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md
+++ b/plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md
@@ -1,17 +1,17 @@
 # Comprehensive Codebase Recommendations — 2026-07-20
 
 - **Status**: Active backlog (post–v0.1.35; workspace `0.1.36` unreleased)
-- **Audit commit**: `1ebab995` (`main`) — refreshed 2026-07-21
+- **Audit commit**: refreshed 2026-07-22
 - **Released tag**: `v0.1.35`
-- **Open PRs**: #880 (release docs), #877 (rust-major deps)
-- **Open issues**: #879 (release drift)
+- **Open PRs**: R-E2 skill evals / plans truth (this wave); #877/#880/#881 merged
+- **Open issues**: none (#879 resolved with release-docs path)
 - **Coordinator**: goap-agent + agent-coordination
 - **Supersedes**: archived `GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md` and dated 2026-06/07 execution plans
 - **Archive**: `plans/archive/2026-07-consolidation/`
 
 ## 1. Executive summary
 
-The 2026-07-14 → 2026-07-20 GOAP campaign closed the high-priority correctness, gate honesty, skill-eval, F4 pilot, and recommendations packages. PRs **#840–#878** are merged; workspace is **`0.1.36`** with **26 unreleased commits** on top of `v0.1.35`. Remaining P0 is **ship v0.1.36** (via #880 + release-manager) and land **#877** dep majors.
+The 2026-07-14 → 2026-07-22 GOAP campaign closed the high-priority correctness, gate honesty, skill-eval, F4 pilot, and recommendations packages. PRs **#840–#881** are merged (including release docs #880 and rust-major #877); workspace is **`0.1.36`**. Remaining P0 is **ship v0.1.36** via `./scripts/release-manager.sh ship --execute` when main is green.
 
 This plan is the **single active recommendations register**. It covers:
 
@@ -37,7 +37,7 @@ This plan is the **single active recommendations register**. It covers:
 |------|----------|---------|
 | Version | `Cargo.toml` `0.1.36`; tag `v0.1.35`; 26 unreleased commits | Unreleased development |
 | Main CI | Recent CI green on main HEAD | Green enough to plan release |
-| Open work | PRs #880, #877; issue #879 | Release + deps CI in flight |
+| Open work | Release ship only | #877/#880/#881 merged |
 | Production LOC >500 (non-test `src`) | No production offenders (`provider_config.rs` 237) | ✅ |
 | `todo!` / `unimplemented!` / “not yet implemented” in prod `src` | 0 matches | Clean surface |
 | Skills | Catalog + `ci-poll` evals present; routes complete | ✅ |
@@ -72,7 +72,7 @@ IDs use prefix **R** (recommendation). Priorities:
 
 | ID | Recommendation | Why | Acceptance |
 |----|----------------|-----|------------|
-| **R-A1** | Cut **v0.1.36** via `./scripts/release-manager.sh ship --execute` after CHANGELOG + Released Version docs | Merge #880 + main green | 🟡 CI / ship |
+| **R-A1** | Cut **v0.1.36** via `./scripts/release-manager.sh ship --execute` after CHANGELOG + Released Version docs | #880 merged; main green | 🟡 ship |
 | **R-A2** | Immediately bump workspace to **0.1.37** after tag | AGENTS post-release rule | 🟡 After R-A1 |
 | **R-A3** | Re-run `./scripts/release-manager.sh status` before ship | Status green before ship | 🟡 With R-A1 |
 
@@ -115,7 +115,7 @@ IDs use prefix **R** (recommendation). Priorities:
 | ID | Recommendation | Why |
 |----|----------------|-----|
 | **R-E1** | K3.3 routes + inventory | ✅ |
-| **R-E2** | Medium-risk skill evals expanded | ✅ |
+| **R-E2** | Medium-risk skill evals expanded | ✅ Second wave (behavioral fixtures for thin skills) |
 | **R-E3** | github-release-best-practices → release-guard only | ✅ Already |
 | **R-E4** | Frontmatter name/description evals | ✅ medium set + compiler |
 | **R-E5** | pycache gitignore | ✅ skill + skills/ + root |

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1,17 +1,17 @@
 # GOAP State Snapshot
 
-- **Last Updated**: 2026-07-21  
+- **Last Updated**: 2026-07-22  
 - **Version**: workspace `0.1.36` unreleased (latest tag `v0.1.35`)  
-- **Branch**: `main` @ `1ebab995`  
-- **Open PRs**: [#880](https://github.com/d-o-hub/rust-self-learning-memory/pull/880) (release docs), [#877](https://github.com/d-o-hub/rust-self-learning-memory/pull/877) (rust-major deps)  
-- **Open issues**: [#879](https://github.com/d-o-hub/rust-self-learning-memory/issues/879) (release drift)  
+- **Branch**: `main`  
+- **Open PRs**: none (implementation PR for R-E2 may be open)  
+- **Open issues**: none  
 - **Active plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
 - **Archive**: `plans/archive/2026-07-consolidation/`  
-- **Release**: 🟡 after #880 merge + main green (R-A1)
+- **Release**: 🟡 ship when main CI green (`verify-release-state` ready)
 
 ---
 
-## Phase: Release readiness + open PR CI 🟡
+## Phase: Release readiness 🟡
 
 | Package | Status |
 |---------|--------|
@@ -20,9 +20,11 @@
 | R-C1–C3 skill routes + ci-poll + SKILLS.md | ✅ |
 | R-B2/C5 `storage journal` CLI | ✅ |
 | R-B3/B5/D docs + ADR aliases | ✅ |
-| Release docs PR #880 | 🟡 CI (commitlint fixed) |
-| Dependabot rust-major #877 | 🟡 CI (compat fixes pushed) |
-| R-A1/A2 release v0.1.36 + post-bump | 🟡 blocked on #880 + main green |
+| R-E2 medium-risk skill evals (second wave) | ✅ |
+| Release docs PR #880 | ✅ Merged |
+| Dependabot rust-major #877 | ✅ Merged |
+| Plans tracker #881 | ✅ Merged |
+| R-A1/A2 release v0.1.36 + post-bump | 🟡 next |
 
 ---
 
@@ -41,10 +43,10 @@ Details: `plans/archive/2026-07-consolidation/completed-sprints/`.
 
 ---
 
-## Goal-state flags (2026-07-21)
+## Goal-state flags (2026-07-22)
 
 ```text
-truth_reconciled                  ≈ true (plans refreshed 2026-07-21; release lag remains)
+truth_reconciled                  ≈ true (plans refreshed 2026-07-22; release lag remains)
 sandbox_capability_boundary       = true (fail-closed; S1.1c NO-GO)
 retrieval_identity_complete       = true
 storage_awaits_lock_free          = true (step paths)
@@ -54,6 +56,7 @@ retry_backpressure_effective      = true
 gates_match_policy                ≈ true (GATE_CONTRACT + ci-parity)
 skill_evals_executable            = true
 skill_routes_complete             = true
+skill_evals_medium_depth          = true (R-E2 second wave)
 docs_match_code                   ≈ true (refresh after release)
 plan_registry_unique              ≈ true (ADR 025/054 aliased)
 feature_pilots_have_baselines     = true (F4 spikes)

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -1,47 +1,48 @@
 # Active Development Roadmap
 
-**Last Updated**: 2026-07-20  
-**Released Version**: v0.1.36
-**Workspace Version**: 0.1.36
-**Active Sprint**: Recommendations backlog + release readiness  
+**Last Updated**: 2026-07-22  
+**Released Version**: v0.1.36  
+**Workspace Version**: 0.1.36  
+**Active Sprint**: Release readiness + residual recommendations  
 **Plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
 **Branch**: `main`  
-**Open PRs**: #880 (release docs), #877 (rust-major deps)  
-**Open issues**: #879 (release drift)
+**Open PRs**: *(implementation PR for R-E2 may be open)*  
+**Open issues**: none  
 
 ---
 
-## Sprint 2026-07-21 — Release + CI
+## Sprint 2026-07-22 — Release
 
 | Priority | Item | Description | Status |
 |----------|------|-------------|--------|
-| 1 | Release docs | PR #880 finalize CHANGELOG / ROADMAP / CURRENT for v0.1.36 | 🟡 CI |
-| 2 | Ship v0.1.36 | `release-manager.sh ship --execute` after #880 + main green | 🟡 |
-| 3 | Post-bump | Workspace → 0.1.37 immediately after tag | 🟡 |
-| 4 | rust-major deps | PR #877 sha2 0.11 / lz4_flex 0.14 / cargo_metadata 0.23 | 🟡 CI |
-| 5 | Plans truth | CURRENT / GAP / GOALS / ACTIONS / GOAP_STATE tracker refresh | 🟡 |
+| 1 | Ship v0.1.36 | `release-manager.sh ship --execute` when main green | 🟡 |
+| 2 | Post-bump | Workspace → 0.1.37 immediately after tag | 🟡 |
+| 3 | R-E2 skill evals | Medium-risk behavioral fixtures second wave | ✅ |
+| 4 | Plans truth | CURRENT / GAP / GOALS / ACTIONS / GOAP_STATE | ✅ |
 
 ---
 
-## Completed last sprint (2026-07-20)
+## Completed last sprint (2026-07-20…21)
 
 | Priority | Item | Status |
 |----------|------|--------|
 | Plans hygiene (ADR-039 archive) | ✅ |
 | Recommendations register R-A…R-G | ✅ |
 | Implementation #878 (LOC, skills, journal CLI, docs) | ✅ |
+| Release docs #880 | ✅ |
+| rust-major deps #877 | ✅ |
+| Tracker refresh #881 | ✅ |
 
 ---
 
-## Follow-on backlog (P1/P2)
+## Follow-on backlog (P2)
 
 | Priority | Theme | Items | Status |
 |----------|-------|-------|--------|
-| P1 | Skills depth | Medium-risk behavioral evals (R-E2) | Backlog |
-| P1 | Operator F4 | Any remaining MCP provenance gaps (R-C4) | Backlog |
-| P2 | Research | WG-108 version retention; WG-110 SIMD (bench-gated); WG-125 MoE; WG-135 federated HDC | Backlog |
+| P2 | Research | WG-108 version retention; WG-110 SIMD (bench-gated); WG-125 MoE; WG-135 federated HDC | ⏸ DEFER |
 | P2 | Vision | Distributed sync, multi-tenancy/RBAC, OTel/Prometheus (see `ROADMAP_V030_VISION.md`) | Future |
 | P2 | Release eng | Trusted Publishing (OIDC) for crates.io | Future |
+| P2 | Security | Transitive Dependabot advisories (upstream libsql/openssl chains) | Monitor |
 
 ---
 

--- a/plans/STATUS/CODEBASE_ANALYSIS_LATEST.md
+++ b/plans/STATUS/CODEBASE_ANALYSIS_LATEST.md
@@ -1,7 +1,7 @@
-# Codebase Analysis Latest — 2026-07-20
+# Codebase Analysis Latest — 2026-07-22
 
-**Commit**: `2e0a2b89` · **Branch**: `main`  
-**Workspace**: `0.1.36` · **Released**: `v0.1.35`  
+**Branch**: `main` (+ R-E2 PR)  
+**Workspace**: `0.1.36` · **Released tag**: `v0.1.35`  
 **Companion**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`
 
 ## Architecture (as implemented)
@@ -22,35 +22,34 @@
 | Check | Result |
 |-------|--------|
 | Production `todo!` / unimplemented strings | None found |
-| Production LOC >500 | **1** (`embeddings/config/provider_config.rs`) |
-| Open GitHub issues/PRs | **0** |
-| Skills with evals | 33/34 (`ci-poll` missing) |
-| Skill routes | 16/34 |
-| Mainline CI (recent runs) | Success (CI, Security, Skill Evals, Storage Matrix) |
+| Production LOC >500 (non-test `src`) | **0** |
+| Open GitHub issues | **0** |
+| Skills with evals | 34/34 (medium-risk behavioral second wave) |
+| Skill routes | 34/34 |
+| Mainline CI (recent runs) | Success (Quick Check, Skill Evals, Storage Matrix, Release Drift) |
 | Fail-closed code execution | Preserved |
 | Plans active-set | Canonical after 2026-07 consolidation |
+| Release readiness | `verify-release-state` ready for v0.1.36 |
 
 ## Strengths
 
 1. Strong correctness campaign (locks, eviction, cache identity, embedding health).  
 2. Gate honesty (deny blocking, benchmark hard-fail, workflow cancelled guards).  
-3. Skill eval schema + high-risk behavioral fixtures.  
+3. Skill eval schema + high-risk and medium-risk behavioral fixtures.  
 4. Release path singularity (`release-manager` + `release.yml` + cadence manager).  
 5. Rich episodic/pattern/playbook/checkpoint MCP+CLI surface.
 
 ## Weaknesses
 
 1. Release lag (0.1.36 unreleased).  
-2. Skills discoverability incomplete (routes, SKILLS.md, one missing eval).  
-3. F4 pilots under-exposed to operators.  
-4. ADR numbering collisions.  
-5. Some user docs / TECH_DEBT lag code truth.
+2. Historical ADR filename collisions (aliased, not renumbered).  
+3. Transitive Dependabot advisories on upstream chains.  
+4. Product/research epics remain spike-gated (R-F*).
 
 ## Recommended focus order
 
-1. Release v0.1.36  
-2. LOC + skill contract completion  
-3. F4 productization  
-4. Optional research spikes  
+1. Ship v0.1.36 + post-bump 0.1.37  
+2. Optional research spikes only after GO artifacts  
+3. Upstream security chain hygiene when direct upgrades are available  
 
 Full prioritized backlog: recommendations plan §3–4.

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -1,46 +1,50 @@
 # Project Status — Self-Learning Memory System
 
-**Last Updated**: 2026-07-20  
-**Released Version**: v0.1.36
-**Workspace Version**: 0.1.36
+**Last Updated**: 2026-07-22  
+**Released Version**: v0.1.36  
+**Workspace Version**: 0.1.36  
 **Edition**: Rust 2024  
 **Active plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
-**Branch**: `main` @ `1ebab995`  
+**Branch**: `main`  
 
 ## Open tracker (live)
 
 | Kind | Items |
 |------|--------|
-| Open PRs | **#880** release docs v0.1.36 · **#877** rust-major deps (sha2/lz4_flex/cargo_metadata) |
-| Open issues | **#879** release drift (`commit_warning`, 26 commits / 2 days) |
+| Open PRs | *(none on main at tracker refresh; see current branch PR)* |
+| Open issues | *(none)* |
 
 ## Snapshot
 
 | Area | State |
 |------|--------|
 | Post-v0.1.35 GOAP campaign (S1/W2/K3/F4/harness) | ✅ Merged (#840–#878) |
-| Recommendations backlog implementation | ✅ Merged (#878) |
-| Release v0.1.36 | 🟡 **Next** — merge #880 → main green → `release-manager.sh ship --execute` |
-| Production LOC >500 (non-test `src`) | ✅ Clean (`provider_config.rs` 237 after R-B1 split) |
-| Skill evals | 34 eval files under `.agents/skills/*/evals/` |
+| Recommendations implementation | ✅ Merged (#878) |
+| Release docs + rust-major deps | ✅ Merged (#880, #877) |
+| Plans tracker refresh | ✅ Merged (#881) |
+| Medium-risk skill evals (R-E2 second wave) | ✅ This PR |
+| Release v0.1.36 | 🟡 **Next** — main green → `./scripts/release-manager.sh ship --execute` |
+| Production LOC >500 (non-test `src`) | ✅ Clean |
+| Skill evals | 34 skills with behavioral fixtures |
 | Skill routes | `.agents/skills/skill-rules.json` complete for catalog |
 | Code execution | Fail-closed (S1.1c NO-GO) |
-| Plans hygiene | ✅ Refreshed 2026-07-21 (open PR/issue truth) |
+| MCP provenance (`with_provenance`) | ✅ Present on `query_memory` |
 
 ## Immediate priorities
 
 | Priority | Item | ID | Status |
 |----------|------|-----|--------|
-| P0 | Merge #880 (release docs) when CI CLEAN | R-A1 prep | 🟡 CI |
-| P0 | Cut v0.1.36 + post-bump 0.1.37 | R-A1 / R-A2 | 🟡 after #880 + main green |
-| P0 | Land #877 dependabot major bumps (compat fixes pushed) | deps | 🟡 CI |
-| P1 | Close #879 after ship | release-drift | 🟡 auto after release |
-| P2 | MCP provenance fields; research spikes | R-C4 / R-F* | Backlog |
+| P0 | Cut v0.1.36 + post-bump 0.1.37 | R-A1 / R-A2 | 🟡 after main green |
+| P2 | Research/product spikes (R-F*) | R-F* | ⏸ DEFER until individual spikes GO |
+| P2 | Transitive Dependabot advisories | G-P1-9 | Monitor / upstream |
 
 ## Recent completed (do not re-open)
 
 | Wave | Result |
 |------|--------|
+| R-E2 medium-risk skill eval expansion | ✅ This PR |
+| Plans tracker #881 | ✅ Merged |
+| Release docs #880 / deps #877 | ✅ Merged |
 | Recommendations #878 (skills, LOC, journal CLI, plans) | ✅ Merged |
 | CLI UX v0.1.35 (#828–#832 family) | ✅ Shipped in v0.1.35 |
 | ADR-075 durable complete + `episode fail` | ✅ |

--- a/plans/STATUS/GAP_ANALYSIS_LATEST.md
+++ b/plans/STATUS/GAP_ANALYSIS_LATEST.md
@@ -1,30 +1,26 @@
-# Gap Analysis — 2026-07-21
+# Gap Analysis — 2026-07-22
 
-**Generated**: 2026-07-21  
-**Audit commit**: `1ebab995` (`main`)  
-**Workspace**: `0.1.36` unreleased · **Tag**: `v0.1.35` · **Unreleased commits**: 26  
+**Generated**: 2026-07-22  
+**Audit commit**: `main` HEAD at PR time  
+**Workspace**: `0.1.36` unreleased · **Tag**: `v0.1.35`  
 **Full backlog**: [`../GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`](../GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md)
 
 ## Method
 
 - Live tree inspection (Cargo version, production LOC, skills, ADR IDs)
 - `rg` for `todo!` / `unimplemented!` / “not yet implemented” in production `src` → **0**
-- GitHub: open PRs **#880**, **#877**; open issue **#879** (release drift)
-- Prior gap register (2026-07-20) re-verified; completed rows closed with evidence
+- GitHub: open PRs/issues checked at audit time
+- Prior gap register re-verified; completed rows closed with evidence
+- Skill eval depth audit: medium-risk skills expanded to behavioral fixtures (R-E2)
 
-## Resolved since 2026-07-20 register
+## Resolved since 2026-07-21 register
 
 | Historical gap | Resolution |
 |----------------|------------|
-| G-P0-2 `provider_config.rs` >500 LOC | Split → 237 LOC (R-B1 / #878) |
-| G-P0-3 ADR 025/054 collision | Alias registry in `plans/adr/README.md` (R-B5); files retained historically |
-| G-P1-1 Incomplete skill routing | `skill-rules.json` expanded (#878) |
-| G-P1-2 `ci-poll` missing evals | evals present (#878) |
-| G-P1-3 Missing `.agents/SKILLS.md` | Generated + maintained |
-| G-P1-4 F4 journal / provenance UX | `storage journal` CLI; MCP provenance already present |
-| G-P1-5 TECH_DEBT stale | Refreshed with AGENTS (#878) |
-| G-P1-6 Vision title v0.1.9+ | Updated (R-D7) |
-| S1/W2/K3/F4 campaign items | Shipped 2026-07-16…20 |
+| G-P0-4 Release docs CI | #880 merged |
+| G-P0-5 Dependabot rust-major CI | #877 merged |
+| G-P1-7 Medium-risk skill eval depth | R-E2 second wave (this PR) |
+| Stale open-PR tracker rows | #881 + this refresh |
 
 ## Open gaps (current)
 
@@ -32,17 +28,14 @@
 
 | ID | Gap | Evidence | Track |
 |----|-----|----------|-------|
-| G-P0-1 | v0.1.36 unreleased (26 commits) | `git rev-list --count v0.1.35..origin/main` = 26; issue #879 | R-A1 |
-| G-P0-4 | Release-prep PR CI must be CLEAN | PR #880 (docs); then ship via release-manager | R-A1 |
-| G-P0-5 | Dependabot rust-major CI | PR #877 — sha2/lz4_flex/cargo_metadata compat fixes | deps |
+| G-P0-1 | v0.1.36 unreleased | tag still `v0.1.35`; workspace `0.1.36` | R-A1 |
 
 ### P1
 
 | ID | Gap | Evidence | Track |
 |----|-----|----------|-------|
-| G-P1-7 | Medium-risk skills lack deeper behavioral evals | Beyond K3.2 core set | R-E2 |
-| G-P1-8 | Historical ADR number reuse remains on disk | Filenames still dual 025/054; aliases documented | R-B5 residual |
-| G-P1-9 | Dependabot security alerts on default branch | GitHub reports open Dependabot vulns (separate from #877) | security hygiene |
+| G-P1-8 | Historical ADR number reuse remains on disk | Filenames still dual 025/054; aliases documented | R-B5 residual (docs only) |
+| G-P1-9 | Transitive Dependabot advisories | Upstream chains (libsql/openssl/webpki); not direct product surface | security hygiene |
 
 ### P2 (product / research)
 
@@ -61,12 +54,13 @@
 |-------|---------|
 | `execute_agent_code` working backend | **Not a gap** — intentional fail-closed |
 | Batch MCP tools | Deferred by product decision; document only |
-| Production `src` LOC >500 | **Closed** — remaining >500 files are `*_tests.rs` / test modules |
+| Production `src` LOC >500 | **Closed** — remaining >500 files are test modules |
 | `todo!` / `unimplemented!` in prod `src` | **0 matches** |
+| MCP `with_provenance` | **Closed** — present + tested |
+| Skill routes / SKILLS.md / ci-poll evals | **Closed** |
+| Medium-risk skill eval presence-only fixtures | **Closed** by R-E2 second wave |
 
 ## Exit criteria for this gap register
 
-- G-P0-1 closed by shipping `v0.1.36` and post-bump  
-- G-P0-4 / G-P0-5 closed when #880 and #877 are green and merged as appropriate  
-- P1 skill-depth rows scheduled or waived with owners  
+- G-P0-1 closed by shipping `v0.1.36` and post-bump to `0.1.37`  
 - P2 rows remain spikes, not silent code stubs  

--- a/plans/STATUS/VALIDATION_LATEST.md
+++ b/plans/STATUS/VALIDATION_LATEST.md
@@ -1,41 +1,38 @@
-# Validation Latest — 2026-07-21 Open Tracker + Gap Refresh
+# Validation Latest — 2026-07-22 Missing Tasks (R-E2 + Tracker)
 
-**Goal**: Reconcile plans status with live GitHub open PRs/issues; close completed gap rows; keep single active recommendations plan.  
-**Workspace**: `0.1.36` unreleased · **Tag**: `v0.1.35` · **HEAD**: `1ebab995`  
-**Release**: ⛔ not performed by this validation (R-A1 remains next after #880)
+**Goal**: Close remaining implementable plan gaps (medium-risk skill eval depth, tracker truth).  
+**Workspace**: `0.1.36` unreleased · **Tag**: `v0.1.35`  
+**Release**: ⛔ not performed by this validation (R-A1 remains next after main green)
 
 ## Evidence
 
 | Check | Command / observation | Result |
 |-------|----------------------|--------|
-| Active set files present | `./scripts/validate-plans.sh --active-set` | Run on this branch |
+| Active set files present | `./scripts/validate-plans.sh --active-set` | ✅ |
 | Version in CURRENT | workspace `0.1.36` | ✅ |
-| Open PRs | `gh pr list --state open` | #880, #877 |
-| Open issues | `gh issue list --state open` | #879 release drift |
-| Commits since tag | `git rev-list --count v0.1.35..origin/main` | **26** |
-| Prod LOC >500 (non-test `src`) | `provider_config.rs` | **237** ✅ |
+| Open issues | `gh issue list --state open` | empty |
+| Prod LOC >500 (non-test `src`) | production offenders | **0** ✅ |
 | Skill eval files | `find .agents/skills -path '*/evals/evals.json'` | 34 |
+| Skill evals run | `./scripts/run-evals.sh` | All passed |
+| Schema fixtures | `./scripts/run-evals.sh --fixtures` | All passed |
+| Skill routes | `./scripts/validate-skill-routes.sh` | 34 unique skills |
 | `todo!` / `unimplemented!` in prod `src` | `rg` | 0 |
-| ADR 025/054 | filenames dual; `plans/adr/README.md` aliases | ✅ documented |
-| #880 commitlint | body-max-line-length; squashed rewrite | ✅ pushed |
-| #877 compile breakers | sha2 0.11 hex; lz4_flex `std`; cargo_metadata `PackageName` | ✅ pushed |
+| MCP provenance | `with_provenance` on `query_memory` | ✅ present |
+| Release readiness | `./scripts/verify-release-state.sh` | ready to release v0.1.36 |
 
-## Prior waves (historical)
+## This change set
 
-- Recommendations implementation: PR **#878** merged  
-- F4 remainder / missing-tasks / harness: #873/#874/#870 (2026-07-18)  
-- Archive: `plans/archive/2026-07-consolidation/`
+- **ACT-310 / R-E2**: Expanded medium-risk skill `evals.json` fixtures from presence-only checks to behavioral contract tests (frontmatter, domain keywords, negative ship-path guards).
+- **Plans truth**: CURRENT / GOALS / ACTIONS / GOAP_STATE / ROADMAP / GAP / VALIDATION refreshed for post-#877/#880/#881 state.
 
 ## Still open after this validation
 
 | Item | Next step |
 |------|-----------|
-| G-P0-1 / R-A1 | Merge #880 → main green → `./scripts/release-manager.sh ship --execute` |
+| G-P0-1 / R-A1 | Main green → `./scripts/release-manager.sh ship --execute` |
 | R-A2 | Immediate post-tag bump to 0.1.37 |
-| #877 | Wait CI green; merge when ready (has `release-preparation`) |
-| #879 | Auto-resolves / updates after release |
-| R-E2 / R-F* | Backlog |
+| R-F* | DEFER until individual spikes under `plans/STATUS/spikes/` return GO |
 
 ## Merge / ship note
 
-This change set is **plans/docs tracker refresh only**. Do not ship a release from this PR alone — use release-guard path after #880 lands on main.
+This change set is **skills + plans**. Do not ship a release from this PR alone unless main is green and release-guard path is followed after merge.


### PR DESCRIPTION
## Summary

Implements remaining **actionable** plan gaps from `plans/` after a full inventory of the active recommendations register (`GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`).

**What was already done on main (not re-implemented):**
- R-B1 LOC split, R-C1–C6 skill routes / journal CLI / provenance, R-D/G docs hygiene
- #878 recommendations, #880 release docs, #877 rust-major deps, #881 tracker refresh
- Production `todo!` / `unimplemented!` = 0; production LOC ≤500 clean

**This PR closes:**
1. **ACT-310 / R-E2 (G-P1-7)** — Second-wave **medium-risk skill behavioral evals**: 26 skills upgraded from presence-only fixtures to contract tests (frontmatter, domain keywords, negative ship-path guards). Validated with `./scripts/run-evals.sh` + `--fixtures`.
2. **Plans truth** — CURRENT / GOALS / ACTIONS / GOAP_STATE / ROADMAP / GAP / VALIDATION / CODEBASE_ANALYSIS / recommendations header updated for post-#877/#880/#881 state.

**Explicitly not in this PR (correct remaining P0):**
- **R-A1** ship `v0.1.36` via `./scripts/release-manager.sh ship --execute` (release-guard path after main green)
- **R-A2** post-bump to `0.1.37`
- **R-F*** product/research epics (DEFER until individual spikes GO)

## Test plan

- [x] `./scripts/run-evals.sh` — all skill evaluations passed
- [x] `./scripts/run-evals.sh --fixtures` — schema fixtures passed
- [x] `./scripts/validate-skill-routes.sh` — 34 unique skills routed
- [x] `./scripts/validate-plans.sh --active-set` — OK
- [x] `./scripts/verify-release-state.sh` — ready to release v0.1.36
- [ ] CI Skill Evals + Quick Check green on this PR