### PR TITLE
docs: synchronize README and internal documentation with current implementation state

### DIFF
--- a/.agents/skills/do-memory-mcp/tools.md
+++ b/.agents/skills/do-memory-mcp/tools.md
@@ -1,98 +1,25 @@
 # MCP Tools Reference
 
-## 1. query_memory
+Please see `docs/API_REFERENCE.md` for the single source of truth on available tools and their schemas.
 
-Query episodic memory for relevant past experiences and learned patterns.
+Below are the primary tools to be aware of:
 
-**Parameters**:
-- `query` (required): Search query describing the task or context
-- `domain` (required): Task domain (e.g., 'web-api', 'data-processing')
-- `task_type` (optional): Type of task - `code_generation`, `debugging`, `refactoring`, `testing`, `analysis`, `documentation`
-- `limit` (default: 10): Maximum number of episodes to retrieve
+## Core & Pattern Discovery
+- **query_memory**: Search past episodes to inform current tasks
+- **search_patterns**: Semantic search across learned patterns
+- **recommend_patterns**: Get task-specific pattern recommendations
+- **analyze_patterns**: Identify successful strategies based on task type
 
-**Example**:
-```json
-{
-  "query": "implement async storage with error handling",
-  "domain": "rust-backend",
-  "task_type": "code_generation",
-  "limit": 5
-}
-```
+## Playbooks & Agents
+- **recommend_playbook**: Actionable step-by-step guidance derived from successful episodes
+- **checkpoint_episode**: Save state for long-running workflows or agent handoffs
 
-**Use when**: You need relevant past experiences to inform current work.
+## Feedback
+- **record_recommendation_session**: Initiate a tracking session for pattern/playbook usage
+- **record_recommendation_feedback**: Rate the effectiveness of recommended patterns
 
-## 2. analyze_patterns
+## Code Execution
+- **execute_agent_code**: Unavailable / fail-closed. This tool will reject calls. Use external execution environments for actual code running.
 
-Analyze patterns from past episodes to identify successful strategies.
-
-**Parameters**:
-- `task_type` (required): Type of task to analyze patterns for
-- `min_success_rate` (default: 0.7): Minimum success rate (0.0-1.0)
-- `limit` (default: 20): Maximum number of patterns to return
-
-**Example**:
-```json
-{
-  "task_type": "debugging",
-  "min_success_rate": 0.8,
-  "limit": 10
-}
-```
-
-**Use when**: You want to identify proven successful approaches for a task type.
-
-## 3. advanced_pattern_analysis
-
-Perform advanced statistical analysis, predictive modeling, and causal inference.
-
-**Parameters**:
-- `analysis_type` (required): `statistical`, `predictive`, or `comprehensive`
-- `time_series_data` (required): Object mapping variable names to numeric arrays
-- `config` (optional): Analysis configuration
-  - `significance_level` (default: 0.05): Statistical significance level
-  - `forecast_horizon` (default: 10): Steps to forecast ahead
-  - `anomaly_sensitivity` (default: 0.5): Anomaly detection sensitivity
-  - `enable_causal_inference` (default: true): Perform causal analysis
-  - `max_data_points` (default: 10000): Maximum data points
-  - `parallel_processing` (default: true): Enable parallel processing
-
-**Example**:
-```json
-{
-  "analysis_type": "comprehensive",
-  "time_series_data": {
-    "latency_ms": [120, 115, 130, 125, 140],
-    "success_rate": [0.95, 0.98, 0.96, 0.97, 0.99]
-  },
-  "config": {
-    "forecast_horizon": 5,
-    "anomaly_sensitivity": 0.6
-  }
-}
-```
-
-**Use when**: You need deep statistical insights and predictions from historical data.
-
-## 4. execute_agent_code (unavailable / fail-closed)
-
-**Status**: Unavailable / fail-closed. The WASM sandbox was removed; there is no `wasmtime-backend` feature and no working code-execution backend. Calls are rejected.
-
-Do not rely on this tool for sandbox execution. Prefer other MCP tools for memory, patterns, and monitoring.
-
-## 5. health_check
-
-Check the health status of the MCP server and its components.
-
-**Parameters**: None
-
-**Use when**: Diagnosing server issues or verifying operational status.
-
-## 6. get_metrics
-
-Get comprehensive monitoring metrics and statistics.
-
-**Parameters**:
-- `metric_type` (default: "all"): `all`, `performance`, `episodes`, or `system`
-
-**Use when**: Monitoring server performance or gathering operational insights.
+## Episode Lifecycle
+Create, get, complete, log steps, and manage tags/relationships. Use the standard CRUD tools (`create_episode`, `add_episode_step`, `complete_episode`, etc.) documented in `docs/API_REFERENCE.md`.

--- a/README.md
+++ b/README.md
@@ -577,13 +577,13 @@ batch_size = 100
 │  └─────────────┘  └─────────────┘  └─────────────┘          │
 └─────────────────────────────────────────────────────────────┘
                                │
-            ┌──────────────────┴──────┬────────────────────────┐
-            │                         │                        │
-┌───────────▼───────────┐ ┌───────────▼───────────┐ ┌───────────▼───────────┐
-│do-memory-storage-turso│ │do-memory-storage-redb │ │do-memory-storage-redb │
-│                       │ │                       │ │                       │
-│     libSQL/Remote     │ │      Fast Access      │ │  In-Memory/Temporary  │
-└───────────────────────┘ └───────────────────────┘ └───────────────────────┘
+            ┌──────────────────┴────────────────────────┐
+            │                                           │
+┌───────────▼───────────┐                   ┌───────────▼───────────┐
+│do-memory-storage-turso│                   │do-memory-storage-redb │
+│                       │                   │                       │
+│ libSQL (remote/local) │                   │ Embedded cache (redb) │
+└───────────────────────┘                   └───────────────────────┘
 ```
 
 ## MCP Server Tools
@@ -594,6 +594,7 @@ The MCP server exposes tools via lazy loading (ADR-024):
 - **analyze_patterns** — Identify successful strategies and recommendations
 - **search_patterns** — Semantic pattern search with multi-signal ranking
 - **recommend_patterns** — Task-specific pattern recommendations
+- **recommend_playbook** — Actionable step-by-step playbook retrieval
 - **configure_embeddings** / **test_embeddings** / **generate_embedding** — Embedding management
 - **search_by_embedding** / **embedding_provider_status** — Semantic search and provider monitoring
 - **Episode lifecycle tools** — create, complete, log steps, get, timeline


### PR DESCRIPTION
- Fixed the architecture diagram in README.md by removing the duplicated `do-memory-storage-redb` box.
- Added `recommend_playbook` to the "MCP Server Tools" section in README.md.
- Updated `.agents/skills/do-memory-mcp/tools.md` to point to `docs/API_REFERENCE.md` and accurately list the current tools.
- Ensured all code blocks use the correct `do_memory_core` crate name in the documentation files.

---
*PR created automatically by Jules for task [5301814198895165792](https://jules.google.com/task/5301814198895165792) started by @d-o-hub*