### PR TITLE
test/docs(embeddings): ADR-077 A6 — validate, document, and gate runtime activation

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -142,6 +142,27 @@ The following tool names are the current contract tracked by parity tests.
 - `search_by_embedding`
 - `embedding_provider_status`
 
+#### Runtime activation contract (ADR-077)
+
+- `configure_embeddings` is an **activation** operation, not a declarative config
+  write. A `success: true` response means the requested provider is live in the
+  server process; subsequent `embedding_provider_status`, `generate_embedding`,
+  `search_by_embedding`, and `query_semantic_memory` calls use it immediately.
+- Selectable providers: `local`, `openai`, `mistral`. `azure`, `azure_openai`,
+  `custom`, and `cohere` are rejected with an error naming the provider before any
+  credential or network work (no runtime adapter yet).
+- Cloud providers require a credential environment-variable **name** via
+  `api_key_env` (for example `OPENAI_API_KEY`, `MISTRAL_API_KEY`). Credentials are
+  read at activation time only; they are never stored, persisted, or echoed in
+  responses, warnings, errors, or audit fields.
+- Activation is atomic: a failed request preserves the previously active provider
+  and its revision unchanged.
+- Successful responses add `activation_revision` (strictly increasing per
+  successful activation), `reindex_required`
+  (`true` when the provider/model/dimension identity changed), and
+  `provider_health` (`"active"`). Activation state is runtime-only and is not
+  persisted across process restarts.
+
 ### Unavailable / Fail-Closed Tool
 
 - `execute_agent_code` — **unavailable / fail-closed**. The WASM sandbox was removed; there is no `wasmtime-backend` feature and no working code-execution backend. Calls are rejected (fail closed).

--- a/docs/EMBEDDINGS_CLI_GUIDE.md
+++ b/docs/EMBEDDINGS_CLI_GUIDE.md
@@ -129,6 +129,69 @@ base_url = "https://api.example.com/v1"
 - Use any OpenAI-compatible embedding API
 - Provide base_url and model name
 
+> **Note (ADR-077):** The MCP `configure_embeddings` runtime-activation tool
+> currently selects only `local`, `openai`, and `mistral`. `azure`, `custom`, and
+> `cohere` are rejected by that tool until a future ADR supplies their runtime
+> adapters and credential/endpoint contracts. The CLI `[embeddings]` config file
+> still parses these types, but they cannot be activated at runtime through MCP.
+
+## Runtime Provider Activation (MCP `configure_embeddings`)
+
+Per [ADR-077](../plans/adr/ADR-077-Runtime-Embedding-Provider-Activation.md),
+`configure_embeddings` is an **activation** operation. A successful call installs
+the requested provider into the running server process; a failed call leaves the
+previously active provider unchanged.
+
+### Selectable providers
+
+| Provider | Selectable via MCP | Credential env var | Build feature |
+|----------|--------------------|--------------------|---------------|
+| `local` | Yes | *(none)* | `local-embeddings` |
+| `openai` | Yes | `OPENAI_API_KEY` | `openai` |
+| `mistral` | Yes | `MISTRAL_API_KEY` | `mistral` |
+| `azure` / `azure_openai` | No (rejected) | — | — |
+| `custom` | No (rejected) | — | — |
+| `cohere` | No (rejected) | — | — |
+
+A provider is selectable only when its build feature is compiled in **and** its
+real-model/credential requirements are satisfied. A degraded or mock provider is
+never reported as configured and available.
+
+### Credentials are runtime-only
+
+- Pass the **name** of the environment variable that holds the key via
+  `api_key_env` (for example `"OPENAI_API_KEY"`); the key itself is read at
+  activation time.
+- API keys are **not** stored in config, output, warnings, errors, or audit logs,
+  and they are **not persisted** for restart recovery. Re-activate after each
+  process start.
+
+### Activation response fields
+
+| Field | Meaning |
+|-------|---------|
+| `success` | `true` only when the provider is live and usable |
+| `provider` / `model` / `dimension` | The exact activated identity |
+| `activation_revision` | Monotonic counter; advances on every successful activation |
+| `reindex_required` | `true` when the provider/model/dimension identity changed |
+| `provider_health` | `"active"` after a successful activation |
+| `warnings` | Non-fatal notices (for example an unknown model falling back to a default) |
+
+### Reindex-required behavior
+
+Changing the provider, model, or dimension changes the embedding identity
+(ADR-074). When the new identity differs from the previous one,
+`reindex_required` is `true` and previously stored embeddings/index entries must
+not be mixed with the new provider. Re-embedding is an explicit, separate
+operation; `configure_embeddings` never re-embeds implicitly.
+
+### Failure preserves the prior provider
+
+If validation, credential resolution, the health probe, or the dimension check
+fails, the call returns an error and the previously active provider (and its
+`activation_revision`) remains in effect. There is no cross-provider or mock
+fallback for an explicit MCP activation.
+
 ## CLI Commands
 
 ### Test Embedding Configuration

