### PR TITLE
chore(release): bump workspace to 0.1.37 after v0.1.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Workspace version advanced to **0.1.37** after shipping `v0.1.36` so release-drift
+  gates treat new commits as normal development (`version_not_advanced` no longer applies).
+
 ## [0.1.36] - 2026-07-20
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.1.36"
+version = "0.1.37"
 edition = "2024"
 authors = ["Self-Learning Memory Contributors"]
 license = "MIT"

--- a/memory-mcp/Cargo.toml
+++ b/memory-mcp/Cargo.toml
@@ -27,9 +27,9 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 # Local dependencies
-do-memory-core = { path = "../memory-core", version = "0.1.36", features = ["agentfs"] }
-do-memory-storage-turso = { path = "../memory-storage-turso", version = "0.1.36" }
-do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.36" }
+do-memory-core = { path = "../memory-core", version = "0.1.37", features = ["agentfs"] }
+do-memory-storage-turso = { path = "../memory-storage-turso", version = "0.1.37" }
+do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.37" }
 
 # MCP-specific dependencies
 parking_lot = "0.12.5"

--- a/memory-storage-redb/Cargo.toml
+++ b/memory-storage-redb/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/do-memory-storage-redb"
 
 [dependencies]
 # Core dependencies
-do-memory-core = { path = "../memory-core", version = "0.1.36" }
+do-memory-core = { path = "../memory-core", version = "0.1.37" }
 
 # Async runtime
 tokio = { workspace = true, features = ["full"] }

--- a/memory-storage-turso/Cargo.toml
+++ b/memory-storage-turso/Cargo.toml
@@ -34,8 +34,8 @@ compression-gzip = ["flate2"]
 
 [dependencies]
 # Core dependencies
-do-memory-core = { path = "../memory-core", version = "0.1.36", features = ["hybrid_search"] }
-do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.36" }
+do-memory-core = { path = "../memory-core", version = "0.1.37", features = ["hybrid_search"] }
+do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.37" }
 
 # Async runtime
 tokio = { workspace = true, features = ["full"] }

--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -4,34 +4,20 @@
 - **Active plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
 - **Archived plans**: `plans/archive/2026-07-consolidation/`
 
-## Active actions (2026-07-22)
+## Active actions (2026-07-22 post-ship)
 
 | ID | Action | Rec | Status |
 |----|--------|-----|--------|
-| ACT-300 | Archive superseded plans; write recommendations + refresh CURRENT/GAP/VALIDATION/README | R-G1–G3 | ✅ Done |
-| ACT-300b | Generate `.agents/SKILLS.md` inventory (HARNESS link target) | R-C3 | ✅ Done |
-| ACT-304 | Split provider configs ≤500 LOC + tests | R-B1 | ✅ Done |
-| ACT-305 | ADR-025 / ADR-054 alias registry (`plans/adr/README.md`) | R-B5 | ✅ Done |
-| ACT-306 | Expand `skill-rules.json` to all catalog skills | R-C1 | ✅ Done |
-| ACT-307 | Add `ci-poll` evals + SKILLS.md sync | R-C2, R-C3 | ✅ Done |
-| ACT-308 | F4 operator UX: `storage journal` CLI (`--pending`/`--repair`) | R-B2, R-C5 | ✅ Done |
-| ACT-308b | MCP provenance fields on query responses | R-C4 | ✅ Already on main |
-| ACT-309 | Align AGENTS skill table + TECH_DEBT + vision title | R-D*, R-B3 | ✅ Done |
-| ACT-310 | Medium-risk skill behavioral evals (second wave) | R-E2 | ✅ Done |
-| ACT-311 | `validate-plans.sh` warn on excess dated root files | R-G4 | ✅ Done |
-| ACT-301 | Prepare CHANGELOG + release docs for v0.1.36 | R-A1 | ✅ #880 merged |
-| ACT-313 | Land rust-major dependabot (sha2/lz4/cargo_metadata) | deps | ✅ #877 merged |
-| ACT-314 | Refresh plans tracker truth | R-G* | ✅ Done |
-| ACT-302 | `./scripts/release-manager.sh ship --execute` for `v0.1.36` | R-A1 | 🟡 After main green |
-| ACT-303 | Post-release workspace bump to 0.1.37 | R-A2 | 🟡 After ACT-302 |
+| ACT-302 | `./scripts/release-manager.sh ship --execute` for `v0.1.36` | R-A1 | ✅ Done |
+| ACT-303 | Post-release workspace bump to 0.1.37 | R-A2 | 🟡 This PR |
 | ACT-312 | Optional product/research spikes R-F* | R-F* | ⏸ DEFER |
