### PR TITLE
docs(plans): reconcile trackers to post-ADR-077 (#897) merged state

### DIFF
--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -19,7 +19,7 @@
 | ACT-321 | R-F9 HNSW persistence + capacity eviction | R-F9 | ✅ #893 merged |
 | ACT-322 | Add 6 domain skills (40 total, all routed) | skills | ✅ #894 |
 | ACT-323 | ADR-077 A1-A5 runtime embedding activation | ADR-077 | ✅ main (`9ef4b742`, `e0f7f712`) |
-| ACT-324 | ADR-077 A6 validate/document/gate (docs + concurrency + zero-unsafe redaction tests) | ADR-077 | ✅ this PR |
+| ACT-324 | ADR-077 A6 validate/document/gate (docs + concurrency + zero-unsafe redaction tests) | ADR-077 | ✅ #897 merged |
 | ACT-312 | Optional product/research spikes R-F1…R-F7, R-F10 | R-F* | ⏸ DEFER |
 
 All ACT-300…ACT-324 items are **complete**. No open code actions remain.

--- a/plans/GOALS.md
+++ b/plans/GOALS.md
@@ -30,7 +30,7 @@ No open code goals. Next trigger: decide to cut v0.1.37 or begin a P2 spike.
 | R-F8 CLI relationship show polish + R-F9 HNSW persistence | ✅ #893 |
 | 6 new domain skills (40 total, all routed) | ✅ #894 |
 | ADR-077 runtime embedding activation A1-A5 | ✅ main (`9ef4b742`, `e0f7f712`) |
-| ADR-077 A6 validate / document / gate | ✅ this PR |
+| ADR-077 A6 validate / document / gate | ✅ #897 merged |
 | Full gap audit — 0 P0/P1 code gaps | ✅ 2026-07-25 |
 
 ## Completed goal series (pointer only)

--- a/plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md
+++ b/plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md
@@ -1,6 +1,6 @@
 # GOAP: Runtime Embedding Provider Activation
 
-- **Status**: Implemented — A1-A6 complete (code `9ef4b742`, coverage `e0f7f712`, A6 validate/document this PR)
+- **Status**: Implemented — A1-A6 complete (code `9ef4b742`, coverage `e0f7f712`, A6 validate/document #897 merged)
 - **Date**: 2026-07-26
 - **Audit checkout**: `main` at `7c854efb`
 - **Decision**: [ADR-077](adr/ADR-077-Runtime-Embedding-Provider-Activation.md) — Accepted / Implemented
@@ -16,7 +16,7 @@
 | REA-2026-07-26-A3 exact-provider factory | ✅ Done | `9ef4b742` — `SemanticService::build_exact` (no fallback), feature-gated OpenAI/Mistral, dimension validation |
 | REA-2026-07-26-A4 identity / invalidation | ✅ Done | `9ef4b742` — `provider:model:dimension` identity, `reindex_required`, revision participates in ADR-074 identity |
 | REA-2026-07-26-A5 MCP end-to-end | ✅ Done | `9ef4b742` — `configure_embeddings` activates live; status/generate/query/search read `live_semantic_service()` |
-| REA-2026-07-26-A6 validate / document / gate | ✅ Done | coverage `e0f7f712`; concurrency + credential-redaction regression tests and `docs/API_REFERENCE.md` + `docs/EMBEDDINGS_CLI_GUIDE.md` activation docs (this PR) |
+| REA-2026-07-26-A6 validate / document / gate | ✅ Done | coverage `e0f7f712`; concurrency + credential-redaction regression tests and `docs/API_REFERENCE.md` + `docs/EMBEDDINGS_CLI_GUIDE.md` activation docs (#897 merged) |
 
 ## Analysis
 

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -2,8 +2,8 @@
 
 - **Last Updated**: 2026-07-26  
 - **Version**: workspace `0.1.37` · latest tag `v0.1.36`  
-- **Branch**: `feat/adr077-a6-validate-document` (open PR) · `main` @ `e0f7f712`  
-- **Open PRs**: ADR-077 A6 validate/document  
+- **Branch**: `main` @ `648e11ad`  
+- **Open PRs**: none  
 - **Open issues**: none  
 - **Active plan**: `plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md` (A1-A6 complete)  
 - **Archive**: `plans/archive/2026-07-consolidation/`  
@@ -25,7 +25,7 @@
 | R-F9 HNSW persistence + hardening | ✅ #893 |
 | 6 new domain skills (40 total, all routed) | ✅ #894 |
 | ADR-077 runtime embedding activation (A1-A5) | ✅ main (`9ef4b742`, `e0f7f712`) |
-| ADR-077 A6 validate / document / gate | ✅ this PR |
+| ADR-077 A6 validate / document / gate | ✅ #897 merged |
 | R-F* remaining product epics | ⏸ DEFER |
 
 ---
@@ -70,5 +70,5 @@ pattern_extract_command           = true  (ADR-076 §5 — G-P1-12, #891)
 r_f8_relationship_show_polish     = true  (#893 — box-drawing panel + unit tests)
 r_f9_hnsw_persistence             = true  (#893 — file_dump/load + capacity eviction)
 skill_count_40_all_routed         = true  (checkpoint-handoff, embedding-ops, episode-relationships, episode-tags, playbook-ops, recommendation-feedback)
-runtime_embedding_activation      = true  (ADR-077 Implemented A1-A6 — configure_embeddings activates exact provider; A6 docs + concurrency/redaction regression tests this PR)
+runtime_embedding_activation      = true  (ADR-077 Implemented A1-A6 — configure_embeddings activates exact provider; A6 docs + concurrency/redaction regression tests #897 merged)
 ```

--- a/plans/README.md
+++ b/plans/README.md
@@ -2,8 +2,8 @@
 
 **Workspace**: `0.1.37` (post-release) · **Released tag**: `v0.1.36` · **Next**: `v0.1.37`  
 **Active plan**: [GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md](GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md)  
-**Last Updated**: 2026-07-23  
-**Open PRs**: #889 (plans progress), #888 (perf), #887 (changelog) · **Open issues**: none  
+**Last Updated**: 2026-07-26  
+**Open PRs**: *(none)* · **Open issues**: none  
 **Policy**: ADR-039 (canonical active set) + ADR-072 (authority / release path)
 
 ## Quick Navigation

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -5,8 +5,8 @@
 **Workspace Version**: 0.1.37 (next release)  
 **Active Sprint**: ADR-077 runtime embedding activation (A1-A6 complete)  
 **Plan**: `plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md`  
-**Branch**: `feat/adr077-a6-validate-document` (open PR) · `main` @ `e0f7f712`  
-**Open PRs**: ADR-077 A6 validate/document  
+**Branch**: `main` @ `648e11ad`  
+**Open PRs**: none  
 **Open issues**: none  
 
 ---
@@ -26,7 +26,7 @@
 | 9 | R-F8 + R-F9 (#893) | CLI relationship box-drawing panel + HNSW persistence/eviction | ✅ |
 | 10 | 6 domain skills | checkpoint-handoff, embedding-ops, episode-relationships, episode-tags, playbook-ops, recommendation-feedback (40 total) | ✅ |
 | 11 | ADR-077 A1-A5 | Runtime embedding activation: exact-provider factory, atomic runtime seam, MCP end-to-end (main `9ef4b742`, `e0f7f712`) | ✅ |
-| 12 | ADR-077 A6 | Validate/document/gate: activation docs + concurrency + zero-unsafe credential-redaction regression tests | ✅ this PR |
+| 12 | ADR-077 A6 | Validate/document/gate: activation docs + concurrency + zero-unsafe credential-redaction regression tests | ✅ #897 merged |
 
 ---
 

--- a/plans/STATUS/CODEBASE_ANALYSIS_LATEST.md
+++ b/plans/STATUS/CODEBASE_ANALYSIS_LATEST.md
@@ -1,6 +1,6 @@
-# Codebase Analysis Latest — 2026-07-25
+# Codebase Analysis Latest — 2026-07-26
 
-**Branch**: `main` @ `5b4b9776`  
+**Branch**: `main` @ `648e11ad`  
 **Workspace**: `0.1.37` · **Released tag**: `v0.1.36`  
 **Companion**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`
 
@@ -28,7 +28,7 @@
 | Skills with evals / routes | 40/40 |
 | Fail-closed code execution | Preserved (ADR-073) |
 | Open issues | **0** |
-| Open PRs | **1** (#894 skills+plans, CI green) |
+| Open PRs | **0** (none) |
 | ADR-071 | Accepted / Implemented (auto-checkpoint on Abstained) |
 | ADR-072 | Accepted / Implemented (authority + governance) |
 | ADR-073 | Accepted / Implemented (S1.1c NO-GO, fail-closed) |
@@ -50,7 +50,7 @@
 
 ## Recommended focus order
 
-1. Merge #894 (skills+plans) when CI CLEAN.  
+1. #894 merged; ADR-077 A6 merged #897 — no open PRs.  
 2. Cut v0.1.37 once sufficient unreleased commits accumulate.  
 3. Research spikes only after individual GO artifacts under `plans/STATUS/spikes/`.
 

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -5,13 +5,13 @@
 **Workspace Version**: 0.1.37  
 **Edition**: Rust 2024  
 **Active plan**: `plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md` (A1-A6 complete)  
-**Branch**: `feat/adr077-a6-validate-document` (open PR) · `main` @ `e0f7f712`  
+**Branch**: `main` @ `648e11ad`
 
 ## Open tracker (live)
 
 | Kind | Items |
 |------|--------|
-| Open PRs | ADR-077 A6 validate/document |
+| Open PRs | *(none)* |
 | Open issues | *(none)* |
 
 ## Snapshot
@@ -29,7 +29,7 @@
 | R-F9 HNSW persistence + eviction | ✅ #893 |
 | 6 new domain skills added | ✅ #894 |
 | ADR-077 runtime embedding activation (A1-A5) | ✅ main (`9ef4b742`, `e0f7f712`) |
-| ADR-077 A6 validate / document / gate | ✅ this PR |
+| ADR-077 A6 validate / document / gate | ✅ #897 merged |
 | Code execution | Fail-closed (S1.1c NO-GO) |
 | MCP provenance (`with_provenance`) | ✅ |
 | P0 plan gaps | **None open** |
@@ -55,7 +55,7 @@
 | R-F8 CLI relationship panel + R-F9 HNSW #893 | ✅ Merged |
 | 6 new domain skills (40 total, all routed) | ✅ Merged |
 | ADR-077 runtime embedding activation A1-A5 | ✅ Merged (main) |
-| ADR-077 A6 validate / document / gate | ✅ this PR |
+| ADR-077 A6 validate / document / gate | ✅ #897 merged |
 
 ## Canonical companions
 

--- a/plans/STATUS/GAP_ANALYSIS_LATEST.md
+++ b/plans/STATUS/GAP_ANALYSIS_LATEST.md
@@ -1,7 +1,7 @@
 # Gap Analysis — 2026-07-26
 
 **Generated**: 2026-07-26  
-**Audit commit**: `e0f7f712` (`main`) + open PR `feat/adr077-a6-validate-document`  
+**Audit commit**: `648e11ad` (`main`; ADR-077 A6 merged #897)  
 **Workspace**: `0.1.37` · **Tag**: `v0.1.36` (published 2026-07-22)  
 **Full backlog**: [`../GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`](../GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md)
 
@@ -28,7 +28,7 @@
 | R-F9 HNSW persistence + eviction (GO spike) | ✅ #893 — file_dump/load + capacity eviction |
 | Skill count 34, 6 domain skills untracked | ✅ 40 skills, all routed (#894) |
 | ADR-077 runtime embedding activation A1-A5 | ✅ main (`9ef4b742`, `e0f7f712`) — exact-provider factory + atomic runtime seam + MCP end-to-end |
-| ADR-077 A6 validate / document / gate | ✅ this PR — activation docs + concurrency + zero-unsafe credential-redaction regression tests |
+| ADR-077 A6 validate / document / gate | ✅ #897 merged — activation docs + concurrency + zero-unsafe credential-redaction regression tests |
 
 ## Open gaps (current)
 

--- a/plans/STATUS/VALIDATION_LATEST.md
+++ b/plans/STATUS/VALIDATION_LATEST.md
@@ -1,7 +1,7 @@
 # Validation Latest — 2026-07-26
 
 **Goal**: Reconcile plans trackers with live post-v0.1.36 + ADR-077 (A1-A6) state.  
-**Workspace**: `0.1.37` · **Tag**: `v0.1.36` · **HEAD**: `e0f7f712` + open PR `feat/adr077-a6-validate-document`  
+**Workspace**: `0.1.37` · **Tag**: `v0.1.36` · **HEAD**: `648e11ad` (main; ADR-077 A6 merged #897)  
 
 ## Evidence
 
@@ -10,7 +10,7 @@
 | Released tag | `v0.1.36` published 2026-07-22 | ✅ |
 | Workspace version | `Cargo.toml` `0.1.37` | ✅ |
 | Open issues | `gh issue list --state open` | empty |
-| Open PRs | #894 skills+plans (CI green) | live |
+| Open PRs | none | — |
 | R-A1 / R-A2 | ship + post-bump | ✅ closed |
 | R-E2 / docs integrity | #883 / #885 | ✅ merged |
 | R-F8 / R-F9 | #893 | ✅ merged |
@@ -19,7 +19,7 @@
 | ADR-072 | authority + governance | ✅ Implemented |
 | ADR-073 | S1.1c NO-GO, fail-closed | ✅ Implemented |
 | ADR-077 A1-A5 | runtime embedding activation (exact factory, atomic seam, MCP e2e) | ✅ main `9ef4b742`/`e0f7f712` |
-| ADR-077 A6 | activation docs + concurrency + zero-unsafe redaction regression tests | ✅ this PR |
+| ADR-077 A6 | activation docs + concurrency + zero-unsafe redaction regression tests | ✅ #897 merged |
 | Prod `todo!` / unimplemented | live search | 0 |
 
 ## Closed validation goals
@@ -35,12 +35,12 @@
 | 6 new domain skills (40 total) | ✅ #894 |
 | ADR-071/072/073 status updated | ✅ #894 |
 | ADR-077 runtime embedding activation A1-A5 | ✅ main (`9ef4b742`, `e0f7f712`) |
-| ADR-077 A6 validate / document / gate | ✅ this PR |
+| ADR-077 A6 validate / document / gate | ✅ #897 merged |
 
 ## Still open after this validation
 
 | Item | Next step |
 |------|-----------|
-| ADR-077 A6 PR | Merge when CI CLEAN |
+| ADR-077 A6 PR | ✅ Merged #897 |
 | R-F* remaining | DEFER until individual GO spikes |
 | v0.1.37 release | Trigger when unreleased commits accumulate |


### PR DESCRIPTION
Docs-only plans-truth reconciliation.

ADR-077 A6 (validate/document/gate) merged via #897 (merge commit `648e11ad` = current `main` HEAD). Several active trackers still referenced the old PR branch `feat/adr077-a6-validate-document`, interim commit `e0f7f712`, or said `this PR`/`open PR`.

## Changes
Replace stale references with the true post-merge state (A6 = #897 merged, main @ 648e11ad, no open PRs) across:
- `STATUS/CURRENT.md`, `STATUS/VALIDATION_LATEST.md`, `STATUS/GAP_ANALYSIS_LATEST.md`, `STATUS/CODEBASE_ANALYSIS_LATEST.md`
- `GOAP_STATE.md`, `ROADMAPS/ROADMAP_ACTIVE.md`, `GOALS.md`, `ACTIONS.md`, `README.md`
- `GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md`

Historical A1-A5 commit citations (`9ef4b742`/`e0f7f712`), immutable ADR prose, and `GATE_CONTRACT.md` policy text are intentionally left unchanged. No code changes; `plans/archive/` untouched (ADR-039).

## Validation
- `./scripts/validate-plans.sh --active-set --version-state --identifiers --links --adrs` -> EXIT 0 (the two ADR 25/54 duplicate-number WARNs are pre-existing documented aliases, G-P1-8).