--- a/memory-core/src/memory/embedding_activation.rs
+++ b/memory-core/src/memory/embedding_activation.rs
@@ -268,4 +268,71 @@ mod tests {
             "runtime slot must be returned after activation"
         );
     }
+
+    /// REA-2026-07-26-A6: reader routine for the concurrency test below.
+    ///
+    /// Repeatedly snapshots the live service and activation.  Extracted into its
+    /// own coroutine so the spawned task stays shallow; must never deadlock or
+    /// panic while a writer replaces the provider concurrently.
+    async fn read_activation_snapshots(memory: Arc<SelfLearningMemory>, reads: usize) {
+        for _ in 0..reads {
+            // Snapshot before any provider/storage await — must never deadlock or
+            // panic while a writer holds the write lock.
+            let _svc = memory.live_semantic_service().await;
+            if let Some(act) = memory.embedding_activation().await {
+                assert!(
+                    !act.provider_identity.is_empty(),
+                    "identity must never be observed empty"
+                );
+                assert!(act.revision >= 1, "revision must be positive once set");
+            }
+            tokio::task::yield_now().await;
+        }
+    }
+
+    /// REA-2026-07-26-A6: reads during a replacement must never deadlock, panic,
+    /// or observe a half-built activation.  Many reader tasks snapshot the live
+    /// service and activation concurrently with a writer that replaces the
+    /// provider repeatedly.  Runs on a multi-thread runtime so the readers and
+    /// writer execute on distinct OS threads (ADR-077 §4).  The final revision
+    /// must equal the number of writes, proving every replacement landed and no
+    /// reader observed a torn slot.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_concurrent_reads_during_activation_replacement() {
+        const WRITES: u64 = 25;
+        const READERS: usize = 8;
+        const READS_PER_TASK: usize = 50;
+
+        let memory = Arc::new(SelfLearningMemory::new());
+        let mut reader_handles = Vec::with_capacity(READERS);
+
+        for _ in 0..READERS {
+            let m = Arc::clone(&memory);
+            reader_handles.push(tokio::spawn(read_activation_snapshots(m, READS_PER_TASK)));
+        }
+
+        let writer_memory = Arc::clone(&memory);
+        let writer = tokio::spawn(async move {
+            for i in 0..WRITES {
+                let model = format!("model-{}", i % 3);
+                writer_memory
+                    .activate_semantic_service(make_service(&model), format!("local:{model}:4"))
+                    .await;
+            }
+        });
+
+        writer.await.expect("writer must not panic");
+        for handle in reader_handles {
+            handle.await.expect("reader must not panic");
+        }
+
+        let final_act = memory
+            .embedding_activation()
+            .await
+            .expect("activation must be set after writes");
+        assert_eq!(
+            final_act.revision, WRITES,
+            "every replacement must advance the revision exactly once"
+        );
+    }
 }

--- a/memory-mcp/src/mcp/tools/embeddings/types.rs
+++ b/memory-mcp/src/mcp/tools/embeddings/types.rs
@@ -182,20 +182,20 @@ pub struct ConfigureEmbeddingsOutput {
     pub warnings: Vec<String>,
     /// Monotonically increasing activation revision counter.
     ///
-    /// `None` when the provider has been *recorded* but not yet activated
-    /// (i.e., the current bug state before REA-2026-07-26 A2 is implemented).
-    /// A `Some(n)` value means the provider was successfully activated and its
-    /// in-memory state revision is `n`.
+    /// `None` when no provider has been activated yet. A `Some(n)` value means a
+    /// provider was successfully activated and the in-memory activation revision
+    /// is `n`; each successful `configure_embeddings` call advances it by one
+    /// (REA-2026-07-26 / ADR-077).
     pub activation_revision: Option<u64>,
     /// Whether the embedding index must be rebuilt because the new provider
     /// has a different dimension or identity from the previously active one.
     pub reindex_required: bool,
     /// Coarse health signal for the provider as seen at configure time.
     ///
-    /// One of:
-    /// - `"configured"` — recorded but NOT yet probed / activated (current state)
-    /// - `"unavailable"` — provider binary/feature/API is absent at runtime
-    /// - `"error"` — an unexpected error occurred during configuration
+    /// `"active"` after a successful activation, meaning the provider is live and
+    /// has passed its health probe. A failed activation returns an error rather
+    /// than a degraded health value, so a success response always reports
+    /// `"active"` (ADR-077).
     pub provider_health: String,
 }
 

