### PR TITLE
chore(release): bump workspace to 0.1.38 after shipping v0.1.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Workspace version advanced to **0.1.38** after shipping `v0.1.37` so release-drift
+  gates treat new commits as normal development (`version_not_advanced` no longer applies).
+
 ## [0.1.37] - 2026-07-27
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.1.37"
+version = "0.1.38"
 edition = "2024"
 authors = ["Self-Learning Memory Contributors"]
 license = "MIT"

--- a/memory-mcp/Cargo.toml
+++ b/memory-mcp/Cargo.toml
@@ -27,9 +27,9 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 # Local dependencies
-do-memory-core = { path = "../memory-core", version = "0.1.37", features = ["agentfs"] }
-do-memory-storage-turso = { path = "../memory-storage-turso", version = "0.1.37" }
-do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.37" }
+do-memory-core = { path = "../memory-core", version = "0.1.38", features = ["agentfs"] }
+do-memory-storage-turso = { path = "../memory-storage-turso", version = "0.1.38" }
+do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.38" }
 
 # MCP-specific dependencies
 parking_lot = "0.12.5"

--- a/memory-storage-redb/Cargo.toml
+++ b/memory-storage-redb/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/do-memory-storage-redb"
 
 [dependencies]
 # Core dependencies
-do-memory-core = { path = "../memory-core", version = "0.1.37" }
+do-memory-core = { path = "../memory-core", version = "0.1.38" }
 
 # Async runtime
 tokio = { workspace = true, features = ["full"] }

--- a/memory-storage-turso/Cargo.toml
+++ b/memory-storage-turso/Cargo.toml
@@ -34,8 +34,8 @@ compression-gzip = ["flate2"]
 
 [dependencies]
 # Core dependencies
-do-memory-core = { path = "../memory-core", version = "0.1.37", features = ["hybrid_search"] }
-do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.37" }
+do-memory-core = { path = "../memory-core", version = "0.1.38", features = ["hybrid_search"] }
+do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.38" }
 
 # Async runtime
 tokio = { workspace = true, features = ["full"] }

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -2,7 +2,7 @@
 
 **Last Updated**: 2026-07-26  
 **Released Version**: v0.1.37 (latest tag)  
-**Workspace Version**: 0.1.37 (next release)  
+**Workspace Version**: 0.1.38 (next release)  
 **Active Sprint**: ADR-077 runtime embedding activation (A1-A6 complete)  
 **Plan**: `plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md`  
 **Branch**: `main` @ `648e11ad`  

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -2,7 +2,7 @@
 
 **Last Updated**: 2026-07-27  
 **Released Version**: v0.1.37  
-**Workspace Version**: 0.1.37 (release preparation in progress)  
+**Workspace Version**: 0.1.38 (next release)  
 **Edition**: Rust 2024  
 **Active plan**: `plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md` (A1-A6 complete)  
 **Branch**: `main` @ `45c6eee8`


### PR DESCRIPTION
## Why

Post-release hygiene (AGENTS.md): advance the workspace version immediately after tagging `v0.1.37` so new `feat`/`fix` work is not flagged as `version_not_advanced` by the release-drift gate.

## Changes

- `Cargo.toml` `[workspace.package]` version `0.1.37` → `0.1.38` (inherited by all 9 member crates).
- Inter-crate dependency pins `0.1.37` → `0.1.38` in `memory-mcp`, `memory-storage-turso`, `memory-storage-redb`.
- `CHANGELOG.md`: add `[Unreleased]` note for the version advance.
- `ROADMAP_ACTIVE.md` / `STATUS/CURRENT.md`: workspace version → `0.1.38` (released version stays `v0.1.37`).

## Verification

- `cargo metadata` → all 9 crates report a consistent `0.1.38`.
- Version-only change; no code/perf impact → `skip-benchmarks` label applied.
