### PR TITLE
docs(plans): refresh progress for post-v0.1.36 state

### DIFF
--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -1,18 +1,21 @@
 # GOAP Actions Backlog
 
-- **Last Updated**: 2026-07-22  
+- **Last Updated**: 2026-07-23  
 - **Active plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
 - **Archived plans**: `plans/archive/2026-07-consolidation/`
 
-## Active actions (2026-07-22 post-ship)
+## Active actions (2026-07-23)
 
 | ID | Action | Rec | Status |
 |----|--------|-----|--------|
 | ACT-302 | `./scripts/release-manager.sh ship --execute` for `v0.1.36` | R-A1 | ✅ Done |
-| ACT-303 | Post-release workspace bump to 0.1.37 | R-A2 | ✅ Done |
+| ACT-303 | Post-release workspace bump to 0.1.37 | R-A2 | ✅ #886 |
+| ACT-315 | Plans progress truth (open PRs, post-ship) | R-G* | 🟡 This PR |
+| ACT-316 | Optional: land #887 changelog hygiene | docs | 🟡 open |
+| ACT-317 | Optional: review/merge #888 cosine perf | perf | 🟡 open |
 | ACT-312 | Optional product/research spikes R-F* | R-F* | ⏸ DEFER |
 
-All other ACT-300…ACT-314 items (LOC, skills, journal, provenance, plans hygiene, evals, docs integrity) are **complete**.
+All ACT-300…ACT-314 items (LOC, skills, journal, provenance, plans hygiene, evals, docs integrity, release) are **complete**.
 
 ## Completed actions (summary)
 
@@ -30,3 +33,4 @@ Full tables: `plans/archive/2026-07-consolidation/completed-sprints/`
 - Fail-closed `execute_agent_code` unless approved capability backend  
 - sha2 digests: use portable hex encode (not `format!("{:x}", finalize())` on 0.11+)  
 - Docs integrity: do not re-check `plans/archive/**` link rot as a ship blocker  
+- After tag `vX.Y.Z`, immediately bump workspace to next patch before more feat/fix commits  

--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -9,7 +9,7 @@
 | ID | Action | Rec | Status |
 |----|--------|-----|--------|
 | ACT-302 | `./scripts/release-manager.sh ship --execute` for `v0.1.36` | R-A1 | ✅ Done |
-| ACT-303 | Post-release workspace bump to 0.1.37 | R-A2 | 🟡 This PR |
+| ACT-303 | Post-release workspace bump to 0.1.37 | R-A2 | ✅ Done |
 | ACT-312 | Optional product/research spikes R-F* | R-F* | ⏸ DEFER |
 
 All other ACT-300…ACT-314 items (LOC, skills, journal, provenance, plans hygiene, evals, docs integrity) are **complete**.

--- a/plans/GOALS.md
+++ b/plans/GOALS.md
@@ -10,7 +10,7 @@
 
 | Goal | Rec IDs | Priority | Status |
 |------|---------|----------|--------|
-| Post-release workspace bump | R-A2 | P0 | 🟡 This PR → `0.1.37` |
+| Post-release workspace bump | R-A2 | P0 | ✅ Done |
 | Optional research/product spikes | R-F* | P2 | ⏸ DEFER |
 
 ## Closed this wave

--- a/plans/GOALS.md
+++ b/plans/GOALS.md
@@ -1,26 +1,28 @@
 # GOAP Goals Index
 
-- **Last Updated**: 2026-07-22  
+- **Last Updated**: 2026-07-23  
 - **Status**: Active — post-v0.1.36 development  
 - **Workspace**: `0.1.37` · **Tag**: `v0.1.36`  
 - **Plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
 - **Archive**: `plans/archive/2026-07-consolidation/`
 
-## Active goals (2026-07-22)
+## Active goals (2026-07-23)
 
 | Goal | Rec IDs | Priority | Status |
 |------|---------|----------|--------|
-| Post-release workspace bump | R-A2 | P0 | ✅ Done |
+| Plans tracker truth (open PRs / post-ship) | R-G* | P1 | 🟡 This PR |
+| Optional: #887 changelog + #888 perf review | — | P1/P2 | 🟡 open |
 | Optional research/product spikes | R-F* | P2 | ⏸ DEFER |
 
-## Closed this wave
+## Closed this wave (2026-07-20…23)
 
 | Goal | Status |
 |------|--------|