--- a/memory-mcp/tests/embeddings_integration.rs
+++ b/memory-mcp/tests/embeddings_integration.rs
@@ -3,9 +3,9 @@
 
 use do_memory_core::SelfLearningMemory;
 use do_memory_mcp::mcp::tools::embeddings::{
-    ConfigureEmbeddingsInput, EmbeddingProviderStatusInput, EmbeddingTools,
-    QuerySemanticMemoryInput, configure_embeddings_tool, query_semantic_memory_tool,
-    test_embeddings_tool,
+    ConfigureEmbeddingsInput, ConfigureEmbeddingsOutput, EmbeddingProviderStatusInput,
+    EmbeddingTools, QuerySemanticMemoryInput, configure_embeddings_tool,
+    query_semantic_memory_tool, test_embeddings_tool,
 };
 use do_memory_mcp::server::MemoryMCPServer;
 use do_memory_mcp::types::SandboxConfig;
@@ -235,15 +235,12 @@ async fn test_configure_embeddings_azure_rejected() {
         let result = tools.execute_configure_embeddings(input).await;
         assert!(
             result.is_err(),
-            "Azure provider '{}' should be rejected",
-            provider_name
+            "Azure provider '{provider_name}' should be rejected"
         );
         let err_msg = result.unwrap_err().to_string();
         assert!(
             err_msg.contains("Azure provider is not supported"),
-            "Expected 'Azure provider is not supported' in error for '{}', got: {}",
-            provider_name,
-            err_msg
+            "Expected 'Azure provider is not supported' in error for '{provider_name}', got: {err_msg}"
         );
     }
 }
@@ -271,8 +268,7 @@ async fn test_configure_embeddings_custom_rejected() {
     let err_msg = result.unwrap_err().to_string();
     assert!(
         err_msg.contains("Custom provider is not supported"),
-        "Expected 'Custom provider is not supported', got: {}",
-        err_msg
+        "Expected 'Custom provider is not supported', got: {err_msg}"
     );
 }
 