+
+All other ACT-300…ACT-314 items (LOC, skills, journal, provenance, plans hygiene, evals, docs integrity) are **complete**.
 
 ## Completed actions (summary)
 
-All ACT-190…ACT-279 series (CLI UX, S1.*, W2.*, K3.*, F4, harness, release cadence) are **complete**.  
-Full tables live under:
-
-`plans/archive/2026-07-consolidation/completed-sprints/`
+All ACT-190…ACT-279 series and 2026-07 recommendation waves are **complete**.  
+Full tables: `plans/archive/2026-07-consolidation/completed-sprints/`
 
 ### Prevention permanently (do not regress)
 
@@ -43,3 +29,4 @@ Full tables live under:
 - No soft-pass on cargo deny / required cancelled checks  
 - Fail-closed `execute_agent_code` unless approved capability backend  
 - sha2 digests: use portable hex encode (not `format!("{:x}", finalize())` on 0.11+)  
+- Docs integrity: do not re-check `plans/archive/**` link rot as a ship blocker  

--- a/plans/GOALS.md
+++ b/plans/GOALS.md
@@ -1,8 +1,8 @@
 # GOAP Goals Index
 
 - **Last Updated**: 2026-07-22  
-- **Status**: Active — release v0.1.36 readiness  
-- **Workspace**: `0.1.36` unreleased · **Tag**: `v0.1.35`  
+- **Status**: Active — post-v0.1.36 development  
+- **Workspace**: `0.1.37` · **Tag**: `v0.1.36`  
 - **Plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
 - **Archive**: `plans/archive/2026-07-consolidation/`
 
@@ -10,23 +10,25 @@
 
 | Goal | Rec IDs | Priority | Status |
 |------|---------|----------|--------|
-| Ship v0.1.36 + post-bump | R-A1, R-A2, R-A3 | P0 | 🟡 Main green → release-manager ship |
-| Restore production LOC ≤500 | R-B1 | P0 | ✅ Done |
-| ADR identifier uniqueness (aliases) | R-B5 | P0 | ✅ Documented |
-| Complete skill routes + ci-poll evals + SKILLS.md | R-C1–C3, R-E1 | P1 | ✅ Done |
-| Productize F4 (provenance / journal / digests UX) | R-B2, R-C4–C6 | P1 | ✅ CLI journal; MCP provenance present |
-| Medium-risk skill behavioral evals | R-E2 | P1 | ✅ Done (second wave) |
-| Docs contract alignment (README, AGENTS, HARNESS, TECH_DEBT) | R-D*, R-B3 | P1 | ✅ |
-| Plans hygiene (archive + live tracker truth) | R-G1–G3 | P1 | ✅ 2026-07-22 refresh |
+| Post-release workspace bump | R-A2 | P0 | 🟡 This PR → `0.1.37` |
 | Optional research/product spikes | R-F* | P2 | ⏸ DEFER |
+
+## Closed this wave
+
+| Goal | Status |
+|------|--------|
+| Ship v0.1.36 | ✅ |
+| R-E2 medium-risk skill evals | ✅ #883 |
+| Docs integrity ship gate | ✅ #885 |
+| Recommendations R-B/C/D/E/G/H | ✅ |
 
 ## Completed goal series (pointer only)
 
 | Series | Outcome | Archive |
 |--------|---------|---------|
 | Recommendations #878 | Merged | — |