-| Ship v0.1.36 | ✅ |
+| Ship v0.1.36 (R-A1) | ✅ |
+| Post-release bump 0.1.37 (R-A2) | ✅ #886 |
 | R-E2 medium-risk skill evals | ✅ #883 |
 | Docs integrity ship gate | ✅ #885 |
-| Recommendations R-B/C/D/E/G/H | ✅ |
+| Recommendations R-B/C/D/E/G/H | ✅ #878 |
 
 ## Completed goal series (pointer only)
 
@@ -30,5 +32,6 @@
 | 2026-07-14 improvements S1/W2/K3/F4 | Implemented; S1.1c NO-GO | `archive/2026-07-consolidation/completed-sprints/` |
 | v0.1.35 CLI UX + ADR-075/076 | Released | same |
 | Harness + release-cadence-manager | Merged | same |
+| v0.1.36 release campaign | Shipped 2026-07-22 | — |
 
 Do not re-list completed WG tables here.

--- a/plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md
+++ b/plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md
@@ -1,9 +1,9 @@
 # Comprehensive Codebase Recommendations — 2026-07-20
 
 - **Status**: Active backlog (post–v0.1.36; workspace `0.1.37`)
-- **Audit commit**: refreshed 2026-07-22 after ship
-- **Released tag**: `v0.1.36`
-- **Open PRs**: post-release bump to 0.1.37
+- **Audit commit**: refreshed 2026-07-23
+- **Released tag**: `v0.1.36` (published 2026-07-22)
+- **Open PRs**: #889 (plans progress), #888 (perf cosine), #887 (changelog)
 - **Open issues**: none
 - **Coordinator**: goap-agent + agent-coordination
 - **Supersedes**: archived `GOAP_CODEBASE_IMPROVEMENTS_2026-07-14.md` and dated 2026-06/07 execution plans
@@ -11,7 +11,7 @@
 
 ## 1. Executive summary
 
-The 2026-07-14 → 2026-07-22 GOAP campaign closed the high-priority correctness, gate honesty, skill-eval, F4 pilot, and recommendations packages. PRs **#840–#881** are merged (including release docs #880 and rust-major #877); workspace is **`0.1.36`**. Remaining P0 is **ship v0.1.36** via `./scripts/release-manager.sh ship --execute` when main is green.
+The 2026-07-14 → 2026-07-23 GOAP campaign closed the high-priority correctness, gate honesty, skill-eval, F4 pilot, recommendations, **ship of v0.1.36**, and **post-bump to 0.1.37**. PRs **#840–#886** are merged (including #883 R-E2, #885 docs integrity, #886 post-bump). Remaining work is optional hygiene/perf PRs and spike-gated **R-F*** research.
 
 This plan is the **single active recommendations register**. It covers:
 
@@ -35,9 +35,9 @@ This plan is the **single active recommendations register**. It covers:
 
 | Area | Evidence | Verdict |
 |------|----------|---------|
-| Version | `Cargo.toml` `0.1.36`; tag `v0.1.35`; 26 unreleased commits | Unreleased development |
-| Main CI | Recent CI green on main HEAD | Green enough to plan release |
-| Open work | Release ship only | #877/#880/#881 merged |
+| Version | `Cargo.toml` `0.1.37`; tag `v0.1.36` published | Post-release development |
+| Main CI | Green on ship HEAD | Release artifacts published |
+| Open work | #887–#889 hygiene/perf | Ship + post-bump closed |
 | Production LOC >500 (non-test `src`) | No production offenders (`provider_config.rs` 237) | ✅ |
 | `todo!` / `unimplemented!` / “not yet implemented” in prod `src` | 0 matches | Clean surface |
 | Skills | Catalog + `ci-poll` evals present; routes complete | ✅ |
@@ -72,8 +72,8 @@ IDs use prefix **R** (recommendation). Priorities:
 
 | ID | Recommendation | Why | Acceptance |
 |----|----------------|-----|------------|
