### PR TITLE
chore: add .claude/worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ mcp-config-*.json
 # Claude local configuration files only
 .claude/**/*.local.*
 .claude/**/.local/
+.claude/worktrees/
 .blackboxcli/settings.json
 *.proptest-regressions
 .memory-traces/


### PR DESCRIPTION
Remove 3 stale git worktrees that caused release-manager.sh to report DIRTY worktree. Add .claude/worktrees/ to .gitignore to prevent recurrence. Required before v0.1.37 ship.