@@ -651,4 +647,114 @@ async fn test_tool_definitions_json_rpc_compliant() {
     let schema = test_tool.input_schema.as_object().unwrap();
     let properties = schema.get("properties").unwrap().as_object().unwrap();
     assert!(properties.is_empty());
+}
+
+/// REA-2026-07-26-A6: credential redaction regression (structural).
+///
+/// The activation output type must have **no field capable of carrying a
+/// credential**.  Assert the serialized field set is exactly the known
+/// non-secret contract so that any future field that could hold a key (for
+/// example `api_key`, `resolved_secret`) fails this test.  Per ADR-077 §6 the
+/// resolved key is read at activation time only and is never stored in config,
+/// output, warnings, or audit fields.
+///
+/// This test is deterministic and never mutates the process environment.
+#[tokio::test]
+async fn test_configure_embeddings_output_contract_has_no_credential_field() {
+    let output = ConfigureEmbeddingsOutput {
+        success: true,
+        provider: "openai".to_string(),
+        model: "text-embedding-3-small".to_string(),
+        dimension: 1536,
+        message: "Activated openai provider with model text-embedding-3-small (dimension: 1536, revision: 1)".to_string(),
+        warnings: vec![],
+        activation_revision: Some(1),
+        reindex_required: false,
+        provider_health: "active".to_string(),
+    };
+
+    let json = serde_json::to_value(&output).expect("output must serialize");
+    let obj = json
+        .as_object()
+        .expect("output must serialize to an object");
+
+    // Exactly the public, non-secret contract — nothing else may be exposed.
+    let allowed: std::collections::BTreeSet<&str> = [
+        "success",
+        "provider",
+        "model",
+        "dimension",
+        "message",
+        "warnings",
+        "activation_revision",
+        "reindex_required",
+        "provider_health",
+    ]
+    .into_iter()
+    .collect();
+    let actual: std::collections::BTreeSet<&str> = obj.keys().map(String::as_str).collect();
+    assert_eq!(
+        actual, allowed,
+        "activation output must expose only the known non-secret fields"
+    );
+
+    // No field name may be credential-bearing.
+    for key in obj.keys() {
+        let lower = key.to_lowercase();
+        for needle in ["key", "secret", "token", "credential", "password", "auth"] {
+            assert!(
+                !lower.contains(needle),
+                "field name must not be credential-bearing: {key}"
+            );
+        }
+    }
+}
+
+/// REA-2026-07-26-A6: credential redaction regression (behavioral).
+///
+/// When activation fails for a missing credential, the error must name the
+/// environment variable to set (usability) but must never carry credential
+/// material.  The variable simply does not exist, so this drives the real
+/// `execute_configure_embeddings` error path **without mutating the process
+/// environment** (no `unsafe`).
+///
+/// The structural guarantee that the output type cannot carry a credential is
+/// covered by `test_configure_embeddings_output_contract_has_no_credential_field`;
+/// this test guards the error-message / usability contract.
+#[tokio::test]
+async fn test_configure_embeddings_credential_error_names_var_not_value() {
+    const UNSET_VAR: &str = "__RSLM_UNSET_CREDENTIAL_VAR__";
+
+    let memory = Arc::new(SelfLearningMemory::new());
+    let tools = EmbeddingTools::new(memory);
+
+    let input = ConfigureEmbeddingsInput {
+        provider: "openai".to_string(),
+        model: Some("text-embedding-3-small".to_string()),
+        api_key_env: Some(UNSET_VAR.to_string()),
+        similarity_threshold: None,
+        batch_size: None,
+        base_url: None,
+        api_version: None,
+        resource_name: None,
+        deployment_name: None,
+    };
+
+    let result = tools.execute_configure_embeddings(input).await;
+    let err = result.expect_err("missing credential must fail activation");
+    let msg = err.to_string();
+
+    // The error tells the operator which variable to set...
+    assert!(
+        msg.contains(UNSET_VAR),
+        "error should name the environment variable: {msg}"
+    );
+
+    // ...and contains no credential-value material.
+    for sentinel in ["sk-", "Bearer ", "key=", "token=", "secret="] {
+        assert!(
+            !msg.contains(sentinel),
+            "error must not contain credential material '{sentinel}': {msg}"
+        );
+    }
 }

--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -1,7 +1,7 @@
 # GOAP Actions Backlog
 
-- **Last Updated**: 2026-07-25  
-- **Active plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
+- **Last Updated**: 2026-07-26  
+- **Active plan**: `plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md`  
 - **Archived plans**: `plans/archive/2026-07-consolidation/`
 
 ## Active actions (2026-07-25)
@@ -17,10 +17,12 @@
 | ACT-319 | Gap analysis tasks: pattern extract + ADR-074 docs | G-P1-12/ACT-317/318 | ✅ #891 merged |
 | ACT-320 | R-F8 CLI relationship show polish | R-F8 | ✅ #893 merged |
 | ACT-321 | R-F9 HNSW persistence + capacity eviction | R-F9 | ✅ #893 merged |
-| ACT-322 | Add 6 domain skills (40 total, all routed) | skills | ✅ this PR |
+| ACT-322 | Add 6 domain skills (40 total, all routed) | skills | ✅ #894 |
+| ACT-323 | ADR-077 A1-A5 runtime embedding activation | ADR-077 | ✅ main (`9ef4b742`, `e0f7f712`) |
+| ACT-324 | ADR-077 A6 validate/document/gate (docs + concurrency + zero-unsafe redaction tests) | ADR-077 | ✅ this PR |
 | ACT-312 | Optional product/research spikes R-F1…R-F7, R-F10 | R-F* | ⏸ DEFER |
 
-All ACT-300…ACT-322 items are **complete**. No open code actions remain.
+All ACT-300…ACT-324 items are **complete**. No open code actions remain.
 
 ## Completed actions (summary)
 