-| **R-A1** | Cut **v0.1.36** via `./scripts/release-manager.sh ship --execute` after CHANGELOG + Released Version docs | Shipped | ✅ |
-| **R-A2** | Immediately bump workspace to **0.1.37** after tag | AGENTS post-release rule | 🟡 This PR |
+| **R-A1** | Cut **v0.1.36** via `./scripts/release-manager.sh ship --execute` after CHANGELOG + Released Version docs | Shipped 2026-07-22 | ✅ |
+| **R-A2** | Immediately bump workspace to **0.1.37** after tag | AGENTS post-release rule; #886 | ✅ |
 | **R-A3** | Re-run `./scripts/release-manager.sh status` before ship | Status green before ship | ✅ |
 
 ### Track B — Code quality & invariants (P0/P1)

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -15,7 +15,7 @@
 | Package | Status |
 |---------|--------|
 | R-A1 ship v0.1.36 | ✅ |
-| R-A2 post-bump 0.1.37 | 🟡 This PR |
+| R-A2 post-bump 0.1.37 | ✅ Done |
 | R-E2 medium-risk skill evals | ✅ #883 |
 | Docs integrity ship unblock | ✅ #885 |
 | Recommendations #878 | ✅ |

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1,32 +1,47 @@
 # GOAP State Snapshot
 
-- **Last Updated**: 2026-07-22  
+- **Last Updated**: 2026-07-23  
 - **Version**: workspace `0.1.37` · latest tag `v0.1.36`  
-- **Branch**: `main` (+ post-bump PR)  
-- **Open issues**: none expected  
+- **Branch**: `main` @ `66286948`  
+- **Open PRs**: #889 (plans progress), #888 (perf cosine), #887 (changelog)  
+- **Open issues**: none  
 - **Active plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
 - **Archive**: `plans/archive/2026-07-consolidation/`  
-- **Release**: ✅ `v0.1.36` shipped via release-manager
+- **Release**: ✅ `v0.1.36` published 2026-07-22  
 
 ---
 
-## Phase: Post-release development ✅/🟡
+## Phase: Post-v0.1.36 development ✅
 
 | Package | Status |
 |---------|--------|
-| R-A1 ship v0.1.36 | ✅ |
-| R-A2 post-bump 0.1.37 | ✅ Done |
+| R-A1 ship v0.1.36 | ✅ Released |
+| R-A2 post-bump 0.1.37 | ✅ #886 |
 | R-E2 medium-risk skill evals | ✅ #883 |
 | Docs integrity ship unblock | ✅ #885 |
 | Recommendations #878 | ✅ |
+| Plans progress refresh | 🟡 #889 |
 | R-F* product epics | ⏸ DEFER |
 
 ---
 
-## Goal-state flags (2026-07-22)
+## Closed campaigns (pointer)
+
+| Campaign | Result |
+|----------|--------|
+| v0.1.36 ship + post-bump | ✅ 2026-07-22…23 |
+| Recommendations #878 | ✅ |
+| F4 remainder / missing tasks / harness | ✅ #873/#874/#870 family |
+| v0.1.35 release | ✅ |
+
+Details: `plans/archive/2026-07-consolidation/completed-sprints/`.
+
+---
+
+## Goal-state flags (2026-07-23)
 
 ```text
-truth_reconciled                  = true
+truth_reconciled                  ≈ true (this refresh; open PR list live)
 sandbox_capability_boundary       = true
 retrieval_identity_complete       = true
 storage_awaits_lock_free          = true
@@ -41,4 +56,5 @@ docs_match_code                   = true
 plan_registry_unique              ≈ true (ADR 025/054 aliased)
 feature_pilots_have_baselines     = true
 release_current                   = true (v0.1.36)
+version_advanced_after_tag        = true (workspace 0.1.37)
 ```

--- a/plans/README.md
+++ b/plans/README.md
@@ -2,8 +2,8 @@
 
 **Workspace**: `0.1.37` (post-release) · **Released tag**: `v0.1.36` · **Next**: `v0.1.37`  
 **Active plan**: [GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md](GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md)  
-**Last Updated**: 2026-07-21  
-**Open PRs**: #880 (release), #877 (deps) · **Open issue**: #879 (drift)  
+**Last Updated**: 2026-07-23  
+**Open PRs**: #889 (plans progress), #888 (perf), #887 (changelog) · **Open issues**: none  
 **Policy**: ADR-039 (canonical active set) + ADR-072 (authority / release path)
 
 ## Quick Navigation
