### PR TITLE
fix(ci): allow release commit type and prep v0.1.37 trackers

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -18,6 +18,7 @@ module.exports = {
         'ci',       // Changes to CI configuration files and scripts
         'chore',    // Other changes that don't modify src or test files
         'revert',   // Reverts a previous commit
+        'release',  // Release preparation (e.g. "release: prepare vX.Y.Z")
       ],
     ],
     // Subject must not be empty

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -1,7 +1,7 @@
 # Active Development Roadmap
 
 **Last Updated**: 2026-07-26  
-**Released Version**: v0.1.36 (latest tag)  
+**Released Version**: v0.1.37 (latest tag)  
 **Workspace Version**: 0.1.37 (next release)  
 **Active Sprint**: ADR-077 runtime embedding activation (A1-A6 complete)  
 **Plan**: `plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md`  

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -1,7 +1,7 @@
 # Project Status — Self-Learning Memory System
 
 **Last Updated**: 2026-07-27  
-**Released Version**: v0.1.36  
+**Released Version**: v0.1.37  
 **Workspace Version**: 0.1.37 (release preparation in progress)  
 **Edition**: Rust 2024  
 **Active plan**: `plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md` (A1-A6 complete)  


### PR DESCRIPTION
## Why

Quick Check on `main` failed (run 30293633317, **Commit Message Lint**): the v0.1.37 prep commit `c23f5752` uses type `release:`, which was not in commitlint's `type-enum`. Re-running cannot help, and the commit can't be rewritten (main is protected), so the fix is to allow the `release` type going forward.

Also completes release prep so `verify-release-state.sh` passes and `release-manager ship` can gate on docs matching the workspace version.

## Changes

1. **`commitlint.config.cjs`** — add `release` to `type-enum` so release-preparation commits (`release: prepare vX.Y.Z`) pass the commit-message lint.
2. **`ROADMAP_ACTIVE.md` / `STATUS/CURRENT.md`** — set `Released Version: v0.1.37` (was v0.1.36) to match workspace version 0.1.37. The `CHANGELOG.md [0.1.37]` section is already present from #907.

## Verification

- `verify-release-state.sh --check-unreleased` → **PASSED** (exit 0; only the informational "unreleased commits" warning).
- Both commits use valid types (`ci`, `chore`); PR title is conventional.

Unblocks shipping **v0.1.37** via `release-manager.sh ship --execute`.