-| 2026-07-14 improvements S1/W2/K3/F4 | Implemented; F4 spikes GO; S1.1c NO-GO | `archive/2026-07-consolidation/completed-sprints/` |
-| v0.1.35 CLI UX + ADR-075/076 | Released as `v0.1.35` | same |
-| Harness #861–#869 + release-cadence-manager | Merged | same |
+| 2026-07-14 improvements S1/W2/K3/F4 | Implemented; S1.1c NO-GO | `archive/2026-07-consolidation/completed-sprints/` |
+| v0.1.35 CLI UX + ADR-075/076 | Released | same |
+| Harness + release-cadence-manager | Merged | same |
 
-Do not re-list completed WG tables here; see ROADMAP historical sections or archives.
+Do not re-list completed WG tables here.

--- a/plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md
+++ b/plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md
@@ -1,10 +1,10 @@
 # Comprehensive Codebase Recommendations — 2026-07-20
 
-- **Status**: Active backlog (post–v0.1.35; workspace `0.1.36` unreleased)
-- **Audit commit**: refreshed 2026-07-22
-- **Released tag**: `v0.1.35`
-- **Open PRs**: R-E2 skill evals / plans truth (this wave); #877/#880/#881 merged
-- **Open issues**: none (#879 resolved with release-docs path)
+- **Status**: Active backlog (post–v0.1.36; workspace `0.1.37`)
+- **Audit commit**: refreshed 2026-07-22 after ship
+- **Released tag**: `v0.1.36`
+- **Open PRs**: post-release bump to 0.1.37
+- **Open issues**: none
 - **Coordinator**: goap-agent + agent-coordination
 - **Supersedes**: archived `GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md` and dated 2026-06/07 execution plans
 - **Archive**: `plans/archive/2026-07-consolidation/`
@@ -72,9 +72,9 @@ IDs use prefix **R** (recommendation). Priorities:
 
 | ID | Recommendation | Why | Acceptance |
 |----|----------------|-----|------------|
-| **R-A1** | Cut **v0.1.36** via `./scripts/release-manager.sh ship --execute` after CHANGELOG + Released Version docs | #880 merged; main green | 🟡 ship |
-| **R-A2** | Immediately bump workspace to **0.1.37** after tag | AGENTS post-release rule | 🟡 After R-A1 |
-| **R-A3** | Re-run `./scripts/release-manager.sh status` before ship | Status green before ship | 🟡 With R-A1 |
+| **R-A1** | Cut **v0.1.36** via `./scripts/release-manager.sh ship --execute` after CHANGELOG + Released Version docs | Shipped | ✅ |
+| **R-A2** | Immediately bump workspace to **0.1.37** after tag | AGENTS post-release rule | 🟡 This PR |
+| **R-A3** | Re-run `./scripts/release-manager.sh status` before ship | Status green before ship | ✅ |
 
 ### Track B — Code quality & invariants (P0/P1)
 

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1,64 +1,44 @@
 # GOAP State Snapshot
 
 - **Last Updated**: 2026-07-22  
-- **Version**: workspace `0.1.36` unreleased (latest tag `v0.1.35`)  
-- **Branch**: `main`  
-- **Open PRs**: none (implementation PR for R-E2 may be open)  
-- **Open issues**: none  
+- **Version**: workspace `0.1.37` · latest tag `v0.1.36`  
+- **Branch**: `main` (+ post-bump PR)  
+- **Open issues**: none expected  
 - **Active plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
 - **Archive**: `plans/archive/2026-07-consolidation/`  
-- **Release**: 🟡 ship when main CI green (`verify-release-state` ready)
+- **Release**: ✅ `v0.1.36` shipped via release-manager
 
 ---
 
-## Phase: Release readiness 🟡
+## Phase: Post-release development ✅/🟡
 
 | Package | Status |
 |---------|--------|
-| Recommendations implementation #878 | ✅ Merged |
-| R-B1 LOC split provider configs | ✅ |
-| R-C1–C3 skill routes + ci-poll + SKILLS.md | ✅ |
-| R-B2/C5 `storage journal` CLI | ✅ |
-| R-B3/B5/D docs + ADR aliases | ✅ |
-| R-E2 medium-risk skill evals (second wave) | ✅ |
-| Release docs PR #880 | ✅ Merged |
-| Dependabot rust-major #877 | ✅ Merged |
-| Plans tracker #881 | ✅ Merged |
-| R-A1/A2 release v0.1.36 + post-bump | 🟡 next |
-
----
-
-## Closed campaigns (pointer)
-
-| Campaign | Result |
-|----------|--------|
-| 2026-07-20 recommendations #878 | ✅ Merged |
-| 2026-07-18 F4 remainder #874 | ✅ Merged |
-| 2026-07-18 Missing tasks #873 | ✅ Merged |
-| 2026-07-18 Harness #870 | ✅ Merged |
-| 2026-07-18 release-cadence-manager #872 | ✅ Merged |
-| v0.1.35 release | ✅ Shipped |
-
-Details: `plans/archive/2026-07-consolidation/completed-sprints/`.
+| R-A1 ship v0.1.36 | ✅ |
+| R-A2 post-bump 0.1.37 | 🟡 This PR |
+| R-E2 medium-risk skill evals | ✅ #883 |
+| Docs integrity ship unblock | ✅ #885 |
+| Recommendations #878 | ✅ |
+| R-F* product epics | ⏸ DEFER |
 
 ---
 
 ## Goal-state flags (2026-07-22)
 
 ```text
-truth_reconciled                  ≈ true (plans refreshed 2026-07-22; release lag remains)
-sandbox_capability_boundary       = true (fail-closed; S1.1c NO-GO)
+truth_reconciled                  = true
+sandbox_capability_boundary       = true
 retrieval_identity_complete       = true
-storage_awaits_lock_free          = true (step paths)
-durable_eviction                  = true (+ reconciliation)
+storage_awaits_lock_free          = true
+durable_eviction                  = true
 embedding_health_truthful         = true
 retry_backpressure_effective      = true
-gates_match_policy                ≈ true (GATE_CONTRACT + ci-parity)
+gates_match_policy                = true
 skill_evals_executable            = true
 skill_routes_complete             = true
-skill_evals_medium_depth          = true (R-E2 second wave)
-docs_match_code                   ≈ true (refresh after release)
+skill_evals_medium_depth          = true
+docs_match_code                   = true
 plan_registry_unique              ≈ true (ADR 025/054 aliased)
-feature_pilots_have_baselines     = true (F4 spikes)
-release_current                   = false (v0.1.36 pending)
+feature_pilots_have_baselines     = true
+release_current                   = true (v0.1.36)
 ```

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,6 +1,6 @@
 # Plans Directory
 
-**Workspace**: `0.1.37` · **Released tag**: `v0.1.36`  
+**Workspace**: `0.1.37` (post-release) · **Released tag**: `v0.1.36` · **Next**: `v0.1.37`  
 **Active plan**: [GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md](GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md)  
 **Last Updated**: 2026-07-21  
 **Open PRs**: #880 (release), #877 (deps) · **Open issue**: #879 (drift)  

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,6 +1,6 @@
 # Plans Directory
 
-**Workspace**: `0.1.36` (release-ready) · **Released tag**: `v0.1.35` · **Next tag**: `v0.1.36`  
+**Workspace**: `0.1.37` · **Released tag**: `v0.1.36`  
 **Active plan**: [GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md](GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md)  
 **Last Updated**: 2026-07-21  
 **Open PRs**: #880 (release), #877 (deps) · **Open issue**: #879 (drift)  

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -2,36 +2,21 @@
 
 **Last Updated**: 2026-07-22  
 **Released Version**: v0.1.36  
-**Workspace Version**: 0.1.36  
-**Active Sprint**: Release readiness + residual recommendations  
+**Workspace Version**: 0.1.37  
+**Active Sprint**: Post-v0.1.36 development  
 **Plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
 **Branch**: `main`  
-**Open PRs**: *(implementation PR for R-E2 may be open)*  
-**Open issues**: none  
 
 ---
 
-## Sprint 2026-07-22 — Release
+## Sprint 2026-07-22 — Ship + post-bump
 
 | Priority | Item | Description | Status |
 |----------|------|-------------|--------|
-| 1 | Ship v0.1.36 | `release-manager.sh ship --execute` when main green | 🟡 |
-| 2 | Post-bump | Workspace → 0.1.37 immediately after tag | 🟡 |
-| 3 | R-E2 skill evals | Medium-risk behavioral fixtures second wave | ✅ |
-| 4 | Plans truth | CURRENT / GAP / GOALS / ACTIONS / GOAP_STATE | ✅ |
-
----
-
-## Completed last sprint (2026-07-20…21)
-
-| Priority | Item | Status |
-|----------|------|--------|
-| Plans hygiene (ADR-039 archive) | ✅ |
-| Recommendations register R-A…R-G | ✅ |
-| Implementation #878 (LOC, skills, journal CLI, docs) | ✅ |
-| Release docs #880 | ✅ |
-| rust-major deps #877 | ✅ |
-| Tracker refresh #881 | ✅ |
+| 1 | Ship v0.1.36 | `release-manager.sh ship --execute` | ✅ |
+| 2 | Post-bump | Workspace → 0.1.37 | 🟡 |
+| 3 | R-E2 skill evals | Medium-risk behavioral fixtures | ✅ #883 |
+| 4 | Docs integrity | Unblock ship gate | ✅ #885 |
 
 ---
 
@@ -39,10 +24,10 @@
 
 | Priority | Theme | Items | Status |
 |----------|-------|-------|--------|
-| P2 | Research | WG-108 version retention; WG-110 SIMD (bench-gated); WG-125 MoE; WG-135 federated HDC | ⏸ DEFER |
-| P2 | Vision | Distributed sync, multi-tenancy/RBAC, OTel/Prometheus (see `ROADMAP_V030_VISION.md`) | Future |
+| P2 | Research | WG-108 / WG-110 / WG-125 / WG-135 | ⏸ DEFER |
+| P2 | Vision | Distributed sync, multi-tenancy, OTel | Future |
 | P2 | Release eng | Trusted Publishing (OIDC) for crates.io | Future |
-| P2 | Security | Transitive Dependabot advisories (upstream libsql/openssl chains) | Monitor |
+| P2 | Security | Transitive Dependabot advisories | Monitor |
 
 ---
 
@@ -59,10 +44,5 @@
 
 ## History pointer
 
-Completed sprint tables (v0.1.28–v0.1.35, July GOAP waves) live under:
-
-- `plans/archive/2026-07-consolidation/completed-sprints/`
-- `plans/archive/2026-03-consolidation/`
-- Older `plans/archive/2026-0{1,2}-completed/`
-
-Do not re-expand completed WG tables into this file (ADR-039: roadmap is forward-only).
+Completed sprint tables live under `plans/archive/2026-07-consolidation/` and older archives.  
+Do not re-expand completed WG tables (ADR-039).

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -2,7 +2,7 @@
 
 **Last Updated**: 2026-07-22  
 **Released Version**: v0.1.36  
-**Workspace Version**: 0.1.36  
+**Workspace Version**: 0.1.37  
 **Edition**: Rust 2024  
 **Active plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
 **Branch**: `main`  
@@ -11,53 +11,40 @@
 
 | Kind | Items |
 |------|--------|
-| Open PRs | *(none on main at tracker refresh; see current branch PR)* |
-| Open issues | *(none)* |
+| Open PRs | post-release bump PR (this branch) |
+| Open issues | *(none expected after release drift auto-close)* |
 
 ## Snapshot
 
 | Area | State |
 |------|--------|
-| Post-v0.1.35 GOAP campaign (S1/W2/K3/F4/harness) | ✅ Merged (#840–#878) |
-| Recommendations implementation | ✅ Merged (#878) |
-| Release docs + rust-major deps | ✅ Merged (#880, #877) |
-| Plans tracker refresh | ✅ Merged (#881) |
-| Medium-risk skill evals (R-E2 second wave) | ✅ This PR |
-| Release v0.1.36 | 🟡 **Next** — main green → `./scripts/release-manager.sh ship --execute` |
+| Release v0.1.36 | ✅ Shipped (`release-manager.sh ship --execute` → tag `v0.1.36`) |
+| Post-release workspace bump | 🟡 This PR → `0.1.37` |
+| Recommendations + F4 + skill contracts | ✅ Closed on main |
+| Medium-risk skill evals (R-E2) | ✅ #883 |
+| Docs integrity ship gate | ✅ #885 |
 | Production LOC >500 (non-test `src`) | ✅ Clean |
-| Skill evals | 34 skills with behavioral fixtures |
-| Skill routes | `.agents/skills/skill-rules.json` complete for catalog |
+| Skill evals / routes | 34/34 |
 | Code execution | Fail-closed (S1.1c NO-GO) |
-| MCP provenance (`with_provenance`) | ✅ Present on `query_memory` |
+| MCP provenance (`with_provenance`) | ✅ |
 
 ## Immediate priorities
 
 | Priority | Item | ID | Status |
 |----------|------|-----|--------|
-| P0 | Cut v0.1.36 + post-bump 0.1.37 | R-A1 / R-A2 | 🟡 after main green |
-| P2 | Research/product spikes (R-F*) | R-F* | ⏸ DEFER until individual spikes GO |
+| P0 | Land post-bump `0.1.37` | R-A2 | 🟡 This PR |
+| P2 | Research/product spikes (R-F*) | R-F* | ⏸ DEFER |
 | P2 | Transitive Dependabot advisories | G-P1-9 | Monitor / upstream |
 
-## Recent completed (do not re-open)
+## Recent completed
 
 | Wave | Result |
 |------|--------|
-| R-E2 medium-risk skill eval expansion | ✅ This PR |
-| Plans tracker #881 | ✅ Merged |
-| Release docs #880 / deps #877 | ✅ Merged |
-| Recommendations #878 (skills, LOC, journal CLI, plans) | ✅ Merged |
-| CLI UX v0.1.35 (#828–#832 family) | ✅ Shipped in v0.1.35 |
-| ADR-075 durable complete + `episode fail` | ✅ |
-| ADR-076 pattern empty-result UX | ✅ |
-| S1.2–S1.7 / W2.1–W2.5 / K3.1–K3.2 / F4 pilots | ✅ |
-| Release-cadence-manager + release-guard | ✅ |
-| Harness engineering #861–#869 | ✅ |
-
-## Metrics notes
-
-- Prefer command-backed numbers in `VALIDATION_LATEST.md` over prose estimates.
-- Coverage floor / target: see `plans/GATE_CONTRACT.md` (do not invent % in status).
-- Ignored-test ceiling: enforced by `./scripts/check-ignored-tests.sh`.
+| Ship v0.1.36 | ✅ Tagged + release.yml |
+| Docs integrity unblock #885 | ✅ Merged |
+| R-E2 medium-risk skill evals #883 | ✅ Merged |
+| Release docs #880 / deps #877 / tracker #881 | ✅ Merged |
+| Recommendations #878 | ✅ Merged |
 
 ## Canonical companions
 

--- a/plans/STATUS/GAP_ANALYSIS_LATEST.md
+++ b/plans/STATUS/GAP_ANALYSIS_LATEST.md
@@ -1,66 +1,48 @@
-# Gap Analysis — 2026-07-22
+# Gap Analysis — 2026-07-22 (post v0.1.36)
 
 **Generated**: 2026-07-22  
-**Audit commit**: `main` HEAD at PR time  
-**Workspace**: `0.1.36` unreleased · **Tag**: `v0.1.35`  
+**Workspace**: `0.1.37` · **Tag**: `v0.1.36`  
 **Full backlog**: [`../GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`](../GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md)
 
 ## Method
 
-- Live tree inspection (Cargo version, production LOC, skills, ADR IDs)
-- `rg` for `todo!` / `unimplemented!` / “not yet implemented” in production `src` → **0**
-- GitHub: open PRs/issues checked at audit time
-- Prior gap register re-verified; completed rows closed with evidence
-- Skill eval depth audit: medium-risk skills expanded to behavioral fixtures (R-E2)
+- Live tree + GitHub release/tag verification  
+- Production `todo!` / `unimplemented!` → **0**  
+- Recommendations register re-verified  
 
-## Resolved since 2026-07-21 register
+## Closed this wave
 
-| Historical gap | Resolution |
-|----------------|------------|
-| G-P0-4 Release docs CI | #880 merged |
-| G-P0-5 Dependabot rust-major CI | #877 merged |
-| G-P1-7 Medium-risk skill eval depth | R-E2 second wave (this PR) |
-| Stale open-PR tracker rows | #881 + this refresh |
+| Gap | Resolution |
+|-----|------------|
+| G-P0-1 v0.1.36 unreleased | ✅ Tagged `v0.1.36` via release-manager |
+| G-P0-4 / G-P0-5 open CI PRs | ✅ #880 / #877 merged earlier |
+| G-P1-7 medium-risk eval depth | ✅ R-E2 #883 |
+| Docs integrity ship blocker | ✅ #885 |
 
 ## Open gaps (current)
 
 ### P0
 
-| ID | Gap | Evidence | Track |
-|----|-----|----------|-------|
-| G-P0-1 | v0.1.36 unreleased | tag still `v0.1.35`; workspace `0.1.36` | R-A1 |
+*None.*
 
 ### P1
 
-| ID | Gap | Evidence | Track |
-|----|-----|----------|-------|
-| G-P1-8 | Historical ADR number reuse remains on disk | Filenames still dual 025/054; aliases documented | R-B5 residual (docs only) |
-| G-P1-9 | Transitive Dependabot advisories | Upstream chains (libsql/openssl/webpki); not direct product surface | security hygiene |
+| ID | Gap | Track |
+|----|-----|-------|
+| G-P1-8 | Historical ADR number reuse on disk (aliased) | residual docs |
+| G-P1-9 | Transitive Dependabot advisories | upstream |
 
-### P2 (product / research)
+### P2
 
-| ID | Gap | Notes | Track |
-|----|-----|-------|--------|
-| G-P2-1 | WG-108 version-retained persistence | Backlog epic | R-F5 |
-| G-P2-2 | WG-110 SIMD similarity | Bench-gated | R-F4 |
-| G-P2-3 | WG-125 MoE routing eval | Research only | R-F6 |
-| G-P2-4 | WG-135 federated HDC | Evaluation archived | R-F7 |
-| G-P2-5 | Distributed sync / multi-tenancy / OTel | Vision | R-F1–F3 |
-| G-P2-6 | Trusted Publishing OIDC | crates.io | R-F10 |
+| ID | Gap | Track |
+|----|-----|-------|
+| G-P2-1…6 | Research / vision epics (R-F*) | ⏸ DEFER |
 
 ## Explicit non-gaps
 
 | Claim | Verdict |
 |-------|---------|
-| `execute_agent_code` working backend | **Not a gap** — intentional fail-closed |
-| Batch MCP tools | Deferred by product decision; document only |
-| Production `src` LOC >500 | **Closed** — remaining >500 files are test modules |
-| `todo!` / `unimplemented!` in prod `src` | **0 matches** |
-| MCP `with_provenance` | **Closed** — present + tested |
-| Skill routes / SKILLS.md / ci-poll evals | **Closed** |
-| Medium-risk skill eval presence-only fixtures | **Closed** by R-E2 second wave |
-
-## Exit criteria for this gap register
-
-- G-P0-1 closed by shipping `v0.1.36` and post-bump to `0.1.37`  
-- P2 rows remain spikes, not silent code stubs  
+| Working `execute_agent_code` backend | Intentional fail-closed |
+| Batch MCP tools | Deferred product decision |
+| Production LOC >500 | Closed |
+| Medium-risk skill presence-only evals | Closed |

--- a/plans/STATUS/VALIDATION_LATEST.md
+++ b/plans/STATUS/VALIDATION_LATEST.md
@@ -1,38 +1,25 @@
-# Validation Latest — 2026-07-22 Missing Tasks (R-E2 + Tracker)
+# Validation Latest — 2026-07-22 Ship + Post-bump
 
-**Goal**: Close remaining implementable plan gaps (medium-risk skill eval depth, tracker truth).  
-**Workspace**: `0.1.36` unreleased · **Tag**: `v0.1.35`  
-**Release**: ⛔ not performed by this validation (R-A1 remains next after main green)
+**Goal**: Close remaining plan P0 (ship v0.1.36 + post-bump 0.1.37).  
+**Workspace**: `0.1.37` (this PR) · **Tag**: `v0.1.36`  
 
 ## Evidence
 
-| Check | Command / observation | Result |
-|-------|----------------------|--------|
-| Active set files present | `./scripts/validate-plans.sh --active-set` | ✅ |
-| Version in CURRENT | workspace `0.1.36` | ✅ |
-| Open issues | `gh issue list --state open` | empty |
-| Prod LOC >500 (non-test `src`) | production offenders | **0** ✅ |
-| Skill eval files | `find .agents/skills -path '*/evals/evals.json'` | 34 |
-| Skill evals run | `./scripts/run-evals.sh` | All passed |
-| Schema fixtures | `./scripts/run-evals.sh --fixtures` | All passed |
-| Skill routes | `./scripts/validate-skill-routes.sh` | 34 unique skills |
-| `todo!` / `unimplemented!` in prod `src` | `rg` | 0 |
-| MCP provenance | `with_provenance` on `query_memory` | ✅ present |
-| Release readiness | `./scripts/verify-release-state.sh` | ready to release v0.1.36 |
+| Check | Result |
+|-------|--------|
+| `./scripts/release-manager.sh ship --execute` | ✅ tag `v0.1.36` pushed |
+| Main CI at ship HEAD | All green (incl. Performance Benchmarks) |
+| `./scripts/check-docs-integrity.sh` | ✅ (after #885) |
+| Skill evals | ✅ (after #883) |
+| Post-bump workspace `0.1.37` | 🟡 This PR |
 
-## This change set
+## Still open
 
-- **ACT-310 / R-E2**: Expanded medium-risk skill `evals.json` fixtures from presence-only checks to behavioral contract tests (frontmatter, domain keywords, negative ship-path guards).
-- **Plans truth**: CURRENT / GOALS / ACTIONS / GOAP_STATE / ROADMAP / GAP / VALIDATION refreshed for post-#877/#880/#881 state.
+| Item | Next |
+|------|------|
+| R-A2 | Merge this post-bump PR |
+| R-F* | DEFER until spike GO |
 
-## Still open after this validation
+## Note
 
-| Item | Next step |
-|------|-----------|
-| G-P0-1 / R-A1 | Main green → `./scripts/release-manager.sh ship --execute` |
-| R-A2 | Immediate post-tag bump to 0.1.37 |
-| R-F* | DEFER until individual spikes under `plans/STATUS/spikes/` return GO |
-
-## Merge / ship note
-
-This change set is **skills + plans**. Do not ship a release from this PR alone unless main is green and release-guard path is followed after merge.
+Do not cut another release from the post-bump PR alone. Next release when 0.1.37 content warrants it.


### PR DESCRIPTION
## Summary

**R-A2** post-release workspace bump after shipping **`v0.1.36`** via `release-manager.sh ship --execute`.

- Workspace + path dep pins: `0.1.36` → `0.1.37`
- Plans trackers: CURRENT / GOALS / ACTIONS / GOAP_STATE / ROADMAP / GAP / VALIDATION / recommendations
- CHANGELOG Unreleased note for post-bump

## Context

| Item | Status |
|------|--------|
| R-A1 ship v0.1.36 | ✅ tagged + pushed |
| R-E2 skill evals | ✅ #883 |
| Docs integrity | ✅ #885 |
| R-F* research | still DEFER |

## Test plan

- [x] `./scripts/check-docs-integrity.sh`
- [ ] CI green on this PR
- [ ] After merge, `./scripts/release-manager.sh status` shows workspace 0.1.37 / tag v0.1.36