@@ -29,49 +29,20 @@
 | [ARCHITECTURE/ARCHITECTURE_CORE.md](ARCHITECTURE/ARCHITECTURE_CORE.md) | Core system architecture |
 | [ARCHITECTURE/ARCHITECTURE_PATTERNS.md](ARCHITECTURE/ARCHITECTURE_PATTERNS.md) | Design patterns |
 | [ARCHITECTURE/ARCHITECTURE_INTEGRATION.md](ARCHITECTURE/ARCHITECTURE_INTEGRATION.md) | Integration architecture |
-| [ARCHITECTURE/API_DOCUMENTATION.md](ARCHITECTURE/API_DOCUMENTATION.md) | API reference (plans-local) |
-| [adr/](adr/) | Architecture Decision Records (ADR-022+) |
+| [ARCHITECTURE/API_DOCUMENTATION.md](ARCHITECTURE/API_DOCUMENTATION.md) | API surface |
 
-## Spikes & evidence
+## ADRs
 
-| Path | Purpose |
-|------|---------|
-| [spikes/](spikes/) | Spike config TOMLs (F4.x, S1.1c, …) |
-| [STATUS/spikes/](STATUS/spikes/) | Spike decision artifacts (GO / NO-GO) |
+See [adr/README.md](adr/README.md) for the ADR index (including number-collision aliases).
 
-## Long-Term Vision
+## Spikes
 
-| Document | Purpose |
-|----------|---------|
-| [ROADMAPS/ROADMAP_V030_VISION.md](ROADMAPS/ROADMAP_V030_VISION.md) | Multi-instance, multi-tenancy, observability vision |
+| Path | Role |
+|------|------|
+| [spikes/](spikes/) | Spike configs (TOML) |
+| [STATUS/spikes/](STATUS/spikes/) | Decision artifacts (JSON) |
 
 ## Archive
 
-Historical and completed documents live under `archive/`:
-
-| Path | Contents |
-|------|----------|
-| `archive/2025-deprecated/` | Deprecated 2025 documents |
-| `archive/2026-01-completed/` | January 2026 completed work |
-| `archive/2026-02-completed/` | February 2026 completed work |
-| `archive/2026-03-consolidation/` | March 2026 ADR-039 consolidation |
-| **`archive/2026-07-consolidation/`** | **July 2026 post-v0.1.35 cleanup** (completed sprints, analyses, CI plans, research WGs, stale status) |
-
-### Active-set rule (ADR-039)
-
-Only forward-looking / living documents stay unarchived:
-
-1. Navigation (`README.md`)
-2. Status + validation + gap + latest analysis
-3. Roadmap + GOAP trio (GOALS / ACTIONS / GOAP_STATE)
-4. Gate contract
-5. One active recommendations / execution plan
-6. ADRs, architecture, spike artifacts
-
-Dated execution plans archive when the sprint merges. Do not keep parallel status files.
-
-### Validation
-
-```bash
-./scripts/validate-plans.sh --active-set --version-state --identifiers --links
-```
+Superseded plans live under [archive/](archive/) (do not treat as active backlog).  
+Latest consolidation: [archive/2026-07-consolidation/](archive/2026-07-consolidation/).

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -14,7 +14,7 @@
 | Priority | Item | Description | Status |
 |----------|------|-------------|--------|
 | 1 | Ship v0.1.36 | `release-manager.sh ship --execute` | ✅ |
-| 2 | Post-bump | Workspace → 0.1.37 | 🟡 |
+| 2 | Post-bump | Workspace → 0.1.37 | ✅ |
 | 3 | R-E2 skill evals | Medium-risk behavioral fixtures | ✅ #883 |
 | 4 | Docs integrity | Unblock ship gate | ✅ #885 |
 

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -1,22 +1,34 @@
 # Active Development Roadmap
 
-**Last Updated**: 2026-07-22  
+**Last Updated**: 2026-07-23  
 **Released Version**: v0.1.36  
 **Workspace Version**: 0.1.37  
 **Active Sprint**: Post-v0.1.36 development  
 **Plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
 **Branch**: `main`  
+**Open PRs**: #889 (plans), #888 (perf), #887 (changelog)  
+**Open issues**: none  
 
 ---
 
-## Sprint 2026-07-22 — Ship + post-bump
+## Completed sprint 2026-07-22…23 — Ship + post-bump
 
 | Priority | Item | Description | Status |
 |----------|------|-------------|--------|