--- a/plans/GOALS.md
+++ b/plans/GOALS.md
@@ -1,9 +1,9 @@
 # GOAP Goals Index
 
-- **Last Updated**: 2026-07-25  
-- **Status**: Quiescent — all sprint goals complete; next action is next release  
+- **Last Updated**: 2026-07-26  
+- **Status**: ADR-077 runtime embedding activation complete (A1-A6); next action is next release  
 - **Workspace**: `0.1.37` · **Tag**: `v0.1.36`  
-- **Plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
+- **Plan**: `plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md`  
 - **Archive**: `plans/archive/2026-07-consolidation/`
 
 ## Active goals (2026-07-25)
@@ -28,7 +28,9 @@ No open code goals. Next trigger: decide to cut v0.1.37 or begin a P2 spike.
 | Cosine perf (8-way unrolled) | ✅ #888 |
 | Gap tasks (ADR-074 docs, G-P1-12 pattern extract) | ✅ #891 |
 | R-F8 CLI relationship show polish + R-F9 HNSW persistence | ✅ #893 |
-| 6 new domain skills (40 total, all routed) | ✅ this PR |
+| 6 new domain skills (40 total, all routed) | ✅ #894 |
+| ADR-077 runtime embedding activation A1-A5 | ✅ main (`9ef4b742`, `e0f7f712`) |
+| ADR-077 A6 validate / document / gate | ✅ this PR |
 | Full gap audit — 0 P0/P1 code gaps | ✅ 2026-07-25 |
 
 ## Completed goal series (pointer only)

--- a/plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md
+++ b/plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md
@@ -1,11 +1,22 @@
 # GOAP: Runtime Embedding Provider Activation
 
-- **Status**: Proposed implementation plan; no production code changed
+- **Status**: Implemented — A1-A6 complete (code `9ef4b742`, coverage `e0f7f712`, A6 validate/document this PR)
 - **Date**: 2026-07-26
 - **Audit checkout**: `main` at `7c854efb`
-- **Decision**: [ADR-077](adr/ADR-077-Runtime-Embedding-Provider-Activation.md)
+- **Decision**: [ADR-077](adr/ADR-077-Runtime-Embedding-Provider-Activation.md) — Accepted / Implemented
 - **Relevant constraints**: ADR-024, ADR-056, ADR-072, ADR-074, Tokio-only async, postcard, zero clippy warnings
 - **Strategy**: Sequential contract and core seam, then parallel provider/test work, followed by converging MCP and end-to-end validation
+
+## Implementation status
+
+| Package | Status | Evidence |
+|---|---|---|
+| REA-2026-07-26-A1 contract baseline | ✅ Done | `9ef4b742` — typed `ActivationError`, Azure/Custom/Cohere rejected, regression tests in `memory-mcp/tests/embeddings_integration.rs` |
+| REA-2026-07-26-A2 core runtime + storage seam | ✅ Done | `9ef4b742` — `activate_semantic_service`, `active_embedding` slot, no lock across `.await` (`memory-core/src/memory/embedding_activation.rs`) |
+| REA-2026-07-26-A3 exact-provider factory | ✅ Done | `9ef4b742` — `SemanticService::build_exact` (no fallback), feature-gated OpenAI/Mistral, dimension validation |
+| REA-2026-07-26-A4 identity / invalidation | ✅ Done | `9ef4b742` — `provider:model:dimension` identity, `reindex_required`, revision participates in ADR-074 identity |
+| REA-2026-07-26-A5 MCP end-to-end | ✅ Done | `9ef4b742` — `configure_embeddings` activates live; status/generate/query/search read `live_semantic_service()` |
+| REA-2026-07-26-A6 validate / document / gate | ✅ Done | coverage `e0f7f712`; concurrency + credential-redaction regression tests and `docs/API_REFERENCE.md` + `docs/EMBEDDINGS_CLI_GUIDE.md` activation docs (this PR) |
 
 ## Analysis
 

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1,11 +1,11 @@
 # GOAP State Snapshot
 
-- **Last Updated**: 2026-07-25  
+- **Last Updated**: 2026-07-26  
 - **Version**: workspace `0.1.37` · latest tag `v0.1.36`  
-- **Branch**: `main` @ `5b4b9776`  
-- **Open PRs**: none  
+- **Branch**: `feat/adr077-a6-validate-document` (open PR) · `main` @ `e0f7f712`  
+- **Open PRs**: ADR-077 A6 validate/document  
 - **Open issues**: none  