-| 1 | Ship v0.1.36 | `release-manager.sh ship --execute` | ✅ |
-| 2 | Post-bump | Workspace → 0.1.37 | ✅ |
-| 3 | R-E2 skill evals | Medium-risk behavioral fixtures | ✅ #883 |
-| 4 | Docs integrity | Unblock ship gate | ✅ #885 |
+| 1 | Ship v0.1.36 | `release-manager.sh ship --execute` + release.yml | ✅ |
+| 2 | Post-bump | Workspace → 0.1.37 (#886) | ✅ |
+| 3 | R-E2 skill evals | Medium-risk behavioral fixtures (#883) | ✅ |
+| 4 | Docs integrity | Unblock ship gate (#885) | ✅ |
+
+---
+
+## Current sprint — hygiene + optional perf
+
+| Priority | Item | Description | Status |
+|----------|------|-------------|--------|
+| 1 | Plans truth | CURRENT / GOALS / ACTIONS / GOAP_STATE / GAP / VALIDATION | 🟡 #889 |
+| 2 | Changelog hygiene | PR #887 | 🟡 open |
+| 3 | Cosine unrolled | PR #888 — review + bench evidence | 🟡 open |
 
 ---
 

--- a/plans/STATUS/CODEBASE_ANALYSIS_LATEST.md
+++ b/plans/STATUS/CODEBASE_ANALYSIS_LATEST.md
@@ -1,55 +1,54 @@
-# Codebase Analysis Latest — 2026-07-22
+# Codebase Analysis Latest — 2026-07-23
 
-**Branch**: `main` (+ R-E2 PR)  
-**Workspace**: `0.1.36` · **Released tag**: `v0.1.35`  
+**Branch**: `main` @ `66286948`  
+**Workspace**: `0.1.37` · **Released tag**: `v0.1.36`  
 **Companion**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`
 
 ## Architecture (as implemented)
 
 | Crate | Role |
 |-------|------|
-| `do-memory-core` | Episodes, patterns, rewards, retrieval (incl. CSM cascade), embeddings, F4 provenance/journal |
+| `do-memory-core` | Episodes, patterns, rewards, retrieval (CSM cascade), embeddings, F4 provenance/journal |
 | `do-memory-storage-turso` | Durable libSQL / Turso |
 | `do-memory-storage-redb` | Embedded cache |
 | `do-memory-mcp` | MCP server, lazy tools, audit, fail-closed code exec |
-| `do-memory-cli` | Operator CLI (episode, pattern, storage, config, …) |
+| `do-memory-cli` | Operator CLI |
 | `do-memory-test-utils` / benches / examples / e2e | Support |
 
-**Stack**: Rust 2024, Tokio, Turso/libSQL, redb, postcard, optional OpenAI/Mistral/local embeddings, `csm` cascade.
+**Stack**: Rust 2024, Tokio, Turso/libSQL, redb, postcard, optional embeddings, `csm` cascade.
 
 ## Health summary
 
 | Check | Result |
 |-------|--------|
-| Production `todo!` / unimplemented strings | None found |
+| Production `todo!` / unimplemented | None found (prior audits) |
 | Production LOC >500 (non-test `src`) | **0** |
-| Open GitHub issues | **0** |
-| Skills with evals | 34/34 (medium-risk behavioral second wave) |
-| Skill routes | 34/34 |
-| Mainline CI (recent runs) | Success (Quick Check, Skill Evals, Storage Matrix, Release Drift) |
+| Released tag | **v0.1.36** |
+| Workspace advanced post-tag | **0.1.37** |
+| Skills with evals / routes | 34/34 |
 | Fail-closed code execution | Preserved |
-| Plans active-set | Canonical after 2026-07 consolidation |
-| Release readiness | `verify-release-state` ready for v0.1.36 |
+| Open issues | **0** |
+| Open PRs | 3 (#887–#889) |
 
 ## Strengths
 
-1. Strong correctness campaign (locks, eviction, cache identity, embedding health).  
-2. Gate honesty (deny blocking, benchmark hard-fail, workflow cancelled guards).  
-3. Skill eval schema + high-risk and medium-risk behavioral fixtures.  
-4. Release path singularity (`release-manager` + `release.yml` + cadence manager).  
-5. Rich episodic/pattern/playbook/checkpoint MCP+CLI surface.
+1. Correctness campaign (locks, eviction, cache identity, embedding health).  
+2. Gate honesty (deny, benchmarks, cancelled guards, docs integrity ship gate).  
+3. Skill eval schema + high- and medium-risk behavioral fixtures.  
+4. Singular release path (`release-manager` + `release.yml`).  
+5. Rich episodic/pattern/playbook MCP+CLI surface.
 
-## Weaknesses
+## Weaknesses / residual
 
-1. Release lag (0.1.36 unreleased).  
-2. Historical ADR filename collisions (aliased, not renumbered).  
-3. Transitive Dependabot advisories on upstream chains.  
-4. Product/research epics remain spike-gated (R-F*).
+1. Historical ADR filename collisions (aliased only).  
+2. Transitive Dependabot advisories.  
+3. Product/research epics still spike-gated (R-F*).  
+4. Open hygiene/perf PRs not yet landed.
 
 ## Recommended focus order
 
-1. Ship v0.1.36 + post-bump 0.1.37  
-2. Optional research spikes only after GO artifacts  
-3. Upstream security chain hygiene when direct upgrades are available  
+1. Land or close open PRs #887–#889 with evidence.  
+2. Optional #888 only with bench comparison.  
+3. Research spikes only after GO artifacts.  
 
 Full prioritized backlog: recommendations plan §3–4.

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -11,7 +11,7 @@
 
 | Kind | Items |
 |------|--------|
-| Open PRs | post-release bump PR (this branch) |
+| Open PRs | *(none)* |
 | Open issues | *(none expected after release drift auto-close)* |
 
 ## Snapshot
@@ -19,7 +19,7 @@
 | Area | State |
 |------|--------|
 | Release v0.1.36 | ✅ Shipped (`release-manager.sh ship --execute` → tag `v0.1.36`) |
-| Post-release workspace bump | 🟡 This PR → `0.1.37` |
+| Post-release workspace bump | ✅ Done |
 | Recommendations + F4 + skill contracts | ✅ Closed on main |
 | Medium-risk skill evals (R-E2) | ✅ #883 |
 | Docs integrity ship gate | ✅ #885 |
@@ -32,7 +32,7 @@
 
 | Priority | Item | ID | Status |
 |----------|------|-----|--------|
-| P0 | Land post-bump `0.1.37` | R-A2 | 🟡 This PR |
+| P0 | Land post-bump `0.1.37` | R-A2 | ✅ Done |
 | P2 | Research/product spikes (R-F*) | R-F* | ⏸ DEFER |
 | P2 | Transitive Dependabot advisories | G-P1-9 | Monitor / upstream |
 

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -1,49 +1,52 @@
 # Project Status — Self-Learning Memory System
 
-**Last Updated**: 2026-07-22  
+**Last Updated**: 2026-07-23  
 **Released Version**: v0.1.36  
 **Workspace Version**: 0.1.37  
 **Edition**: Rust 2024  
 **Active plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
-**Branch**: `main`  
+**Branch**: `main` @ `66286948`  
 
 ## Open tracker (live)
 
 | Kind | Items |
 |------|--------|
-| Open PRs | *(none)* |
-| Open issues | *(none expected after release drift auto-close)* |
+| Open PRs | **#889** plans progress (this) · **#888** perf cosine unrolled · **#887** changelog v0.1.36 |
+| Open issues | *(none)* |
 
 ## Snapshot
 
 | Area | State |
 |------|--------|
-| Release v0.1.36 | ✅ Shipped (`release-manager.sh ship --execute` → tag `v0.1.36`) |
-| Post-release workspace bump | ✅ Done |
-| Recommendations + F4 + skill contracts | ✅ Closed on main |
+| Release **v0.1.36** | ✅ Shipped 2026-07-22 — [release](https://github.com/d-o-hub/rust-self-learning-memory/releases/tag/v0.1.36) |
+| Post-release workspace **0.1.37** | ✅ #886 merged |
+| Recommendations + F4 + skill contracts | ✅ #878 |
 | Medium-risk skill evals (R-E2) | ✅ #883 |
 | Docs integrity ship gate | ✅ #885 |
 | Production LOC >500 (non-test `src`) | ✅ Clean |
 | Skill evals / routes | 34/34 |
 | Code execution | Fail-closed (S1.1c NO-GO) |
 | MCP provenance (`with_provenance`) | ✅ |
+| P0 plan gaps | **None open** |
 
 ## Immediate priorities
 
 | Priority | Item | ID | Status |
 |----------|------|-----|--------|
-| P0 | Land post-bump `0.1.37` | R-A2 | ✅ Done |
+| P1 | Land hygiene PRs (#889 plans, #887 changelog) when CI CLEAN | ops | 🟡 open |
+| P1 | Review #888 cosine-sim unrolled (perf; may need benches) | perf | 🟡 open |
 | P2 | Research/product spikes (R-F*) | R-F* | ⏸ DEFER |
 | P2 | Transitive Dependabot advisories | G-P1-9 | Monitor / upstream |
 
-## Recent completed
+## Recent completed (2026-07-20…23)
 
 | Wave | Result |
 |------|--------|
-| Ship v0.1.36 | ✅ Tagged + release.yml |
+| Ship v0.1.36 + GitHub Release artifacts | ✅ |
+| Post-bump 0.1.37 #886 | ✅ Merged |
 | Docs integrity unblock #885 | ✅ Merged |
 | R-E2 medium-risk skill evals #883 | ✅ Merged |
-| Release docs #880 / deps #877 / tracker #881 | ✅ Merged |
+| Release docs #880 / rust-major #877 / tracker #881 | ✅ Merged |
 | Recommendations #878 | ✅ Merged |
 
 ## Canonical companions
@@ -51,4 +54,5 @@
 - Roadmap: `plans/ROADMAPS/ROADMAP_ACTIVE.md`
 - Goals / actions / GOAP: `plans/GOALS.md`, `plans/ACTIONS.md`, `plans/GOAP_STATE.md`
 - Gaps: `plans/STATUS/GAP_ANALYSIS_LATEST.md`
+- Validation: `plans/STATUS/VALIDATION_LATEST.md`
 - Archive: `plans/archive/2026-07-consolidation/`

--- a/plans/STATUS/GAP_ANALYSIS_LATEST.md
+++ b/plans/STATUS/GAP_ANALYSIS_LATEST.md
@@ -1,23 +1,26 @@
-# Gap Analysis — 2026-07-22 (post v0.1.36)
+# Gap Analysis — 2026-07-23
 
-**Generated**: 2026-07-22  
-**Workspace**: `0.1.37` · **Tag**: `v0.1.36`  
+**Generated**: 2026-07-23  
+**Audit commit**: `66286948` (`main`)  
+**Workspace**: `0.1.37` · **Tag**: `v0.1.36` (published 2026-07-22)  
 **Full backlog**: [`../GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`](../GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md)
 
 ## Method
 
-- Live tree + GitHub release/tag verification  
-- Production `todo!` / `unimplemented!` → **0**  
-- Recommendations register re-verified  
+- Live GitHub: open PRs **#889**, **#888**, **#887**; open issues **none**  
+- Release: `gh release view v0.1.36` published  
+- Workspace version advanced post-tag (R-A2 / #886)  
+- Prior gap register closed for all P0 ship items  
 
 ## Closed this wave
 
 | Gap | Resolution |
 |-----|------------|
-| G-P0-1 v0.1.36 unreleased | ✅ Tagged `v0.1.36` via release-manager |
-| G-P0-4 / G-P0-5 open CI PRs | ✅ #880 / #877 merged earlier |
+| G-P0-1 v0.1.36 unreleased | ✅ Tag + GitHub Release 2026-07-22 |
+| G-P0-4 / G-P0-5 release docs / rust-major | ✅ #880 / #877 |
 | G-P1-7 medium-risk eval depth | ✅ R-E2 #883 |
 | Docs integrity ship blocker | ✅ #885 |
+| Post-tag version lag | ✅ workspace `0.1.37` #886 |
 
 ## Open gaps (current)
 
@@ -27,16 +30,17 @@
 
 ### P1
 
-| ID | Gap | Track |
-|----|-----|-------|
-| G-P1-8 | Historical ADR number reuse on disk (aliased) | residual docs |
-| G-P1-9 | Transitive Dependabot advisories | upstream |
+| ID | Gap | Evidence | Track |
+|----|-----|----------|-------|
+| G-P1-8 | Historical ADR number reuse on disk | Dual 025/054 filenames; aliases in `plans/adr/README.md` | residual docs |
+| G-P1-9 | Transitive Dependabot advisories | Upstream chains (libsql/openssl/webpki) | security hygiene |
+| G-P1-10 | Open hygiene/perf PRs | #887, #888, #889 | land or close with evidence |
 
-### P2
+### P2 (product / research)
 
-| ID | Gap | Track |
-|----|-----|-------|
-| G-P2-1…6 | Research / vision epics (R-F*) | ⏸ DEFER |
+| ID | Gap | Notes | Track |
+|----|-----|-------|--------|
+| G-P2-1…6 | R-F* epics | Spike-gated DEFER | R-F* |
 
 ## Explicit non-gaps
 
@@ -46,3 +50,9 @@
 | Batch MCP tools | Deferred product decision |
 | Production LOC >500 | Closed |
 | Medium-risk skill presence-only evals | Closed |
+| Release lag / commit_limit on tag | Closed by v0.1.36 ship |
+
+## Exit criteria for this register
+
+- G-P1-10 closed when open PRs merge or are declined with reason  
+- P2 rows remain spikes until GO artifacts under `plans/STATUS/spikes/`  

--- a/plans/STATUS/VALIDATION_LATEST.md
+++ b/plans/STATUS/VALIDATION_LATEST.md
@@ -1,25 +1,38 @@
-# Validation Latest — 2026-07-22 Ship + Post-bump
+# Validation Latest — 2026-07-23 Plans Progress Refresh
 
-**Goal**: Close remaining plan P0 (ship v0.1.36 + post-bump 0.1.37).  
-**Workspace**: `0.1.37` (this PR) · **Tag**: `v0.1.36`  
+**Goal**: Reconcile plans trackers with live post-v0.1.36 state (tag, workspace, open PRs).  
+**Workspace**: `0.1.37` · **Tag**: `v0.1.36` · **HEAD**: `66286948`  
 
 ## Evidence
 
-| Check | Result |
-|-------|--------|
-| `./scripts/release-manager.sh ship --execute` | ✅ tag `v0.1.36` pushed |
-| Main CI at ship HEAD | All green (incl. Performance Benchmarks) |
-| `./scripts/check-docs-integrity.sh` | ✅ (after #885) |
-| Skill evals | ✅ (after #883) |
-| Post-bump workspace `0.1.37` | 🟡 This PR |
+| Check | Observation | Result |
+|-------|-------------|--------|
+| Released tag | `v0.1.36` published 2026-07-22 | ✅ |
+| Workspace version | `Cargo.toml` `0.1.37` | ✅ |
+| Open issues | `gh issue list --state open` | empty |
+| Open PRs | #889 plans · #888 perf · #887 changelog | live |
+| R-A1 / R-A2 | ship + post-bump | ✅ closed |
+| R-E2 / docs integrity | #883 / #885 | ✅ merged |
+| Prod `todo!` / unimplemented | prior audits | 0 |
 
-## Still open
+## Closed validation goals
 
-| Item | Next |
-|------|------|
-| R-A2 | Merge this post-bump PR |
-| R-F* | DEFER until spike GO |
+| Goal | Result |
+|------|--------|
+| Ship v0.1.36 | ✅ release-manager + release.yml |
+| Post-bump 0.1.37 | ✅ #886 |
+| Skill eval depth (R-E2) | ✅ #883 |
+| Docs integrity ship gate | ✅ #885 |
+
+## Still open after this validation
+
+| Item | Next step |
+|------|-----------|
+| #889 | Merge this plans refresh when CI CLEAN |
+| #887 | Changelog hygiene review |
+| #888 | Perf PR review + Criterion evidence if landing |
+| R-F* | DEFER until individual spikes GO |
 
 ## Note
 
-Do not cut another release from the post-bump PR alone. Next release when 0.1.37 content warrants it.
+This change set is **plans progress only**. Do not ship a release from this PR.


### PR DESCRIPTION
## Summary

Updates `plans/` trackers to match live state as of **2026-07-23**:

| Fact | Status |
|------|--------|
| Tag **v0.1.36** | Published |
| Workspace **0.1.37** | On main (#886) |
| Open issues | none |
| Open PRs | #889 (this), #888 perf, #887 changelog |
| P0 ship/post-bump | closed |

Files: CURRENT, GOALS, ACTIONS, GOAP_STATE, ROADMAP_ACTIVE, GAP_ANALYSIS_LATEST, VALIDATION_LATEST, CODEBASE_ANALYSIS_LATEST, plans/README, recommendations register header/R-A*.

## Test plan

- [x] `./scripts/validate-plans.sh --active-set`
- [x] `./scripts/check-docs-integrity.sh`
- [ ] CI green