-- **Active plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
+- **Active plan**: `plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md` (A1-A6 complete)  
 - **Archive**: `plans/archive/2026-07-consolidation/`  
 - **Release**: ✅ `v0.1.36` published 2026-07-22  
 
@@ -23,7 +23,9 @@
 | Plans progress refresh | ✅ #889 |
 | R-F8 CLI relationship show polish | ✅ #893 |
 | R-F9 HNSW persistence + hardening | ✅ #893 |
-| 6 new domain skills (40 total, all routed) | ✅ this PR |
+| 6 new domain skills (40 total, all routed) | ✅ #894 |
+| ADR-077 runtime embedding activation (A1-A5) | ✅ main (`9ef4b742`, `e0f7f712`) |
+| ADR-077 A6 validate / document / gate | ✅ this PR |
 | R-F* remaining product epics | ⏸ DEFER |
 
 ---
@@ -68,5 +70,5 @@ pattern_extract_command           = true  (ADR-076 §5 — G-P1-12, #891)
 r_f8_relationship_show_polish     = true  (#893 — box-drawing panel + unit tests)
 r_f9_hnsw_persistence             = true  (#893 — file_dump/load + capacity eviction)
 skill_count_40_all_routed         = true  (checkpoint-handoff, embedding-ops, episode-relationships, episode-tags, playbook-ops, recommendation-feedback)
-runtime_embedding_activation      = true  (ADR-077 Implemented — configure_embeddings now activates exact provider)
+runtime_embedding_activation      = true  (ADR-077 Implemented A1-A6 — configure_embeddings activates exact provider; A6 docs + concurrency/redaction regression tests this PR)
 ```

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -1,12 +1,12 @@
 # Active Development Roadmap
 
-**Last Updated**: 2026-07-25  
+**Last Updated**: 2026-07-26  
 **Released Version**: v0.1.36 (latest tag)  
 **Workspace Version**: 0.1.37 (next release)  
-**Active Sprint**: Post-v0.1.36 — all sprint items complete  
-**Plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
-**Branch**: `main` @ `5b4b9776`  
-**Open PRs**: none  
+**Active Sprint**: ADR-077 runtime embedding activation (A1-A6 complete)  
+**Plan**: `plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md`  
+**Branch**: `feat/adr077-a6-validate-document` (open PR) · `main` @ `e0f7f712`  
+**Open PRs**: ADR-077 A6 validate/document  
 **Open issues**: none  
 
 ---
@@ -25,6 +25,8 @@
 | 8 | Gap tasks (#891) | ADR-074 docs, pattern extract command (G-P1-12), coverage | ✅ |
 | 9 | R-F8 + R-F9 (#893) | CLI relationship box-drawing panel + HNSW persistence/eviction | ✅ |
 | 10 | 6 domain skills | checkpoint-handoff, embedding-ops, episode-relationships, episode-tags, playbook-ops, recommendation-feedback (40 total) | ✅ |
+| 11 | ADR-077 A1-A5 | Runtime embedding activation: exact-provider factory, atomic runtime seam, MCP end-to-end (main `9ef4b742`, `e0f7f712`) | ✅ |
+| 12 | ADR-077 A6 | Validate/document/gate: activation docs + concurrency + zero-unsafe credential-redaction regression tests | ✅ this PR |
 
 ---
 

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -1,17 +1,17 @@
 # Project Status — Self-Learning Memory System
 
-**Last Updated**: 2026-07-25  
+**Last Updated**: 2026-07-26  
 **Released Version**: v0.1.36  
 **Workspace Version**: 0.1.37  
 **Edition**: Rust 2024  
-**Active plan**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`  
-**Branch**: `main` @ `5b4b9776`  
+**Active plan**: `plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md` (A1-A6 complete)  
+**Branch**: `feat/adr077-a6-validate-document` (open PR) · `main` @ `e0f7f712`  
 
 ## Open tracker (live)
 
 | Kind | Items |
 |------|--------|
-| Open PRs | *(none)* |
+| Open PRs | ADR-077 A6 validate/document |
 | Open issues | *(none)* |
 
 ## Snapshot
@@ -27,7 +27,9 @@
 | Skill evals / routes | 40/40 |
 | R-F8 relationship info show polish | ✅ #893 |
 | R-F9 HNSW persistence + eviction | ✅ #893 |
-| 6 new domain skills added | ✅ this PR |
+| 6 new domain skills added | ✅ #894 |
+| ADR-077 runtime embedding activation (A1-A5) | ✅ main (`9ef4b742`, `e0f7f712`) |
+| ADR-077 A6 validate / document / gate | ✅ this PR |
 | Code execution | Fail-closed (S1.1c NO-GO) |
 | MCP provenance (`with_provenance`) | ✅ |
 | P0 plan gaps | **None open** |
@@ -52,6 +54,8 @@
 | Recommendations #878 | ✅ Merged |
 | R-F8 CLI relationship panel + R-F9 HNSW #893 | ✅ Merged |
 | 6 new domain skills (40 total, all routed) | ✅ Merged |
+| ADR-077 runtime embedding activation A1-A5 | ✅ Merged (main) |
+| ADR-077 A6 validate / document / gate | ✅ this PR |
 
 ## Canonical companions
 

--- a/plans/STATUS/GAP_ANALYSIS_LATEST.md
+++ b/plans/STATUS/GAP_ANALYSIS_LATEST.md
@@ -1,7 +1,7 @@
-# Gap Analysis — 2026-07-25
+# Gap Analysis — 2026-07-26
 
-**Generated**: 2026-07-25  
-**Audit commit**: `5b4b9776` (`main`)  
+**Generated**: 2026-07-26  
+**Audit commit**: `e0f7f712` (`main`) + open PR `feat/adr077-a6-validate-document`  
 **Workspace**: `0.1.37` · **Tag**: `v0.1.36` (published 2026-07-22)  
 **Full backlog**: [`../GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`](../GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md)
 
@@ -26,7 +26,9 @@
 | G-P1-10 open hygiene/perf PRs | ✅ #887, #888, #889, #891, #893 all merged |
 | R-F8 relationship show polish (GO spike) | ✅ #893 — box-drawing panel + unit tests |
 | R-F9 HNSW persistence + eviction (GO spike) | ✅ #893 — file_dump/load + capacity eviction |
-| Skill count 34, 6 domain skills untracked | ✅ 40 skills, all routed (this PR) |
+| Skill count 34, 6 domain skills untracked | ✅ 40 skills, all routed (#894) |
+| ADR-077 runtime embedding activation A1-A5 | ✅ main (`9ef4b742`, `e0f7f712`) — exact-provider factory + atomic runtime seam + MCP end-to-end |
+| ADR-077 A6 validate / document / gate | ✅ this PR — activation docs + concurrency + zero-unsafe credential-redaction regression tests |
 
 ## Open gaps (current)
 

--- a/plans/STATUS/VALIDATION_LATEST.md
+++ b/plans/STATUS/VALIDATION_LATEST.md
@@ -1,7 +1,7 @@
-# Validation Latest — 2026-07-25
+# Validation Latest — 2026-07-26
 
-**Goal**: Reconcile plans trackers with live post-v0.1.36 + post-#893 state.  
-**Workspace**: `0.1.37` · **Tag**: `v0.1.36` · **HEAD**: `5b4b9776`  
+**Goal**: Reconcile plans trackers with live post-v0.1.36 + ADR-077 (A1-A6) state.  
+**Workspace**: `0.1.37` · **Tag**: `v0.1.36` · **HEAD**: `e0f7f712` + open PR `feat/adr077-a6-validate-document`  
 
 ## Evidence
 
@@ -18,6 +18,8 @@
 | ADR-071 | auto-checkpoint on Abstained | ✅ Implemented |
 | ADR-072 | authority + governance | ✅ Implemented |
 | ADR-073 | S1.1c NO-GO, fail-closed | ✅ Implemented |
+| ADR-077 A1-A5 | runtime embedding activation (exact factory, atomic seam, MCP e2e) | ✅ main `9ef4b742`/`e0f7f712` |
+| ADR-077 A6 | activation docs + concurrency + zero-unsafe redaction regression tests | ✅ this PR |
 | Prod `todo!` / unimplemented | live search | 0 |
 
 ## Closed validation goals
@@ -32,11 +34,13 @@
 | R-F9 HNSW persistence | ✅ #893 |
 | 6 new domain skills (40 total) | ✅ #894 |
 | ADR-071/072/073 status updated | ✅ #894 |
+| ADR-077 runtime embedding activation A1-A5 | ✅ main (`9ef4b742`, `e0f7f712`) |
+| ADR-077 A6 validate / document / gate | ✅ this PR |
 
 ## Still open after this validation
 
 | Item | Next step |
 |------|-----------|
-| #894 | Merge when CI CLEAN |
+| ADR-077 A6 PR | Merge when CI CLEAN |
 | R-F* remaining | DEFER until individual GO spikes |
 | v0.1.37 release | Trigger when unreleased commits accumulate |


### PR DESCRIPTION
## Summary

Completes work package **REA-2026-07-26-A6 (validate / document / gate)** of [ADR-077](plans/adr/ADR-077-Runtime-Embedding-Provider-Activation.md). A1-A5 were already merged to `main` (`9ef4b742`, `e0f7f712`); this PR adds the user documentation and the validation/regression tests, and refreshes the plans trackers. The A6 work package was the only remaining item — the GOAP plan still read "Proposed / no production code changed".

## What's included

**Documentation (A6.4)**
- `docs/API_REFERENCE.md`: a "Runtime activation contract (ADR-077)" note — success means the provider is live; selectable providers `local`/`openai`/`mistral`; `azure`/`custom`/`cohere` rejected before any credential or network work; credentials runtime-only and never echoed; failure preserves the prior provider; `activation_revision` / `reindex_required` / `provider_health` fields; runtime-only, not persisted.
- `docs/EMBEDDINGS_CLI_GUIDE.md`: a "Runtime Provider Activation (MCP)" section (provider/credential/feature table, response fields, reindex behavior, failure semantics).

**Tests (A6.2, A6.3)**
- `test_concurrent_reads_during_activation_replacement` (memory-core): 8 readers + 1 writer on a **multi-thread** runtime prove reads during a replacement never deadlock/panic/observe a torn slot, and the final revision equals the write count (ADR-077 §4).
- `test_configure_embeddings_output_contract_has_no_credential_field` (memory-mcp): structural guard that the output type exposes exactly the non-secret field set.
- `test_configure_embeddings_credential_error_names_var_not_value` (memory-mcp): behavioral guard that a missing-credential error names the env var but carries no credential material — **zero `unsafe`** (no process-env mutation).

**Plans**
- `GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md`: Proposed → Implemented with an A1-A6 evidence table.
- Trackers refreshed: GOAP_STATE, CURRENT, ROADMAP_ACTIVE, GOALS, ACTIONS, GAP_ANALYSIS_LATEST, VALIDATION_LATEST.

## Verification (all green)

- `cargo fmt --check` ✅
- `./scripts/code-quality.sh clippy --workspace` ✅ and strict `cargo clippy -p do-memory-core -p do-memory-mcp --all-targets -- -D warnings` ✅ (zero warnings even without the CI allow-flags)
- `./scripts/build-rust.sh check` ✅
- `cargo nextest run --all` → **3675 passed** ✅
- `cargo test --doc` ✅ · `cargo doc --no-deps --document-private-items` ✅

An independent `code-reviewer` pass found **no blockers**; SHOULD-FIX/NIT findings were addressed (removed a "typed error" overclaim, made the concurrency test genuinely parallel, fixed stale `ConfigureEmbeddingsOutput` rustdoc, tightened "monotonic"/"reindex" wording).

## Pre-existing follow-ups (out of scope, not touched here)

- Local `quality-gates.sh` file-size gate flags 3 files >500 LOC (`memory-cli/.../extract.rs`, `relationships/types.rs`, `semantic_service.rs`). These pre-date this PR, are **not** modified here, and the gate is **not run by PR CI** (`ci.yml`'s quality-gates job runs `cargo-deny` + `cargo-llvm-cov` only). Worth a dedicated split-up PR.
- `ActivationError` (`memory-mcp/.../embeddings/errors.rs`) is defined but never constructed (rejections use `anyhow!`). Docs were corrected to not claim a typed error; wiring the enum is a follow-up.
- `disable_wasm_for_tests` uses `unsafe { set_var }` (same anti-pattern removed from the new tests). It genuinely needs to set env before server creation and has no seam; removing it is a separate change.

## References
- ADR-077: `plans/adr/ADR-077-Runtime-Embedding-Provider-Activation.md`
- Plan: `plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md`