### PR TITLE
feat: implement PTA-A1/A2/A3 product truth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,7 +1684,7 @@ checksum = "2906d3628a885aa49a23b88e71f63e51ae8df41cd76652287f0a6179a11833a9"
 
 [[package]]
 name = "do-memory-benches"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1705,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-cli"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1740,7 +1740,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-core"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "agentfs-sdk",
  "anyhow",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-examples"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "anyhow",
  "do-memory-core",
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-mcp"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "agentfs-sdk",
  "anyhow",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-storage-redb"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-storage-turso"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1881,7 +1881,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-test-utils"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1910,7 +1910,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "e2e-tests"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/memory-cli/CLI_USER_GUIDE.md
+++ b/memory-cli/CLI_USER_GUIDE.md
@@ -463,27 +463,6 @@ do-memory-cli eval stats web-development
 do-memory-cli eval stats web-development --format json
 ```
 
-#### `do-memory-cli eval set-threshold`
-
-Set custom duration and step count thresholds for a domain.
-
-**Options:**
-- `--domain <DOMAIN>`: Domain to configure (required)
-- `--duration <SECONDS>`: Duration threshold in seconds
-- `--steps <NUM>`: Step count threshold
-
-**Examples:**
-```bash
-# Set duration threshold
-do-memory-cli eval set-threshold --domain web-development --duration 300
-
-# Set step count threshold
-do-memory-cli eval set-threshold --domain web-development --steps 15
-
-# Set both thresholds
-do-memory-cli eval set-threshold --domain web-development --duration 300 --steps 15
-```
-
 ### Meta Commands
 
 #### `do-memory-cli completion`

--- a/memory-cli/README.md
+++ b/memory-cli/README.md
@@ -363,15 +363,6 @@ do-memory-cli eval calibration --min-episodes 10
 do-memory-cli eval stats web-development
 ```
 
-#### Set Threshold
-```bash
-# Set duration threshold
-do-memory-cli eval set-threshold --domain web-development --duration 300
-
-# Set step count threshold
-do-memory-cli eval set-threshold --domain web-development --steps 15
-```
-
 ### Meta Commands
 
 #### Generate Completions (alias: `comp`)

--- a/memory-cli/src/commands/eval.rs
+++ b/memory-cli/src/commands/eval.rs
@@ -29,21 +29,6 @@ pub enum EvalCommands {
         #[arg(value_name = "DOMAIN")]
         domain: String,
     },
-
-    /// Set custom threshold for a domain (manual override)
-    SetThreshold {
-        /// Domain to configure
-        #[arg(long)]
-        domain: String,
-
-        /// Duration threshold in seconds
-        #[arg(long)]
-        duration: Option<f32>,
-
-        /// Step count threshold
-        #[arg(long)]
-        steps: Option<usize>,
-    },
 }
 
 #[derive(Debug, Serialize)]
@@ -388,32 +373,6 @@ pub async fn domain_stats(
 
     detail.write(&mut std::io::stdout(), &format)?;
     Ok(())
-}
-
-/// Set custom thresholds for a domain.
-///
-/// **WG-152 / ADR-055**: Custom per-domain threshold overrides require a
-/// persistence backend that does not yet exist in `SelfLearningMemory`. Rather
-/// than silently accept arguments and discard them, we return an explicit
-/// error so callers know the request was not honored.
-///
-/// Current adaptive-threshold behavior (no override needed):
-/// - Domains with 5+ completed episodes: adaptive calibration (median baseline)
-/// - Domains with <5 episodes: fixed defaults (60s, 10 steps)
-pub async fn set_threshold(
-    domain: String,
-    duration: Option<f32>,
-    steps: Option<usize>,
-    _memory: &do_memory_core::SelfLearningMemory,
-    _config: &Config,
-    _format: OutputFormat,
-) -> anyhow::Result<()> {
-    anyhow::bail!(
-        "Custom threshold overrides are not supported (no persistence backend).\n\
-         Requested: domain={domain}, duration={duration:?}, steps={steps:?}\n\
-         Adaptive calibration is used automatically once a domain has >=5 completed episodes.\n\
-         To inspect current calibration, run: `do-memory-cli eval show --domain {domain}`."
-    );
 }
 
 fn format_time(dt: chrono::DateTime<chrono::Utc>) -> String {

--- a/memory-cli/src/commands/mod.rs
+++ b/memory-cli/src/commands/mod.rs
@@ -206,11 +206,6 @@ pub async fn handle_eval_command(
             min_episodes,
         } => eval::calibration(domain, all, min_episodes, memory, config, format).await,
         EvalCommands::Stats { domain } => eval::domain_stats(domain, memory, config, format).await,
-        EvalCommands::SetThreshold {
-            domain,
-            duration,
-            steps,
-        } => eval::set_threshold(domain, duration, steps, memory, config, format).await,
     }
 }
 

--- a/memory-cli/src/commands/storage/commands.rs
+++ b/memory-cli/src/commands/storage/commands.rs
@@ -8,6 +8,7 @@ use crate::config::Config;
 use crate::errors::helpers;
 use crate::output::OutputFormat;
 
+use super::provenance::MetricValue;
 use super::types::*;
 
 // Command implementations
@@ -18,40 +19,31 @@ pub async fn storage_stats(
 ) -> anyhow::Result<()> {
     let (total_episodes, completed_episodes, total_patterns) = memory.get_stats().await;
 
-    // Get enhanced statistics from storage backends
-    let _storage_size_bytes = 0u64;
-    let cache_hit_rate = 0.0;
-    let last_sync = None;
+    // Heuristic size estimates. These are NOT measured through any backend
+    // interface; they are explicitly labeled `Estimated` in output (PTA-A2).
+    let episode_size_estimate = 2048u64; // ~2KB per episode
+    let pattern_size_estimate = 1024u64; // ~1KB per pattern
+    let storage_size_bytes = (total_episodes as u64) * episode_size_estimate
+        + (total_patterns as u64) * pattern_size_estimate;
 
-    // Estimate storage size based on counts (rough calculation)
-    // Note: We can't get detailed backend statistics through the trait interface
-    // In a full implementation, we'd need to extend the StorageBackend trait
-    let mut storage_size_bytes = 0u64;
-    storage_size_bytes += (total_episodes * 2048) as u64; // ~2KB per episode
-    storage_size_bytes += (total_patterns * 1024) as u64; // ~1KB per pattern
-
-    // Cache hit rate not available through trait interface
-    // Last sync timestamp not available through trait interface
-
-    // Calculate recent counts (last 24 hours) - this is an approximation
-    // In a full implementation, we'd query the storage backends with time filters
-    let recent_episodes = completed_episodes; // Approximation
-    let recent_patterns = 0; // Would need time-based queries
-
+    // Cache hit rate and last sync time are not exposed through the
+    // `StorageBackend` trait. Report them as unavailable rather than
+    // fabricating a zero hit rate or current timestamp.
     let stats = StorageStats {
         episodes: StorageStatsData {
             total_count: total_episodes,
-            recent_count: recent_episodes,
-            average_size_bytes: if total_episodes > 0 { 2048 } else { 0 }, // Estimate
+            completed_count: MetricValue::measured(completed_episodes),
+            average_size_bytes: MetricValue::estimated(episode_size_estimate),
         },
         patterns: StorageStatsData {
             total_count: total_patterns,
-            recent_count: recent_patterns,
-            average_size_bytes: if total_patterns > 0 { 1024 } else { 0 }, // Estimate
+            // Patterns have no completed concept; do not report 0 as measured.
+            completed_count: MetricValue::unavailable(),
+            average_size_bytes: MetricValue::estimated(pattern_size_estimate),
         },
-        storage_size_bytes,
-        cache_hit_rate,
-        last_sync,
+        storage_size_bytes: MetricValue::estimated(storage_size_bytes),
+        cache_hit_rate: MetricValue::unavailable(),
+        last_sync: MetricValue::unavailable(),
     };
 
     format.print_output(&stats)?;
@@ -430,53 +422,28 @@ pub async fn storage_health(
 }
 
 pub async fn connection_status(
-    memory: &do_memory_core::SelfLearningMemory,
+    _memory: &do_memory_core::SelfLearningMemory,
     _config: &Config,
     format: OutputFormat,
 ) -> anyhow::Result<()> {
-    let mut turso_info = ConnectionInfo {
-        active_connections: 0,
-        pool_size: 0,
-        queue_depth: 0,
-        last_activity: None,
-    };
-
-    let mut redb_info = ConnectionInfo {
-        active_connections: 0,
-        pool_size: 0,
-        queue_depth: 0,
-        last_activity: None,
-    };
-
-    // Get Turso connection info
-    // Note: Detailed pool statistics not available through StorageBackend trait
-    if memory.has_turso_storage() {
-        // Estimate connection info since we can't access pool stats through trait
-        turso_info.active_connections = 1; // At least one connection
-        turso_info.pool_size = 10; // Default pool size
-        turso_info.queue_depth = 0; // Not available through trait
-        turso_info.last_activity = Some(
-            chrono::Utc::now()
-                .format("%Y-%m-%d %H:%M:%S UTC")
-                .to_string(),
-        );
-    }
-
-    // Get redb connection info (simpler, single connection)
-    if memory.has_cache_storage() {
-        redb_info.active_connections = 1; // redb uses a single synchronous connection
-        redb_info.pool_size = 1;
-        redb_info.queue_depth = 0; // No queuing in redb
-        redb_info.last_activity = Some(
-            chrono::Utc::now()
-                .format("%Y-%m-%d %H:%M:%S UTC")
-                .to_string(),
-        );
-    }
+    // Pool telemetry is not exposed through the `StorageBackend` trait, so all
+    // connection metrics are reported as `Unavailable` regardless of
+    // configuration rather than fabricating active/pool/last-activity values
+    // (PTA-A2).
 
     let status = ConnectionStatus {
-        turso: turso_info,
-        redb: redb_info,
+        turso: ConnectionInfo {
+            active_connections: MetricValue::unavailable(),
+            pool_size: MetricValue::unavailable(),
+            queue_depth: MetricValue::unavailable(),
+            last_activity: MetricValue::unavailable(),
+        },
+        redb: ConnectionInfo {
+            active_connections: MetricValue::unavailable(),
+            pool_size: MetricValue::unavailable(),
+            queue_depth: MetricValue::unavailable(),
+            last_activity: MetricValue::unavailable(),
+        },
     };
 
     format.print_output(&status)?;

--- a/memory-cli/src/commands/storage/mod.rs
+++ b/memory-cli/src/commands/storage/mod.rs
@@ -2,8 +2,13 @@
 
 mod commands;
 mod journal;
+mod provenance;
 mod types;
 
 pub use commands::*;
 pub use journal::*;
+pub use provenance::*;
 pub use types::*;
+
+#[cfg(test)]
+mod tests;

--- a/memory-cli/src/commands/storage/provenance.rs
+++ b/memory-cli/src/commands/storage/provenance.rs
@@ -1,0 +1,103 @@
+//! Metric provenance types for truthful storage telemetry (PTA-A2).
+//!
+//! Every metric reported by the storage commands carries an explicit
+//! [`MetricProvenance`]: either it was measured through a backend interface,
+//! it is an explicitly labeled estimate, or it is unavailable. This prevents
+//! fabricated values (e.g. a zero cache-hit rate or a fixed connection-pool
+//! size) from being presented as observed telemetry.
+
+use serde::Serialize;
+
+/// Provenance of a reported metric value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetricProvenance {
+    /// Directly measured through a backend interface.
+    Measured,
+    /// Derived estimate; not a direct measurement.
+    Estimated,
+    /// Not available through current backend interfaces.
+    Unavailable,
+}
+
+/// A metric value with explicit provenance.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct MetricValue<T> {
+    /// The value, or `None` when unavailable.
+    pub value: Option<T>,
+    /// How the value was obtained.
+    pub provenance: MetricProvenance,
+}
+
+impl<T> MetricValue<T> {
+    /// Build a directly measured metric.
+    pub fn measured(value: T) -> Self {
+        Self {
+            value: Some(value),
+            provenance: MetricProvenance::Measured,
+        }
+    }
+
+    /// Build an explicitly estimated metric.
+    pub fn estimated(value: T) -> Self {
+        Self {
+            value: Some(value),
+            provenance: MetricProvenance::Estimated,
+        }
+    }
+
+    /// Build a metric that is not available through current interfaces.
+    pub fn unavailable() -> Self {
+        Self {
+            value: None,
+            provenance: MetricProvenance::Unavailable,
+        }
+    }
+
+    /// Whether no real value is reported (unavailable provenance or no value).
+    pub fn is_unavailable(&self) -> bool {
+        matches!(self.provenance, MetricProvenance::Unavailable) || self.value.is_none()
+    }
+}
+
+impl<T: std::fmt::Display> MetricValue<T> {
+    /// Render for human output: value, `value (estimate)`, or `unavailable`.
+    pub fn render(&self) -> String {
+        self.render_with_suffix("")
+    }
+
+    /// Render for human output with a unit suffix, e.g. `2048 bytes (estimate)`.
+    pub fn render_with_suffix(&self, suffix: &str) -> String {
+        match (self.provenance, self.value.as_ref()) {
+            (MetricProvenance::Measured, Some(v)) => format!("{v}{suffix}"),
+            (MetricProvenance::Estimated, Some(v)) => format!("{v}{suffix} (estimate)"),
+            _ => "unavailable".to_string(),
+        }
+    }
+}
+
+impl MetricValue<u64> {
+    /// Render as megabytes, labeling estimates and unavailable metrics.
+    pub fn render_mb(&self) -> String {
+        match (self.provenance, self.value) {
+            (MetricProvenance::Measured, Some(v)) => {
+                format!("{:.2} MB", v as f32 / 1_000_000.0)
+            }
+            (MetricProvenance::Estimated, Some(v)) => {
+                format!("{:.2} MB (estimate)", v as f32 / 1_000_000.0)
+            }
+            _ => "unavailable".to_string(),
+        }
+    }
+}
+
+impl MetricValue<f32> {
+    /// Render as a percentage, labeling estimates and unavailable metrics.
+    pub fn render_percent(&self) -> String {
+        match (self.provenance, self.value) {
+            (MetricProvenance::Measured, Some(v)) => format!("{:.1}%", v * 100.0),
+            (MetricProvenance::Estimated, Some(v)) => format!("{:.1}% (estimate)", v * 100.0),
+            _ => "unavailable".to_string(),
+        }
+    }
+}

--- a/memory-cli/src/commands/storage/tests.rs
+++ b/memory-cli/src/commands/storage/tests.rs
@@ -1,0 +1,267 @@
+//! Unit tests for storage telemetry provenance (PTA-A2).
+//!
+//! Verifies that `MetricValue`/`MetricProvenance` behave correctly, that JSON
+//! output carries provenance, and that human output labels estimates and
+//! unavailable metrics truthfully.
+
+use super::provenance::{MetricProvenance, MetricValue};
+use super::types::{ConnectionInfo, ConnectionStatus, StorageStats, StorageStatsData};
+use crate::output::Output;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+fn sample_stats() -> StorageStats {
+    StorageStats {
+        episodes: StorageStatsData {
+            total_count: 5,
+            completed_count: MetricValue::measured(3),
+            average_size_bytes: MetricValue::estimated(2048),
+        },
+        patterns: StorageStatsData {
+            total_count: 2,
+            completed_count: MetricValue::unavailable(),
+            average_size_bytes: MetricValue::estimated(1024),
+        },
+        storage_size_bytes: MetricValue::estimated(5 * 2048 + 2 * 1024),
+        cache_hit_rate: MetricValue::unavailable(),
+        last_sync: MetricValue::unavailable(),
+    }
+}
+
+fn unavailable_connections() -> ConnectionStatus {
+    ConnectionStatus {
+        turso: ConnectionInfo {
+            active_connections: MetricValue::unavailable(),
+            pool_size: MetricValue::unavailable(),
+            queue_depth: MetricValue::unavailable(),
+            last_activity: MetricValue::unavailable(),
+        },
+        redb: ConnectionInfo {
+            active_connections: MetricValue::unavailable(),
+            pool_size: MetricValue::unavailable(),
+            queue_depth: MetricValue::unavailable(),
+            last_activity: MetricValue::unavailable(),
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MetricValue constructors and provenance
+// ---------------------------------------------------------------------------
+
+#[test]
+fn metric_value_measured_sets_value_and_provenance() {
+    // Arrange
+    let metric = MetricValue::measured(42usize);
+
+    // Act
+    let value = metric.value;
+    let provenance = metric.provenance;
+
+    // Assert
+    assert_eq!(value, Some(42));
+    assert_eq!(provenance, MetricProvenance::Measured);
+    assert!(!metric.is_unavailable());
+}
+
+#[test]
+fn metric_value_estimated_sets_value_and_provenance() {
+    // Arrange
+    let metric = MetricValue::estimated(2048u64);
+
+    // Act
+    let value = metric.value;
+    let provenance = metric.provenance;
+
+    // Assert
+    assert_eq!(value, Some(2048));
+    assert_eq!(provenance, MetricProvenance::Estimated);
+    assert!(!metric.is_unavailable());
+}
+
+#[test]
+fn metric_value_unavailable_has_no_value() {
+    // Arrange
+    let metric = MetricValue::<usize>::unavailable();
+
+    // Act
+    let value = metric.value;
+    let provenance = metric.provenance;
+
+    // Assert
+    assert_eq!(value, None);
+    assert_eq!(provenance, MetricProvenance::Unavailable);
+    assert!(metric.is_unavailable());
+}
+
+#[test]
+fn metric_provenance_serializes_snake_case() {
+    // Arrange
+    let cases = [
+        (MetricProvenance::Measured, "measured"),
+        (MetricProvenance::Estimated, "estimated"),
+        (MetricProvenance::Unavailable, "unavailable"),
+    ];
+
+    for (provenance, expected) in cases {
+        // Act
+        let json = serde_json::to_string(&provenance).unwrap();
+
+        // Assert
+        assert_eq!(json, format!("\"{expected}\""));
+    }
+}
+
+#[test]
+fn metric_value_render_labels_estimate_and_unavailable() {
+    // Arrange
+    let measured = MetricValue::measured(3usize);
+    let estimated = MetricValue::estimated(2048u64);
+    let unavailable = MetricValue::<usize>::unavailable();
+
+    // Act
+    let measured_render = measured.render();
+    let estimated_render = estimated.render_with_suffix(" bytes");
+    let unavailable_render = unavailable.render();
+
+    // Assert
+    assert_eq!(measured_render, "3");
+    assert_eq!(estimated_render, "2048 bytes (estimate)");
+    assert_eq!(unavailable_render, "unavailable");
+}
+
+// ---------------------------------------------------------------------------
+// JSON serialization carries provenance
+// ---------------------------------------------------------------------------
+
+#[test]
+fn storage_stats_json_includes_provenance() {
+    // Arrange
+    let stats = sample_stats();
+
+    // Act
+    let json = serde_json::to_value(&stats).unwrap();
+
+    // Assert
+    assert_eq!(json["episodes"]["total_count"], 5);
+    assert_eq!(
+        json["episodes"]["completed_count"],
+        serde_json::json!({ "value": 3, "provenance": "measured" })
+    );
+    assert_eq!(
+        json["episodes"]["average_size_bytes"],
+        serde_json::json!({ "value": 2048, "provenance": "estimated" })
+    );
+    // Patterns have no completed concept: unavailable, never 0 measured.
+    assert_eq!(
+        json["patterns"]["completed_count"],
+        serde_json::json!({ "value": null, "provenance": "unavailable" })
+    );
+    assert_eq!(
+        json["storage_size_bytes"],
+        serde_json::json!({ "value": 12288, "provenance": "estimated" })
+    );
+    assert_eq!(
+        json["cache_hit_rate"],
+        serde_json::json!({ "value": null, "provenance": "unavailable" })
+    );
+    assert_eq!(
+        json["last_sync"],
+        serde_json::json!({ "value": null, "provenance": "unavailable" })
+    );
+}
+
+#[test]
+fn connection_status_json_includes_provenance() {
+    // Arrange
+    let status = unavailable_connections();
+
+    // Act
+    let json = serde_json::to_value(&status).unwrap();
+
+    // Assert
+    for backend in ["turso", "redb"] {
+        for metric in [
+            "active_connections",
+            "pool_size",
+            "queue_depth",
+            "last_activity",
+        ] {
+            assert_eq!(
+                json[backend][metric],
+                serde_json::json!({ "value": null, "provenance": "unavailable" }),
+                "unexpected provenance for {backend}.{metric}"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Human output labels estimates and unavailable metrics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn storage_stats_human_output_labels_estimates_and_unavailable() {
+    // Arrange
+    let stats = sample_stats();
+
+    // Act
+    let mut buffer = Vec::new();
+    stats.write_human(&mut buffer).unwrap();
+    let output = String::from_utf8(buffer).unwrap();
+
+    // Assert
+    assert!(
+        output.contains("Completed: 3"),
+        "episodes completed must be shown"
+    );
+    assert!(
+        output.contains("Completed: unavailable"),
+        "patterns completed must be unavailable, not 0"
+    );
+    assert!(
+        output.contains("Avg Size: 2048 bytes (estimate)"),
+        "episode average size must be labeled as an estimate"
+    );
+    assert!(
+        output.contains("Total Size: 0.01 MB (estimate)"),
+        "storage size must be labeled as an estimate"
+    );
+    assert!(
+        output.contains("Cache Hit Rate: unavailable"),
+        "cache hit rate must be unavailable, never 0.0%"
+    );
+    assert!(
+        !output.contains("Last Sync"),
+        "unavailable last sync line should be omitted"
+    );
+}
+
+#[test]
+fn connection_status_human_output_marks_metrics_unavailable() {
+    // Arrange
+    let status = unavailable_connections();
+
+    // Act
+    let mut buffer = Vec::new();
+    status.write_human(&mut buffer).unwrap();
+    let output = String::from_utf8(buffer).unwrap();
+
+    // Assert
+    assert!(output.contains("Connection Status"));
+    assert!(output.contains("Turso:"));
+    assert!(output.contains("redb:"));
+    // No fabricated connection-pool values; every metric is unavailable.
+    assert_eq!(
+        output.matches("unavailable").count(),
+        8,
+        "all four metrics for both backends must be unavailable"
+    );
+    assert!(!output.contains("Active: 1"), "must not fabricate active=1");
+    assert!(
+        !output.contains("Pool Size: 10"),
+        "must not fabricate pool=10"
+    );
+}

--- a/memory-cli/src/commands/storage/tests.rs
+++ b/memory-cli/src/commands/storage/tests.rs
@@ -132,6 +132,33 @@ fn metric_value_render_labels_estimate_and_unavailable() {
     assert_eq!(unavailable_render, "unavailable");
 }
 
+#[test]
+fn metric_value_render_units_cover_all_provenances() {
+    // Arrange
+    let measured_mb = MetricValue::measured(1_000_000u64);
+    let estimated_mb = MetricValue::estimated(2_000_000u64);
+    let unavailable_mb = MetricValue::<u64>::unavailable();
+    let measured_pct = MetricValue::measured(0.5f32);
+    let estimated_pct = MetricValue::estimated(0.25f32);
+    let unavailable_pct = MetricValue::<f32>::unavailable();
+
+    // Act
+    let mb_measured = measured_mb.render_mb();
+    let mb_estimated = estimated_mb.render_mb();
+    let mb_unavailable = unavailable_mb.render_mb();
+    let pct_measured = measured_pct.render_percent();
+    let pct_estimated = estimated_pct.render_percent();
+    let pct_unavailable = unavailable_pct.render_percent();
+
+    // Assert
+    assert_eq!(mb_measured, "1.00 MB");
+    assert_eq!(mb_estimated, "2.00 MB (estimate)");
+    assert_eq!(mb_unavailable, "unavailable");
+    assert_eq!(pct_measured, "50.0%");
+    assert_eq!(pct_estimated, "25.0% (estimate)");
+    assert_eq!(pct_unavailable, "unavailable");
+}
+
 // ---------------------------------------------------------------------------
 // JSON serialization carries provenance
 // ---------------------------------------------------------------------------

--- a/memory-cli/src/commands/storage/tests.rs
+++ b/memory-cli/src/commands/storage/tests.rs
@@ -267,6 +267,26 @@ fn storage_stats_human_output_labels_estimates_and_unavailable() {
 }
 
 #[test]
+fn storage_stats_human_output_shows_last_sync_when_available() {
+    // Arrange
+    let stats = StorageStats {
+        last_sync: MetricValue::measured("2026-08-01T12:00:00Z".to_string()),
+        ..sample_stats()
+    };
+
+    // Act
+    let mut buffer = Vec::new();
+    stats.write_human(&mut buffer).unwrap();
+    let output = String::from_utf8(buffer).unwrap();
+
+    // Assert
+    assert!(
+        output.contains("Last Sync: 2026-08-01T12:00:00Z"),
+        "measured last sync must be shown, not omitted"
+    );
+}
+
+#[test]
 fn connection_status_human_output_marks_metrics_unavailable() {
     // Arrange
     let status = unavailable_connections();

--- a/memory-cli/src/commands/storage/types.rs
+++ b/memory-cli/src/commands/storage/types.rs
@@ -3,6 +3,7 @@
 use clap::Subcommand;
 use serde::Serialize;
 
+use super::provenance::MetricValue;
 use crate::output::Output;
 
 #[derive(Subcommand)]
@@ -40,20 +41,27 @@ pub enum StorageCommands {
     },
 }
 
+/// Storage statistics. Every non-count value carries explicit provenance so
+/// estimates and unavailable telemetry are never presented as measured.
 #[derive(Debug, Serialize)]
 pub struct StorageStats {
     pub episodes: StorageStatsData,
     pub patterns: StorageStatsData,
-    pub storage_size_bytes: u64,
-    pub cache_hit_rate: f32,
-    pub last_sync: Option<String>,
+    pub storage_size_bytes: MetricValue<u64>,
+    pub cache_hit_rate: MetricValue<f32>,
+    pub last_sync: MetricValue<String>,
 }
 
+/// Per-kind storage data. Total counts are measured; other values carry
+/// provenance (PTA-A2).
 #[derive(Debug, Serialize)]
 pub struct StorageStatsData {
+    /// Total stored entries (measured).
     pub total_count: usize,
-    pub recent_count: usize, // Last 24 hours
-    pub average_size_bytes: u64,
+    /// Completed entries (measured for episodes; unavailable for patterns).
+    pub completed_count: MetricValue<usize>,
+    /// Average entry size (heuristic estimate or unavailable).
+    pub average_size_bytes: MetricValue<u64>,
 }
 
 impl Output for StorageStats {
@@ -65,36 +73,48 @@ impl Output for StorageStats {
 
         writeln!(writer, "Episodes:")?;
         writeln!(writer, "  Total: {}", self.episodes.total_count)?;
-        writeln!(writer, "  Recent (24h): {}", self.episodes.recent_count)?;
         writeln!(
             writer,
-            "  Avg Size: {} bytes",
-            self.episodes.average_size_bytes
+            "  Completed: {}",
+            self.episodes.completed_count.render()
+        )?;
+        writeln!(
+            writer,
+            "  Avg Size: {}",
+            self.episodes
+                .average_size_bytes
+                .render_with_suffix(" bytes")
         )?;
 
         writeln!(writer, "\nPatterns:")?;
         writeln!(writer, "  Total: {}", self.patterns.total_count)?;
-        writeln!(writer, "  Recent (24h): {}", self.patterns.recent_count)?;
         writeln!(
             writer,
-            "  Avg Size: {} bytes",
-            self.patterns.average_size_bytes
+            "  Completed: {}",
+            self.patterns.completed_count.render()
+        )?;
+        writeln!(
+            writer,
+            "  Avg Size: {}",
+            self.patterns
+                .average_size_bytes
+                .render_with_suffix(" bytes")
         )?;
 
         writeln!(writer, "\nStorage:")?;
         writeln!(
             writer,
-            "  Total Size: {:.2} MB",
-            self.storage_size_bytes as f32 / 1_000_000.0
+            "  Total Size: {}",
+            self.storage_size_bytes.render_mb()
         )?;
         writeln!(
             writer,
-            "  Cache Hit Rate: {:.1}%",
-            self.cache_hit_rate * 100.0
+            "  Cache Hit Rate: {}",
+            self.cache_hit_rate.render_percent()
         )?;
 
-        if let Some(last_sync) = &self.last_sync {
-            writeln!(writer, "  Last Sync: {}", last_sync)?;
+        if !self.last_sync.is_unavailable() {
+            writeln!(writer, "  Last Sync: {}", self.last_sync.render())?;
         }
 
         Ok(())
@@ -190,18 +210,22 @@ impl Output for StorageHealth {
     }
 }
 
+/// Connection status for both backends (PTA-A2).
 #[derive(Debug, Serialize)]
 pub struct ConnectionStatus {
     pub turso: ConnectionInfo,
     pub redb: ConnectionInfo,
 }
 
+/// Per-backend connection info. Pool statistics are not exposed through the
+/// `StorageBackend` trait, so all metrics are reported as unavailable rather
+/// than fabricated (PTA-A2).
 #[derive(Debug, Serialize)]
 pub struct ConnectionInfo {
-    pub active_connections: usize,
-    pub pool_size: usize,
-    pub queue_depth: usize,
-    pub last_activity: Option<String>,
+    pub active_connections: MetricValue<usize>,
+    pub pool_size: MetricValue<usize>,
+    pub queue_depth: MetricValue<usize>,
+    pub last_activity: MetricValue<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -295,24 +319,30 @@ impl Output for ConnectionStatus {
         writeln!(writer, "Turso:")?;
         writeln!(
             writer,
-            "  Active: {}/{}",
-            self.turso.active_connections, self.turso.pool_size
+            "  Active: {}",
+            self.turso.active_connections.render()
         )?;
-        writeln!(writer, "  Queue: {}", self.turso.queue_depth)?;
-        if let Some(activity) = &self.turso.last_activity {
-            writeln!(writer, "  Last Activity: {}", activity)?;
-        }
+        writeln!(writer, "  Pool Size: {}", self.turso.pool_size.render())?;
+        writeln!(writer, "  Queue Depth: {}", self.turso.queue_depth.render())?;
+        writeln!(
+            writer,
+            "  Last Activity: {}",
+            self.turso.last_activity.render()
+        )?;
 
         writeln!(writer, "\nredb:")?;
         writeln!(
             writer,
-            "  Active: {}/{}",
-            self.redb.active_connections, self.redb.pool_size
+            "  Active: {}",
+            self.redb.active_connections.render()
         )?;
-        writeln!(writer, "  Queue: {}", self.redb.queue_depth)?;
-        if let Some(activity) = &self.redb.last_activity {
-            writeln!(writer, "  Last Activity: {}", activity)?;
-        }
+        writeln!(writer, "  Pool Size: {}", self.redb.pool_size.render())?;
+        writeln!(writer, "  Queue Depth: {}", self.redb.queue_depth.render())?;
+        writeln!(
+            writer,
+            "  Last Activity: {}",
+            self.redb.last_activity.render()
+        )?;
 
         Ok(())
     }

--- a/memory-cli/src/commands/storage/types.rs
+++ b/memory-cli/src/commands/storage/types.rs
@@ -73,45 +73,29 @@ impl Output for StorageStats {
 
         writeln!(writer, "Episodes:")?;
         writeln!(writer, "  Total: {}", self.episodes.total_count)?;
-        writeln!(
-            writer,
-            "  Completed: {}",
-            self.episodes.completed_count.render()
-        )?;
-        writeln!(
-            writer,
-            "  Avg Size: {}",
-            self.episodes
-                .average_size_bytes
-                .render_with_suffix(" bytes")
-        )?;
+        let episodes_completed = self.episodes.completed_count.render();
+        writeln!(writer, "  Completed: {}", episodes_completed)?;
+        let episodes_avg = self
+            .episodes
+            .average_size_bytes
+            .render_with_suffix(" bytes");
+        writeln!(writer, "  Avg Size: {}", episodes_avg)?;
 
         writeln!(writer, "\nPatterns:")?;
         writeln!(writer, "  Total: {}", self.patterns.total_count)?;
-        writeln!(
-            writer,
-            "  Completed: {}",
-            self.patterns.completed_count.render()
-        )?;
-        writeln!(
-            writer,
-            "  Avg Size: {}",
-            self.patterns
-                .average_size_bytes
-                .render_with_suffix(" bytes")
-        )?;
+        let patterns_completed = self.patterns.completed_count.render();
+        writeln!(writer, "  Completed: {}", patterns_completed)?;
+        let patterns_avg = self
+            .patterns
+            .average_size_bytes
+            .render_with_suffix(" bytes");
+        writeln!(writer, "  Avg Size: {}", patterns_avg)?;
 
         writeln!(writer, "\nStorage:")?;
-        writeln!(
-            writer,
-            "  Total Size: {}",
-            self.storage_size_bytes.render_mb()
-        )?;
-        writeln!(
-            writer,
-            "  Cache Hit Rate: {}",
-            self.cache_hit_rate.render_percent()
-        )?;
+        let total_size = self.storage_size_bytes.render_mb();
+        writeln!(writer, "  Total Size: {}", total_size)?;
+        let cache_hit = self.cache_hit_rate.render_percent();
+        writeln!(writer, "  Cache Hit Rate: {}", cache_hit)?;
 
         if !self.last_sync.is_unavailable() {
             writeln!(writer, "  Last Sync: {}", self.last_sync.render())?;
@@ -317,32 +301,20 @@ impl Output for ConnectionStatus {
         writeln!(writer, "{}", "─".repeat(40))?;
 
         writeln!(writer, "Turso:")?;
-        writeln!(
-            writer,
-            "  Active: {}",
-            self.turso.active_connections.render()
-        )?;
+        let turso_active = self.turso.active_connections.render();
+        writeln!(writer, "  Active: {}", turso_active)?;
         writeln!(writer, "  Pool Size: {}", self.turso.pool_size.render())?;
         writeln!(writer, "  Queue Depth: {}", self.turso.queue_depth.render())?;
-        writeln!(
-            writer,
-            "  Last Activity: {}",
-            self.turso.last_activity.render()
-        )?;
+        let turso_activity = self.turso.last_activity.render();
+        writeln!(writer, "  Last Activity: {}", turso_activity)?;
 
         writeln!(writer, "\nredb:")?;
-        writeln!(
-            writer,
-            "  Active: {}",
-            self.redb.active_connections.render()
-        )?;
+        let redb_active = self.redb.active_connections.render();
+        writeln!(writer, "  Active: {}", redb_active)?;
         writeln!(writer, "  Pool Size: {}", self.redb.pool_size.render())?;
         writeln!(writer, "  Queue Depth: {}", self.redb.queue_depth.render())?;
-        writeln!(
-            writer,
-            "  Last Activity: {}",
-            self.redb.last_activity.render()
-        )?;
+        let redb_activity = self.redb.last_activity.render();
+        writeln!(writer, "  Last Activity: {}", redb_activity)?;
 
         Ok(())
     }

--- a/memory-cli/src/main.rs
+++ b/memory-cli/src/main.rs
@@ -414,3 +414,32 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 }
+
+#[cfg(test)]
+mod cli_parsing_tests {
+    use super::Cli;
+    use clap::Parser;
+
+    #[test]
+    fn test_eval_stats_parses() {
+        let cli = Cli::try_parse_from(["do-memory-cli", "eval", "stats", "web-development"])
+            .expect("eval stats should parse");
+        assert!(matches!(cli.command, crate::Commands::Eval { .. }));
+    }
+
+    #[test]
+    fn test_eval_set_threshold_rejected() {
+        // The set-threshold subcommand was removed because no override model
+        // is persisted or consumed by reward calculation. Parsing must fail.
+        let result = Cli::try_parse_from([
+            "do-memory-cli",
+            "eval",
+            "set-threshold",
+            "--domain",
+            "web-development",
+            "--duration",
+            "300",
+        ]);
+        assert!(result.is_err());
+    }
+}

--- a/memory-cli/tests/snapshots/snapshot_tests__cli_eval_help.snap
+++ b/memory-cli/tests/snapshots/snapshot_tests__cli_eval_help.snap
@@ -7,10 +7,9 @@ Evaluation and calibration commands
 Usage: do-memory-cli eval <COMMAND>
 
 Commands:
-  calibration    View domain calibration statistics
-  stats          View detailed domain statistics
-  set-threshold  Set custom threshold for a domain (manual override)
-  help           Print this message or the help of the given subcommand(s)
+  calibration  View domain calibration statistics
+  stats        View detailed domain statistics
+  help         Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help

--- a/memory-core/src/retrieval/cascade/mod.rs
+++ b/memory-core/src/retrieval/cascade/mod.rs
@@ -13,7 +13,7 @@ mod concept_graph;
 pub use concept_graph::ConceptGraph;
 
 mod types;
-pub use types::{CascadeConfig, CascadeResult, TierResult};
+pub use types::{CascadeConfig, CascadeError, CascadeResult, TierResult};
 
 /// Cascading retrieval orchestrator.
 ///
@@ -115,26 +115,22 @@ impl CascadeRetriever {
     /// 3. ConceptGraph expansion (CPU-local, 0 API calls)
     /// 4. API fallback (requires external embedding call)
     ///
-    /// Without `csm`, returns empty results (placeholder behavior).
-    pub fn retrieve(&self, query: &str) -> CascadeResult {
+    /// Without `csm`, this method returns `Err(CascadeError::CapabilityUnavailable)`
+    /// rather than empty results.
+    pub fn retrieve(&self, query: &str) -> Result<CascadeResult, CascadeError> {
         #[cfg(feature = "csm")]
         {
-            self.retrieve_with_csm(query)
+            Ok(self.retrieve_with_csm(query))
         }
 
         #[cfg(not(feature = "csm"))]
         {
             tracing::warn!(
-                "CSM feature not enabled; cascade retrieval returns empty results. \
+                "CSM feature not enabled; cascade retrieval is unavailable. \
                  Enable the `csm` feature for BM25/HDC/ConceptGraph retrieval."
             );
             let _ = query;
-            CascadeResult {
-                episode_ids: Vec::new(),
-                scores: Vec::new(),
-                contributing_tiers: Vec::new(),
-                api_calls: 0,
-            }
+            Err(CascadeError::CapabilityUnavailable)
         }
     }
 
@@ -163,7 +159,12 @@ impl CascadeRetriever {
         if self.config.merge_results && !bm25_results.is_empty() {
             // Merge BM25 and HDC results with query-length-dependent weights
             let weights = compute_weights(query.len());
-            let merged = merge_results(&bm25_results.results, &hdc_results.results, weights);
+            let merged = merge_results(
+                &bm25_results.results,
+                &hdc_results.results,
+                weights,
+                self.config.top_k,
+            );
 
             // Check if merged results are sufficient
             if merged.len() >= self.config.min_results {
@@ -201,7 +202,12 @@ impl CascadeRetriever {
         // Return best available results with api_calls = 1 indicator
         let best_results: Vec<(String, f32)> = if self.config.merge_results {
             let weights = compute_weights(query.len());
-            merge_results(&bm25_results.results, &hdc_results.results, weights)
+            merge_results(
+                &bm25_results.results,
+                &hdc_results.results,
+                weights,
+                self.config.top_k,
+            )
         } else if !hdc_results.is_empty() {
             hdc_results.results.clone()
         } else {

--- a/memory-core/src/retrieval/cascade/tests.rs
+++ b/memory-core/src/retrieval/cascade/tests.rs
@@ -51,18 +51,26 @@ fn test_clear_episodes() {
     assert!(retriever.is_empty());
 }
 
+#[cfg(not(feature = "csm"))]
 #[test]
-fn test_placeholder_retrieve_without_csm() {
-    #[cfg(not(feature = "csm"))]
-    {
-        let mut retriever = CascadeRetriever::default_config();
-        retriever.add_episode("ep-1", "Test episode");
-        let result = retriever.retrieve("test query");
-        // Without CSM feature, returns empty results
-        assert!(result.episode_ids.is_empty());
-        assert!(result.scores.is_empty());
-        assert_eq!(result.api_calls, 0);
-    }
+fn test_retrieve_unavailable_without_csm() {
+    let retriever = CascadeRetriever::default_config();
+    // Without CSM feature, cascade retrieval is unavailable
+    assert!(matches!(
+        retriever.retrieve("test query"),
+        Err(CascadeError::CapabilityUnavailable)
+    ));
+}
+
+#[cfg(not(feature = "csm"))]
+#[test]
+fn test_non_csm_retriever_supports_episodes_and_reports_unavailable() {
+    let mut retriever = CascadeRetriever::default_config();
+    retriever.add_episode("ep-1", "Test episode");
+    assert_eq!(retriever.len(), 1);
+
+    let result = retriever.retrieve("test query");
+    assert!(matches!(result, Err(CascadeError::CapabilityUnavailable)));
 }
 
 #[test]
@@ -156,6 +164,21 @@ mod csm_tests {
     use super::*;
 
     #[test]
+    fn test_retrieve_returns_ok_with_csm() {
+        let mut retriever = CascadeRetriever::default_config();
+        retriever.add_episode("ep-1", "authentication JWT token implementation");
+        retriever.add_episode("ep-2", "authentication session management");
+        retriever.add_episode("ep-3", "authentication refresh token handling");
+
+        let result = retriever.retrieve("authentication JWT");
+
+        assert!(result.is_ok());
+        let result = result.expect("csm retrieve should succeed");
+        assert!(!result.episode_ids.is_empty());
+        assert_eq!(result.api_calls, 0);
+    }
+
+    #[test]
     fn test_bm25_exact_match_zero_api_calls() {
         let mut retriever = CascadeRetriever::default_config();
 
@@ -167,7 +190,9 @@ mod csm_tests {
         retriever.add_episode("ep-5", "error handling patterns in async code");
 
         // Query with exact keyword match should return 0 API calls
-        let result = retriever.retrieve("authentication JWT token");
+        let result = retriever
+            .retrieve("authentication JWT token")
+            .expect("csm retrieve should succeed");
 
         // Should find the matching episode
         assert!(!result.episode_ids.is_empty());
@@ -192,7 +217,9 @@ mod csm_tests {
         retriever.add_episode("ep-5", "fix memory leak in cache implementation");
 
         // Semantic-like query (similar words but not exact match)
-        let result = retriever.retrieve("user authentication and login security");
+        let result = retriever
+            .retrieve("user authentication and login security")
+            .expect("csm retrieve should succeed");
 
         // Should find related episodes
         assert!(!result.episode_ids.is_empty());
@@ -210,7 +237,9 @@ mod csm_tests {
         let retriever = CascadeRetriever::default_config();
 
         // Empty index should indicate API call needed
-        let result = retriever.retrieve("any query");
+        let result = retriever
+            .retrieve("any query")
+            .expect("csm retrieve should succeed");
 
         assert!(result.episode_ids.is_empty());
         // Should indicate API fallback needed
@@ -227,11 +256,15 @@ mod csm_tests {
         retriever.add_episode("ep-3", "unique_keyword_gamma optimization");
 
         // Query that matches exactly should hit BM25
-        let result = retriever.retrieve("unique_keyword_alpha");
+        let result = retriever
+            .retrieve("unique_keyword_alpha")
+            .expect("csm retrieve should succeed");
         assert!(result.contributing_tiers.contains(&"bm25".to_string()));
 
         // Query with no exact match but similar content should use HDC
-        let result = retriever.retrieve("implement alpha feature");
+        let result = retriever
+            .retrieve("implement alpha feature")
+            .expect("csm retrieve should succeed");
         // Either BM25 (if partial match) or HDC (if semantic similarity)
         assert!(!result.episode_ids.is_empty() || result.api_calls > 0);
     }
@@ -257,7 +290,9 @@ mod csm_tests {
         retriever.add_episode("ep-5", "async task spawning performance tips");
 
         // Query that matches multiple aspects
-        let result = retriever.retrieve("Rust async programming");
+        let result = retriever
+            .retrieve("Rust async programming")
+            .expect("csm retrieve should succeed");
 
         // Should have results from merging BM25 and HDC
         assert!(!result.episode_ids.is_empty());
@@ -283,7 +318,9 @@ mod csm_tests {
         retriever.add_episode("ep-1", "authentication implementation");
         retriever.add_episode("ep-2", "database connection setup");
 
-        let result = retriever.retrieve("authentication");
+        let result = retriever
+            .retrieve("authentication")
+            .expect("csm retrieve should succeed");
 
         // Without merge, should only use single tier
         assert!(result.contributing_tiers.len() <= 1);
@@ -319,7 +356,9 @@ mod csm_tests {
         retriever.add_episode("ep-2", "database pool connection");
         retriever.add_episode("ep-3", "rate limiting API");
 
-        let result = retriever.retrieve("authentication");
+        let result = retriever
+            .retrieve("authentication")
+            .expect("csm retrieve should succeed");
 
         // All scores should be in 0.0-1.0 range
         for score in &result.scores {
@@ -340,7 +379,9 @@ mod csm_tests {
             retriever.add_episode(&format!("ep-{i}"), &format!("episode {i} content"));
         }
 
-        let result = retriever.retrieve("episode");
+        let result = retriever
+            .retrieve("episode")
+            .expect("csm retrieve should succeed");
 
         // Should not exceed top_k
         assert!(result.episode_ids.len() <= 3);
@@ -395,7 +436,9 @@ mod csm_tests {
         retriever.add_episode("ep-5", "refactor error handling patterns");
 
         // Query with abbreviated terms that need expansion
-        let result = retriever.retrieve("fix auth bug");
+        let result = retriever
+            .retrieve("fix auth bug")
+            .expect("csm retrieve should succeed");
 
         // Should find results via concept graph expansion ("auth" → authentication domain)
         assert!(!result.episode_ids.is_empty());

--- a/memory-core/src/retrieval/cascade/types.rs
+++ b/memory-core/src/retrieval/cascade/types.rs
@@ -86,6 +86,26 @@ pub struct CascadeResult {
     pub api_calls: u32,
 }
 
+/// Error type for the cascading retrieval pipeline.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CascadeError {
+    /// The `csm` feature is disabled, so cascade retrieval is unavailable.
+    CapabilityUnavailable,
+}
+
+impl std::fmt::Display for CascadeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CascadeError::CapabilityUnavailable => write!(
+                f,
+                "cascade retrieval is unavailable without the `csm` feature"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CascadeError {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -202,5 +222,12 @@ mod tests {
         assert!((result.scores[1] - 0.8).abs() < f32::EPSILON);
         assert_eq!(result.contributing_tiers, vec!["bm25", "hdc"]);
         assert_eq!(result.api_calls, 0);
+    }
+
+    #[test]
+    fn cascade_error_capability_unavailable_construct_and_partial_eq() {
+        let error = CascadeError::CapabilityUnavailable;
+
+        assert_eq!(error, CascadeError::CapabilityUnavailable);
     }
 }

--- a/memory-core/src/retrieval/cascade/types.rs
+++ b/memory-core/src/retrieval/cascade/types.rs
@@ -230,4 +230,15 @@ mod tests {
 
         assert_eq!(error, CascadeError::CapabilityUnavailable);
     }
+
+    #[test]
+    fn cascade_error_display_and_error_impl() {
+        let error = CascadeError::CapabilityUnavailable;
+
+        assert!(
+            error.to_string().contains("unavailable"),
+            "display should describe the unavailable capability"
+        );
+        assert!(std::error::Error::source(&error).is_none());
+    }
 }

--- a/memory-core/src/retrieval/mod.rs
+++ b/memory-core/src/retrieval/mod.rs
@@ -35,7 +35,7 @@ pub use cache::{
     CacheKey, CacheMetrics, DEFAULT_CACHE_TTL, DEFAULT_MAX_ENTRIES, QueryCache,
     RANKING_CONFIG_VERSION, RetrievalProvenance, provider_cache_identity,
 };
-pub use cascade::{CascadeConfig, CascadeResult, CascadeRetriever};
+pub use cascade::{CascadeConfig, CascadeError, CascadeResult, CascadeRetriever};
 pub use gist::{EpisodeGist, GistExtractor, GistScoredItem, HierarchicalReranker, RerankConfig};
 pub use semantic_retriever::{HybridHit, ScoreComponents, SemanticRetriever};
 pub use shard::{EpisodeMetadata, RoutingResult, ScopeFilter, ShardConfig, ShardRouter, TimeRange};

--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -1,13 +1,29 @@
 # GOAP Actions Backlog
 
-- **Last Updated**: 2026-07-26  
-- **Active plan**: `plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md`  
+- **Last Updated**: 2026-07-30
+- **Active plan**: `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`
 - **Archived plans**: `plans/archive/2026-07-consolidation/`
 
-## Active actions (2026-07-25)
+## Active actions (2026-07-30)
 
 | ID | Action | Rec | Status |
 |----|--------|-----|--------|
+| ACT-334 | Accept ADR-079 and freeze the `CI / Required` aggregate contract | CIT-A1 | Proposed |
+| ACT-335 | Implement and fault-inject same-run required aggregation | CIT-A1 | Blocked by ADR acceptance |
+| ACT-336 | Fail closed on cancellation/missing/commitlint and restore Dependabot/fork assertion parity | CIT-A2 | Blocked by ACT-335 |
+| ACT-337 | Reconcile test/Clippy/quality scopes and add semantic gate-contract fixtures | CIT-A3 | Blocked by ACT-336 |
+| ACT-338 | Remove broken release dispatch and make publish selection/dependency planning truthful | CIT-A4 | Planned |
+| ACT-339 | Preserve fuzz/mutation evidence, then measure and remove duplicate CI work | CIT-A5 | Planned |
+| ACT-340 | With approval, require the verified aggregate in ruleset `9591004` and validate blocking | CIT-A1/PTA-A9 | Blocked by ACT-335…337 and maintainer approval |
+| ACT-325 | Make non-`csm` cascade retrieval capability-truthful | PTA-A1 | ✅ Implemented |
+| ACT-326 | Make CLI storage metrics measured/estimated/unavailable explicitly | PTA-A2 | ✅ Implemented |
+| ACT-327 | Hide unsupported `eval set-threshold` command | PTA-A3 | ✅ Implemented |
+| ACT-328 | Accept ADR-078 and freeze attributed contracts | RAT-A1 | Proposed |
+| ACT-329 | Add capability-aware checked attribution persistence | RAT-A2 | Blocked by ADR acceptance |
+| ACT-330 | Add core attributed pattern/playbook operations | RAT-A3 | Blocked by ACT-329 |
+| ACT-331 | Enforce session and feedback integrity | RAT-A4 | Blocked by ACT-330 |
+| ACT-332 | Wire optional attribution through MCP and CLI | RAT-A5/A6 | Blocked by ACT-331 |
+| ACT-333 | End-to-end validation, docs, and authority update | RAT-A7/PTA-A9 | Blocked by ACT-325…332 |
 | ACT-302 | `./scripts/release-manager.sh ship --execute` for `v0.1.36` | R-A1 | ✅ Done |
 | ACT-303 | Post-release workspace bump to 0.1.37 | R-A2 | ✅ #886 |
 | ACT-315 | Plans progress truth (open PRs, post-ship) | R-G* | ✅ #889 |
@@ -22,7 +38,9 @@
 | ACT-324 | ADR-077 A6 validate/document/gate (docs + concurrency + zero-unsafe redaction tests) | ADR-077 | ✅ #897 merged |
 | ACT-312 | Optional product/research spikes R-F1…R-F7, R-F10 | R-F* | ⏸ DEFER |
 
-All ACT-300…ACT-324 items are **complete**. No open code actions remain.
+All ACT-300…ACT-324 items are complete. ACT-325…ACT-340 are open and must not
+be marked complete without code, workflow, live-ruleset, and validation evidence
+as applicable.
 
 ## Completed actions (summary)
 
@@ -37,6 +55,8 @@ Full tables: `plans/archive/2026-07-consolidation/completed-sprints/`
 - Cross-process storage features → e2e CLI test  
 - No manual `gh release create`; use release-manager + `release.yml`  
 - No soft-pass on cargo deny / required cancelled checks  
+- Required status must be a causal same-run aggregate; an echo anchor is not a gate
+- Dependabot/fork trust changes permissions and secret access, not test assertions
 - Fail-closed `execute_agent_code` unless approved capability backend  
 - sha2 digests: use portable hex encode (not `format!("{:x}", finalize())` on 0.11+)  
 - Docs integrity: do not re-check `plans/archive/**` link rot as a ship blocker  

--- a/plans/GATE_CONTRACT.md
+++ b/plans/GATE_CONTRACT.md
@@ -1,8 +1,8 @@
 # Quality Gate Contract (W2.1)
 
-- **Status**: Accepted baseline (W2.1a) + CI parity (W2.1b) + skill-evals CI (K3.1b)
+- **Status**: Accepted baseline; **implementation drift detected 2026-07-30**
 - **Date**: 2026-07-18
-- **Related**: ADR-042, AGENTS.md, `scripts/quality-gates.sh`, Codecov config
+- **Related**: ADR-042, ADR-072, proposed ADR-079, AGENTS.md, `scripts/quality-gates.sh`, Codecov config
 - **Validator**: `./scripts/validate-gate-contract.sh` (+ `--ci-parity`)
 
 ## Purpose
@@ -12,28 +12,43 @@ One matrix that maps every **advertised** quality gate to:
 1. **Measured** value (what we observe when tools run),
 2. **Blocking floor** (what fails CI / local commit gate today),
 3. **Aspirational target** (where we are ratcheting),
-4. **Authoritative command / CI job**.
+4. **Authoritative command / CI job**; and
+5. whether the live merge ruleset actually requires it.
 
 Claims such as “coverage ≥90%” without a matching blocking check are **documentation debt**, not green status.
 
+## Live merge-protection truth (2026-07-30)
+
+Ruleset `9591004` (`main-protection`) is active for `refs/heads/main`. Its only
+required status context is `Codacy Static Code Analysis`; it separately enforces
+CodeQL code scanning at the configured severity. No first-party Quick Check, CI,
+test, coverage, security, storage, skill, release-drift, or anchor job is required.
+The standalone `Required Check Anchor` is also not required and performs no
+validation. Therefore a green workflow job means that workflow ran successfully;
+it does **not** mean the merge ruleset requires the gate.
+
+ADR-079 proposes a staged `CI / Required` aggregate. Until that context is both
+implemented and present in the live ruleset, every first-party row below remains
+**not merge-required**.
+
 ## Gate matrix
 
-| Gate | Measured (how) | Blocking floor (local) | Blocking floor (CI) | Aspirational target | Authoritative surface |
-|------|----------------|------------------------|---------------------|---------------------|------------------------|
-| Format | `cargo fmt --check` | required | Quick PR Check | 100% formatted | `./scripts/code-quality.sh fmt` / Quick Check |
-| Clippy | `cargo clippy -D warnings` | required | Quick PR Check | 0 warnings workspace | `./scripts/code-quality.sh clippy --workspace` |
-| Build check | `cargo check` / `./scripts/build-rust.sh check` | recommended | CI Tests / MCP Build | always clean | `./scripts/build-rust.sh check` |
-| Unit + integration | `cargo nextest run --all` | required before commit (AGENTS) | CI Tests job | all pass | `cargo nextest run --all` |
-| Doctests | `cargo test --doc` | required before commit (AGENTS) | CI / quality-gates path | all pass | `cargo test --doc` |
-| Docs links | `cargo doc --no-deps` | required before commit | CI docs where configured | 0 broken | `cargo doc --no-deps --document-private-items` |
-| LOC ≤500 | quality-gates / file structure | required in quality-gates | File Structure / quality | 0 prod files >500 | `./scripts/quality-gates.sh` LOC check |
-| Coverage | `cargo llvm-cov` | **default floor 70%** via `QUALITY_GATE_COVERAGE_THRESHOLD` (quality-gates.sh); AGENTS text still says 90% | Codecov / Coverage job (project + patch targets) | **90%** (AGENTS + ADR-042 ratchet) | `QUALITY_GATE_COVERAGE_THRESHOLD` + Codecov |
-| Security advisories | `cargo deny check advisories` | blocking (W2.2) | Cargo Deny / Supply Chain | clean advisories | `cargo deny` (not soft-pass audit) |
-| Cargo audit | `cargo audit` | informational if deny is blocking | may still run | no ignored vulns without justification | prefer deny for gating |
-| Semver | cargo-semver-checks | CI Semver Check | Semver Check job | no accidental breaks | CI Semver Check |
-| Skill evals | `./scripts/run-evals.sh` | `./scripts/run-evals.sh --fixtures` recommended before skill PRs | Skill Evals workflow: fixtures always; `--changed` on PR; full suite on schedule / dispatch | all skills strict schema | `.github/workflows/skill-evals.yml` + `./scripts/run-evals.sh --fixtures` |
-| Release cadence | `./scripts/check-release-drift.sh` | warning@20 / critical@30 | Release Drift Check | tag before hard limit | release-drift workflow |
-| Gate contract integrity | `./scripts/validate-gate-contract.sh` | required when editing gates | Skill Evals job runs default + `--ci-parity` | matrix ↔ scripts ↔ workflows aligned | `./scripts/validate-gate-contract.sh --ci-parity` |
+| Gate | Measured (how) | Blocking floor (local) | Workflow enforcement today | Merge-required? | Aspirational target | Authoritative surface |
+|------|----------------|------------------------|----------------------------|-----------------|---------------------|-----------------------|
+| Format | `cargo fmt --check` | required | Quick Check job | No | 100% formatted | `./scripts/code-quality.sh fmt` / Quick Check |
+| Clippy | `cargo clippy -D warnings` | required | Quick Check uses separate lib/tests commands and a broad copied allow-list | No | 0 warnings workspace | Local: `./scripts/code-quality.sh clippy --workspace`; CI drift open |
+| Build check | `cargo check` / `./scripts/build-rust.sh check` | recommended | Builds occur in CI jobs, but no exact canonical check | No | always clean | `./scripts/build-rust.sh check` |
+| Unit + integration | `cargo nextest run --all` | required before commit (AGENTS) | CI excludes benches, examples, and test-utils; MCP and multi-platform duplicate subsets | No | all pass | Local command is authoritative; CI scope drift open |
+| Doctests | `cargo test --doc` | required before commit (AGENTS) | Quick Check invokes `scripts/check-doctests.sh` | No | all pass | `cargo test --doc` / `scripts/check-doctests.sh` |
+| Docs links | `cargo doc --no-deps` | required before commit | Quick Check invokes `scripts/check-doctests.sh` with warnings denied | No | 0 broken | `cargo doc --no-deps --document-private-items` |
+| LOC ≤500 | quality-gates source-size check | required in quality-gates | No equivalent production LOC job; File Structure validates locations | No | 0 prod files >500 | `./scripts/quality-gates.sh` LOC check |
+| Coverage | `cargo llvm-cov` | **default floor 70%** via `QUALITY_GATE_COVERAGE_THRESHOLD`; AGENTS text still says 90% | Coverage and CI quality jobs run overlapping commands; Codecov upload may soft-fail | No | **90%** (AGENTS + ADR-042 ratchet) | `QUALITY_GATE_COVERAGE_THRESHOLD` + Codecov |
+| Security advisories | `cargo deny check advisories` | blocking (W2.2) | Security, Supply Chain, and CI quality jobs overlap | No | clean advisories | `cargo deny` (not soft-pass audit) |
+| Cargo audit | `cargo audit` | informational if deny is blocking | optional structured reporting | No | no ignored vulns without justification | prefer deny for gating |
+| Semver | cargo-semver-checks | CI-only informational | `continue-on-error: true` and Dependabot excluded | No | no accidental breaks | CI Semver Check |
+| Skill evals | `./scripts/run-evals.sh` | fixtures recommended before skill PRs | Skill Evals runs fixtures always, changed on PR, full on schedule/dispatch | No | all skills strict schema | `.github/workflows/skill-evals.yml` + `./scripts/run-evals.sh --fixtures` |
+| Release cadence | `./scripts/check-release-drift.sh` | warning@20 / critical@30 | Release Drift Check | No | tag before hard limit | release-drift workflow |
+| Gate contract integrity | `./scripts/validate-gate-contract.sh` | required when editing gates | Skill Evals runs default + `--ci-parity`, but parity is presence/keyword based | No | semantic matrix ↔ scripts ↔ workflows ↔ ruleset alignment | `./scripts/validate-gate-contract.sh --ci-parity` |
 
 ### Coverage truth (explicit)
 
@@ -51,8 +66,8 @@ Claims such as “coverage ≥90%” without a matching blocking check are **doc
 | Concern | Local entrypoint | CI entrypoint |
 |---------|------------------|---------------|
 | fmt + clippy | `./scripts/code-quality.sh` | Quick PR Check (`quick-check.yml`) |
-| tests | `cargo nextest run --all` | CI Tests (`ci.yml`) |
-| quality bundle | `./scripts/quality-gates.sh` | Quality Gates job (subset may differ) |
+| tests | `cargo nextest run --all` | CI Tests excludes three workspace packages; **not parity** |
+| quality bundle | `./scripts/quality-gates.sh` | Quality Gates job duplicates only a subset; **not parity** |
 | deny advisories | `cargo deny check` | Cargo Deny / Supply Chain (`security.yml` / `supply-chain.yml`) |
 | skill schema | `./scripts/run-evals.sh --fixtures` | Skill Evals workflow (`skill-evals.yml`) always |
 | changed skill evals | `./scripts/run-evals.sh --changed` | Skill Evals on `pull_request` |
@@ -62,7 +77,11 @@ Claims such as “coverage ≥90%” without a matching blocking check are **doc
 
 `./scripts/validate-gate-contract.sh` fails if this matrix file is missing required sections or if default coverage floor in `quality-gates.sh` disagrees with the **Blocking floor (local)** cell above.
 
-`./scripts/validate-gate-contract.sh --ci-parity` additionally requires the authoritative workflow files and scripts listed above (including `skill-evals.yml` wiring for fixtures + gate-contract checks).
+`./scripts/validate-gate-contract.sh --ci-parity` currently verifies authoritative
+files and selected keywords exist (including `skill-evals.yml` wiring). It does
+not parse command arguments, dependency topology, actor exclusions, accepted
+conclusions, or live ruleset configuration. Calling this semantic CI parity is a
+known gap tracked by ADR-079 / CIT-A3.
 
 ## Non-goals (W2.1)
 
@@ -80,6 +99,7 @@ Claims such as “coverage ≥90%” without a matching blocking check are **doc
 - [x] `--ci-parity` verifies quick-check, ci, release-drift, security/supply-chain (deny), skill-evals surfaces
 - [x] CI runs `./scripts/validate-gate-contract.sh` and `--ci-parity` (Skill Evals workflow)
 - [x] Local vs CI parity table lists skill schema + gate contract entrypoints
+- [ ] Exact command scopes, actor conditions, aggregate outcomes, and live ruleset context agree (drift detected; ADR-079)
 
 ## Acceptance (K3.1b)
 

--- a/plans/GOALS.md
+++ b/plans/GOALS.md
@@ -1,18 +1,30 @@
 # GOAP Goals Index
 
-- **Last Updated**: 2026-07-26  
-- **Status**: ADR-077 runtime embedding activation complete (A1-A6); next action is next release  
-- **Workspace**: `0.1.37` · **Tag**: `v0.1.36`  
-- **Plan**: `plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md`  
+- **Last Updated**: 2026-07-30
+- **Status**: CI trust, product-truth remediation, and ADR-078 attribution capture proposed
+- **Workspace**: `0.1.38` · **Tag**: `v0.1.37`
+- **Plan**: `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`
 - **Archive**: `plans/archive/2026-07-consolidation/`
 
-## Active goals (2026-07-25)
+## Active goals (2026-07-30)
 
 | Goal | Rec IDs | Priority | Status |
 |------|---------|----------|--------|
+| Make first-party validation causally merge-required | CIT-A1 / ADR-079 | P0 | Proposed |
+| Fail closed across cancellation, missing checks, commit lint, Dependabot, and forks | CIT-A2 | P0 | Planned |
+| Reconcile local/CI gate scope and semantic drift validation | CIT-A3 | P1 | Planned |
+| Make release/publish/fuzz automation truthful and observable | CIT-A4/A5 | P1 | Planned |
+| Make disabled cascade capability truthful | PTA-A1 | P0 | ✅ Implemented |
+| Make storage metrics provenance-truthful | PTA-A2 | P0 | ✅ Implemented |
+| Remove unsupported threshold command from CLI help | PTA-A3 | P1 | ✅ Implemented |
+| Capture episode-bound recommendation attribution automatically | RAT-A1…A7 / ADR-078 | P1 | Proposed |
+| Design idempotent feedback-to-ranking updates | Follow-up ADR | P2 | Deferred |
 | Optional research/product spikes (R-F1…R-F7, R-F10) | R-F* | P2 | ⏸ DEFER |
 
-No open code goals. Next trigger: decide to cut v0.1.37 or begin a P2 spike.
+The ranking-learning loop remains open: ADR-078 captures trustworthy evidence but
+does not yet apply feedback to recommendation scores. First-party CI is also not
+currently merge-required; green workflow runs must not be described as branch
+protection until ADR-079's staged ruleset migration completes.
 
 ## Closed this wave (2026-07-20…25)
 

--- a/plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md
+++ b/plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md
@@ -1,0 +1,296 @@
+# GOAP: Product Truth, CI Trust, and Automatic Recommendation Attribution
+
+- **Status**: Proposed
+- **Date**: 2026-07-30
+- **Audit checkout**: `main` at `e66defdf`
+- **Decisions**: [ADR-078](adr/ADR-078-Automatic-Recommendation-Attribution.md) and [ADR-079](adr/ADR-079-Fail-Closed-CI-Required-Check-Control-Plane.md) — Proposed
+- **Relevant constraints**: ADR-039, ADR-044, ADR-072, ADR-075, Tokio-only async, postcard, zero clippy warnings
+- **Strategy**: Restore a fail-closed merge control plane first, fix product false-success contracts, then implement attribution integrity from storage/core to MCP/CLI, with converging end-to-end validation
+
+## Analysis summary
+
+The workspace is healthy at version `0.1.38` after release `v0.1.37`, but the
+prior “no open code gaps” claim is not supported by current source. The audit
+found a critical CI governance gap, two correctness gaps, one
+advertised-but-unimplemented command, and one high-value feature that completes
+the capture half of ADR-044.
+
+| Priority | Finding | Evidence | Disposition |
+|----------|---------|----------|-------------|
+| P0 | The active ruleset requires no first-party build/test aggregate | Ruleset `9591004`, `.github/workflows/pr-check-anchor.yml` | Implement ADR-079 and stage `CI / Required` into protection |
+| P0 | Five waiters treat cancelled/skipped/missing format/Clippy as acceptable and ignore commit lint | `ci.yml`, `coverage.yml`, `security.yml`, `benchmarks.yml`, `file-structure.yml`; PR #914 | Replace polling with same-run fail-closed aggregation |
+| P0 | Cascade retrieval returns successful empty results when `csm` is disabled | `memory-core/src/retrieval/cascade/mod.rs` | ✅ Implemented — typed `CapabilityUnavailable` |
+| P0 | CLI storage statistics present fixed estimates/unknowns as measured values | `memory-cli/src/commands/storage/commands.rs`, `types.rs` | ✅ Implemented — `MetricValue` provenance |
+| P1 | Dependabot is excluded from most substantive CI and gate contracts overstate parity | workflow actor conditions; `plans/GATE_CONTRACT.md` | Actor parity plus semantic contract validation |
+| P1 | Release manual dispatch is broken; publish selection and fuzz evidence have false-success paths | release run `30301797956`, workflow conditions | Truthful trigger/planner/evidence remediation |
+| P1 | `eval set-threshold` is advertised but always errors; its help suggests nonexistent `eval show` | `memory-cli/src/commands/eval.rs` | ✅ Implemented — command removed/hidden |
+| P1 | Recommendation generation does not automatically create truthful episode-bound sessions | ADR-078 evidence | Implement this plan's RAT packages |
+| P2 | Azure/Custom/Cohere embedding adapters are absent | ADR-077, embedding factory | Remain unavailable until a provider-specific ADR and adapter tests exist |
+| Non-gap | `execute_agent_code` and batch MCP tools are unavailable | ADR-073 and standing product decisions | Preserve fail-closed/deferred state |
+
+## Goal state
+
+| Fact | Before | Desired |
+|------|--------|---------|
+| `required_ci_causal` | Ruleset requires only external analysis | Same-run first-party aggregate required |
+| `ci_cancellation_fail_closed` | Cancelled/skipped/missing may pass waiters | Applicable non-success always blocks |
+| `automation_actor_parity` | Dependabot skips core validation | Same assertions with least privilege |
+| `gate_contract_semantic` | Presence/keyword parity only | Commands, DAG, conditions, and ruleset validated |
+| `cascade_capability_truthful` | Disabled feature looks like zero matches | ✅ Typed `CapabilityUnavailable` returned |
+| `storage_metrics_truthful` | Estimates/unknowns look measured | ✅ Values carry provenance or are omitted |
+| `unsupported_threshold_command_hidden` | CLI advertises guaranteed failure | ✅ No advertised non-operation |
+| `recommendation_capture_automatic` | Separate manual session step | Optional episode-bound attributed operation |
+| `attribution_persistence_truthful` | Warning-only, no-op defaults can look successful | Tagged persistence receipt |
+| `feedback_integrity_checked` | Orphan/mismatched feedback accepted | Session and recommended-ID validation |
+| `ranking_learns_from_feedback` | Statistics only | Explicitly deferred follow-up |
+
+## Action graph
+
+```text
+CIT-A1 required topology ─► CIT-A2 fail-closed + actor parity ─► CIT-A3 contract
+            │                           │                            │
+            └───────────────────────────┴──► CIT-A4 release/publish  │
+                                         └─► CIT-A5 evidence         │
+                                                                   v
+PTA-A1 cascade truth ───────────────┐                              PTA-A9
+PTA-A2 storage metric truth ────────┼──► full validation and plan evidence
+PTA-A3 threshold surface cleanup ───┘                 ▲
+                                                      │
+RAT-A1 contract tests                                 │
+     │                                                │
+     v                                                │
+RAT-A2 capability + checked persistence               │
+     │                                                │
+     v                                                │
+RAT-A3 attributed core APIs + playbook cleanup        │
+     │                                                │
+     v                                                │
+RAT-A4 feedback/session integrity                     │
+     │                                                │
+     +----------------------+-------------------------+
+                            v
+                 RAT-A5 MCP + RAT-A6 CLI
+                            │
+                            v
+                 RAT-A7 end-to-end docs/tests
+```
+
+CIT-A1…A3 are the first implementation wave because later code cannot rely on
+merge gates until they are causal and fail closed. CIT-A4/A5 may follow in
+parallel. PTA-A1…A3 are independent. RAT packages are sequential through the
+core contract; MCP and CLI can proceed in parallel after RAT-A4.
+
+## Work packages
+
+### CIT-A1: Build and stage one required aggregate
+
+Implement ADR-079's same-workflow PR orchestrator and stable `CI / Required`
+context. Keep path classification in the workflow, make the aggregate run with
+`always()`, and fail on every applicable non-success. First deploy without a
+ruleset change; fault-inject normal, Dependabot, fork, docs-only, code, failure,
+cancellation, timeout, and missing-result cases. With maintainer approval, add
+the observed context to ruleset `9591004`, prove a failure blocks merge, then
+remove the unused echo anchor and cross-workflow waiters.
+
+**Exit**: The live ruleset requires a first-party aggregate causally derived
+from substantive checks, with no merge bypass used during verification.
+
+### CIT-A2: Make fast gates and actor behavior fail closed
+
+Aggregate commit lint with formatting, Clippy, doctests/docs, frontmatter, and
+ignored-test ceiling. Remove `cancelled`, unclassified `skipped`, and missing
+checks from accepted outcomes. Run the same code-quality/test assertions for
+Dependabot and forks with read-only permissions, no secrets, and no cache writes.
+Secret-dependent jobs declare explicit applicability rather than skipping actors.
+
+**Exit**: Commit-lint failure and cancelled/missing fast checks block; actor type
+changes privileges, not the asserted code contract.
+
+### CIT-A3: Reconcile and enforce the gate contract
+
+Choose and document the required Linux test surface, using the full workspace or
+explicitly owned exclusions. Replace copied Clippy flags and partial quality
+bundles with canonical scripts/shared commands. Extend gate-contract validation
+to inspect exact command scope, aggregate dependencies/results, actor conditions,
+and the expected ruleset context. Add negative fixtures for each current defect.
+
+**Exit**: Local documentation, workflow commands, aggregate semantics, and live
+protection agree; presence-only validation cannot pass semantic drift.
+
+### CIT-A4: Repair release and publish orchestration
+
+Remove Release `workflow_dispatch` because ADR-072 permits tag-only creation.
+Give publish a package plan and dependency closure, exact-version preflight,
+`--locked`, bounded sparse-index polling, and an independent dry-run mode. A
+selected crate must run, be proven already published, or fail explicitly.
+
+**Exit**: No advertised trigger is guaranteed to fail or silently skip requested
+publish work; tag release remains the sole release authority.
+
+### CIT-A5: Make informational CI produce durable evidence
+
+Ensure fuzz crashes/startup failures/timeouts are visible and upload artifacts
+with `always()`. Preserve mutation reports even when the job is informational.
+Record baselines before proposing blocking mutation/fuzz thresholds. After trust
+is restored, remove duplicate builds/tests through reusable workflows and
+artifact handoff, measuring queue-to-result time and compute before/after.
+
+**Exit**: Informational checks cannot greenwash or discard failures, and cost
+optimization does not weaken the aggregate contract.
+
+### PTA-A1: Make disabled cascade retrieval truthful
+
+**Status: ✅ Implemented (2026-08-01).** `CascadeRetriever::retrieve` now returns
+`Result<CascadeResult, CascadeError>`; non-`csm` builds return
+`Err(CascadeError::CapabilityUnavailable)` instead of a successful empty result.
+
+Change the non-`csm` contract so callers cannot confuse unavailable capability
+with a valid zero-match result. Prefer compile-time exclusion where public API
+compatibility permits; otherwise return a typed `CapabilityUnavailable` error.
+Update feature-matrix tests and docs. Do not silently fall back to unrelated
+retrieval under the `CascadeRetriever` name.
+
+**Exit**: A non-`csm` build cannot produce a successful empty cascade result.
+
+### PTA-A2: Make CLI storage metrics truthful
+
+**Status: ✅ Implemented (2026-08-01).** Storage `stats`/`connections` now carry
+`MetricValue` provenance (`measured`/`estimated`/`unavailable`); the fabricated
+"last 24h", zero cache-hit rate, and fixed connection-pool values were removed.
+
+Define measured/estimated/unavailable provenance in machine output, or remove
+fields that cannot be measured through current backend interfaces. Human output
+must label estimates. Do not report completed episode count as “last 24h,” zero
+as an observed cache-hit rate, or fixed connection-pool values. Adding full
+backend telemetry is a follow-up unless existing interfaces expose it.
+
+**Exit**: Every displayed metric is measured, explicitly estimated, or unavailable.
+
+### PTA-A3: Remove the advertised threshold non-operation
+
+**Status: ✅ Implemented (2026-08-01).** `eval set-threshold` removed from Clap,
+dispatch, help snapshot, and user docs; the dangling `eval show` reference is gone.
+
+Remove/hide `eval set-threshold` from Clap and active documentation because no
+override model is persisted or consumed by reward calculation. Correct references
+to the existing `eval stats DOMAIN` command. A future override feature requires a
+separate decision covering storage, precedence, runtime loading, and deletion.
+
+**Exit**: CLI help contains no command guaranteed to fail by design.
+
+### RAT-A1: Freeze attributed recommendation contracts
+
+Add failing tests for legacy compatibility, episode validation, exact returned-ID
+capture, empty recommendations, playbook generation errors, multiple sessions,
+and all persistence receipt states. Define stable serialized receipt names and
+ensure no raw backend errors cross MCP boundaries.
+
+**Exit**: Tests distinguish recommendation failure, valid empty output, memory-only,
+partial persistence, and total persistence failure.
+
+### RAT-A2: Add capability-aware checked persistence
+
+Add an explicit recommendation-attribution capability or typed unsupported result
+so successful storage trait defaults cannot count as writes. Implement checked
+session and feedback recording across Turso/redb/cache configurations. Keep old
+warning-only public methods as compatibility delegates. Return backend-neutral,
+tagged receipts and preserve detailed errors only in logs.
+
+**Exit**: Receipt state is derived from configured capable backends and verified
+loads, never from a successful no-op default.
+
+### RAT-A3: Add attributed core APIs and remove hidden playbook recording
+
+Add attributed pattern/playbook methods requiring a valid episode ID. Derive the
+session from exact returned IDs through the shared checked recorder. Retain old
+unattributed APIs unchanged. Remove `Uuid::nil()` playbook sessions and make
+playbook generation return enough status to distinguish error from valid empty.
+
+**Exit**: Core tests prove exact capture and no hidden attribution side effects.
+
+### RAT-A4: Enforce session and feedback integrity
+
+Resolve sessions by ID from memory or persistence before feedback. Reject unknown
+sessions and applied IDs outside the recommended set. Define multiple sessions per
+episode as valid and latest lookup as deterministic. Treat replacement feedback
+as idempotent replacement in statistics; do not count it as another exposure or
+application.
+
+**Exit**: Orphan/mismatched feedback fails and repeated replacement does not inflate
+adoption or success statistics.
+
+### RAT-A5: Expose optional attribution through MCP
+
+Add optional `episode_id` to pattern and playbook recommendation tool schemas.
+Absent means the exact legacy response. Present means an attribution envelope is
+returned with results. Route manual session/feedback tools through checked core
+semantics and retain lazy registry/schema consistency.
+
+**Exit**: MCP protocol tests cover both shapes and all stable receipt states.
+
+### RAT-A6: Expose optional attribution through CLI
+
+Add `--episode-id` to pattern and playbook recommendation commands. Preserve
+legacy JSON/YAML exactly when absent; include the envelope when present. Human
+output prints the session ID and persistence state, warning clearly for
+process-only or failed durability. Keep manual feedback commands compatible.
+
+**Exit**: CLI end-to-end tests can recommend for an episode, capture the returned
+session ID, and submit validated feedback.
+
+### RAT-A7: Document capture limits and define ranking follow-up
+
+Update API/CLI/MCP docs to explain attributed versus legacy calls, receipt states,
+restart implications, multiple sessions, and feedback validation. Record a
+follow-up requirement for idempotent feedback-to-effectiveness ranking updates;
+do not claim the learning loop is closed until that work has its own ADR/tests.
+
+**Exit**: User docs call this attribution capture and make degraded persistence actionable.
+
+### PTA-A9: Validate and update authority documents
+
+Run focused crate tests after each package, then workspace gates. Update ADR-078
+and ADR-079 to Accepted/Implemented only after code, live ruleset state, and
+evidence exist. Record commit, feature set, UTC timestamp, and validation
+artifacts per ADR-072.
+
+## Quality gates
+
+```bash
+./scripts/code-quality.sh fmt
+./scripts/code-quality.sh clippy --workspace
+./scripts/build-rust.sh check
+cargo nextest run -p do-memory-core
+cargo nextest run -p do-memory-storage-turso
+cargo nextest run -p do-memory-storage-redb
+cargo nextest run -p do-memory-mcp
+cargo nextest run -p do-memory-cli
+cargo nextest run --all
+cargo test --doc
+cargo doc --no-deps --document-private-items
+./scripts/quality-gates.sh
+./scripts/validate-gate-contract.sh --ci-parity
+./scripts/validate-plans.sh --active-set --version-state --adrs --identifiers --links
+```
+
+Cascade checks must compile and test both default and `csm` feature sets.
+Attribution storage tests must cover memory-only, redb-only, Turso-only, dual
+backend, partial failure, total failure, and restart retrieval.
+
+## Promotion gates
+
+1. Accept ADR-078 before RAT-A2 changes public persistence semantics.
+2. Accept ADR-079 before replacing required-check topology; obtain explicit
+   approval immediately before mutating the repository ruleset.
+3. Review the receipt/capability model before MCP/CLI wire changes.
+4. Prove deterministic multiple-session behavior and idempotent feedback before
+   calling attribution statistics trustworthy.
+5. Do not promote the ranking follow-up without a separate durability and
+   idempotency decision.
+
+## Definition of done
+
+- CIT-A1…A5, PTA-A1…A3, and RAT-A1…A7 exits are met.
+- All quality gates pass with evidence recorded.
+- ADR-078, ADR-079, and canonical trackers reflect actual, not intended, implementation.
+- No plan or user documentation claims feedback changes ranking until verified.

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -3,7 +3,7 @@
 - **Last Updated**: 2026-07-30
 - **Version**: workspace `0.1.38` · latest tag `v0.1.37`
 - **Branch**: `main` @ `f0ffc4a3`
-- **Open PRs**: #916
+- **Open PRs**: #916 (PTA-A1/A2/A3 product truth — all CI green)
 - **Open issues**: #913
 - **Active plan**: `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md` (PTA-A1/A2/A3 implemented)
 - **Archive**: `plans/archive/2026-07-consolidation/`  

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1,20 +1,33 @@
 # GOAP State Snapshot
 
-- **Last Updated**: 2026-07-27  
-- **Version**: workspace `0.1.37` · latest tag `v0.1.36`  
-- **Branch**: `main` @ `9b14a7a6`  
-- **Open PRs**: none  
-- **Open issues**: none  
-- **Active plan**: `plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md` (A1-A6 complete)  
+- **Last Updated**: 2026-07-30
+- **Version**: workspace `0.1.38` · latest tag `v0.1.37`
+- **Branch**: `main` @ `e66defdf`
+- **Open PRs**: #914, #915
+- **Open issues**: #913
+- **Active plan**: `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md` (PTA-A1/A2/A3 implemented)
 - **Archive**: `plans/archive/2026-07-consolidation/`  
-- **Release**: ✅ `v0.1.36` published 2026-07-22  
+- **Release**: ✅ `v0.1.37` tagged and shipped
 
 ---
 
-## Phase: Post-v0.1.36 development ✅
+## Phase: Analyze / decide — CI trust + product truth + attribution
 
 | Package | Status |
 |---------|--------|
+| ADR-079 fail-closed required-check control plane | Proposed (P0) |
+| CIT-A1 required aggregate + staged ruleset migration | Blocked by ADR acceptance |
+| CIT-A2 cancellation/actor fail-closed behavior | Blocked by CIT-A1 |
+| CIT-A3 semantic gate-contract parity | Blocked by CIT-A2 |
+| CIT-A4 release/publish trigger truth | Planned (P1) |
+| CIT-A5 durable informational evidence + deduplication | Planned (P1/P2) |
+| PTA-A1 non-`csm` cascade capability truth | Implemented | PTA-A1 |
+| PTA-A2 CLI storage metric truth | Implemented | PTA-A2 |
+| PTA-A3 threshold command cleanup | Implemented | PTA-A3 |
+| ADR-078 automatic recommendation attribution | Proposed |
+| RAT-A1 contract tests | Blocked by ADR acceptance |
+| RAT-A2…A7 implementation | Blocked by preceding RAT packages |
+| Feedback-to-ranking adaptation | Deferred to separate ADR |
 | PR queue cleanup (GOAP swarm) | ✅ 5 PRs → 0 open (2026-07-27) |
 | cargo-mutants workspace fix #901 | ✅ Merged (fixes #898) |
 | Dependabot batch #902/#903/#904 | ✅ Merged |
@@ -57,15 +70,20 @@ storage_awaits_lock_free          = true
 durable_eviction                  = true
 embedding_health_truthful         = true
 retry_backpressure_effective      = true
-gates_match_policy                = true
+gates_match_policy                = false (ADR-079 — no first-party required aggregate; contract scope drift)
+required_ci_causal                = false (ruleset 9591004 requires Codacy + CodeQL policy only)
+ci_cancellation_fail_closed       = false (five waiters accept cancelled/skipped/missing)
+automation_actor_parity           = false (Dependabot excluded from substantive jobs)
+release_dispatch_truthful         = false (manual Release dispatch fails tag preflight)
+informational_ci_evidence_durable = false (fuzz continue-on-error can suppress crash upload)
 skill_evals_executable            = true
 skill_routes_complete             = true
 skill_evals_medium_depth          = true
 docs_match_code                   = true
 plan_registry_unique              ≈ true  (ADR 025/054 aliased)
 feature_pilots_have_baselines     = true
-release_current                   = true  (v0.1.36)
-version_advanced_after_tag        = true  (workspace 0.1.37)
+release_current                   = true  (v0.1.37)
+version_advanced_after_tag        = true  (workspace 0.1.38)
 adr074_provenance_envelope        = true  (RetrievalProvenance + CacheKey all fields)
 adr075_durable_complete           = true  (completion.rs hard-errors on backend failure)
 adr076_pattern_ux                 = true  (empty diagnostics + sync messaging + pattern extract)
@@ -75,4 +93,10 @@ r_f8_relationship_show_polish     = true  (#893 — box-drawing panel + unit tes
 r_f9_hnsw_persistence             = true  (#893 — file_dump/load + capacity eviction)
 skill_count_40_all_routed         = true  (checkpoint-handoff, embedding-ops, episode-relationships, episode-tags, playbook-ops, recommendation-feedback)
 runtime_embedding_activation      = true  (ADR-077 Implemented A1-A6 — configure_embeddings activates exact provider; A6 docs + concurrency/redaction regression tests #897 merged)
+cascade_capability_truthful       = true  (PTA-A1 — non-csm `retrieve` returns `Err(CascadeError::CapabilityUnavailable)`)
+storage_metrics_truthful          = true  (PTA-A2 — `MetricValue` provenance: measured/estimated/unavailable)
+unsupported_threshold_hidden      = true  (PTA-A3 — `eval set-threshold` removed from Clap + docs)
+automatic_attribution_capture     = false (ADR-078 Proposed)
+feedback_integrity_checked        = false (RAT-A4)
+feedback_updates_ranking          = false (follow-up ADR required)
 ```

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,9 +1,9 @@
 # Plans Directory
 
-**Workspace**: `0.1.37` (post-release) · **Released tag**: `v0.1.36` · **Next**: `v0.1.37`  
-**Active plan**: [GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md](GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md)  
-**Last Updated**: 2026-07-26  
-**Open PRs**: *(none)* · **Open issues**: none  
+**Workspace**: `0.1.38` (post-release) · **Released tag**: `v0.1.37` · **Next**: `v0.1.38`
+**Active plan**: [GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md](GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md) (PTA-A1/A2/A3 implemented)
+**Last Updated**: 2026-07-30
+**Open PRs**: #914, #915 · **Open issues**: #913
 **Policy**: ADR-039 (canonical active set) + ADR-072 (authority / release path)
 
 ## Quick Navigation
@@ -19,7 +19,8 @@
 | [ACTIONS.md](ACTIONS.md) | Action backlog |
 | [GOAP_STATE.md](GOAP_STATE.md) | GOAP phase snapshot |
 | [GATE_CONTRACT.md](GATE_CONTRACT.md) | Local/CI quality gate matrix |
-| [GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md](GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md) | **Active**: full recommendations backlog |
+| [GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md](GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md) | **Active**: CI trust + product-truth fixes + ADR-078 attribution capture |
+| [GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md](GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md) | Reference recommendations backlog |
 | [ANALYSIS_GH_CLI_SKILLS_AND_BEST_PRACTICES_2026-07-20.md](ANALYSIS_GH_CLI_SKILLS_AND_BEST_PRACTICES_2026-07-20.md) | Official `gh` / `gh skill` skills + manual vs repo policy |
 
 ## Architecture
@@ -34,6 +35,9 @@
 ## ADRs
 
 See [adr/README.md](adr/README.md) for the ADR index (including number-collision aliases).
+
+Current proposals: [ADR-078 automatic recommendation attribution](adr/ADR-078-Automatic-Recommendation-Attribution.md)
+and [ADR-079 fail-closed CI control plane](adr/ADR-079-Fail-Closed-CI-Required-Check-Control-Plane.md).
 
 ## Spikes
 

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -36,11 +36,11 @@
 |----------|------|-------------|--------|
 | P0 | ADR-079 / CIT-A1 | Same-run `CI / Required` aggregate and staged ruleset migration | Proposed |
 | P0 | CIT-A2 | Fail closed on cancellation/missing/commitlint; Dependabot/fork parity | Planned |
-| P0 | PTA-A1 cascade truth | Non-`csm` retrieval returns typed `CapabilityUnavailable` instead of successful empty | ✅ Implemented |
-| P0 | PTA-A2 storage metric truth | Label measured/estimated/unavailable via `MetricValue` provenance; remove fabricated telemetry | ✅ Implemented |
+| P0 | PTA-A1 cascade truth | Non-`csm` retrieval returns typed `CapabilityUnavailable` instead of successful empty | ✅ #916 |
+| P0 | PTA-A2 storage metric truth | Label measured/estimated/unavailable via `MetricValue` provenance; remove fabricated telemetry | ✅ #916 |
 | P1 | CIT-A3 | Exact local/CI command scope and semantic gate-contract validation | Planned |
 | P1 | CIT-A4/A5 | Truthful release/publish triggers and durable fuzz/mutation evidence | Planned |
-| P1 | PTA-A3 threshold CLI truth | Hide advertised `eval set-threshold` non-operation | ✅ Implemented |
+| P1 | PTA-A3 threshold CLI truth | Hide advertised `eval set-threshold` non-operation | ✅ #916 |
 | P1 | ADR-078 / RAT-A1…A7 | Episode-bound automatic attribution with truthful persistence receipts | Proposed |
 | P2 | Ranking adaptation | Idempotent feedback-to-ranking update; requires separate ADR | Deferred |
 

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -1,13 +1,13 @@
 # Active Development Roadmap
 
-**Last Updated**: 2026-07-26  
+**Last Updated**: 2026-07-30
 **Released Version**: v0.1.37 (latest tag)  
 **Workspace Version**: 0.1.38 (next release)  
-**Active Sprint**: ADR-077 runtime embedding activation (A1-A6 complete)  
-**Plan**: `plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md`  
-**Branch**: `main` @ `648e11ad`  
-**Open PRs**: none  
-**Open issues**: none  
+**Active Sprint**: CI trust + product truth + ADR-078 automatic recommendation attribution (proposed)
+**Plan**: `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`
+**Branch**: `main` @ `e66defdf`
+**Open PRs**: #914, #915
+**Open issues**: #913
 
 ---
 
@@ -30,6 +30,22 @@
 
 ---
 
+## Active forward work
+
+| Priority | Item | Description | Status |
+|----------|------|-------------|--------|
+| P0 | ADR-079 / CIT-A1 | Same-run `CI / Required` aggregate and staged ruleset migration | Proposed |
+| P0 | CIT-A2 | Fail closed on cancellation/missing/commitlint; Dependabot/fork parity | Planned |
+| P0 | PTA-A1 cascade truth | Non-`csm` retrieval returns typed `CapabilityUnavailable` instead of successful empty | ✅ Implemented |
+| P0 | PTA-A2 storage metric truth | Label measured/estimated/unavailable via `MetricValue` provenance; remove fabricated telemetry | ✅ Implemented |
+| P1 | CIT-A3 | Exact local/CI command scope and semantic gate-contract validation | Planned |
+| P1 | CIT-A4/A5 | Truthful release/publish triggers and durable fuzz/mutation evidence | Planned |
+| P1 | PTA-A3 threshold CLI truth | Hide advertised `eval set-threshold` non-operation | ✅ Implemented |
+| P1 | ADR-078 / RAT-A1…A7 | Episode-bound automatic attribution with truthful persistence receipts | Proposed |
+| P2 | Ranking adaptation | Idempotent feedback-to-ranking update; requires separate ADR | Deferred |
+
+---
+
 ## Follow-on backlog (P2 — spike-gated)
 
 | Priority | Theme | Items | Status |
@@ -37,6 +53,7 @@
 | P2 | Research | WG-108 / WG-110 / WG-125 / WG-135 | ⏸ DEFER |
 | P2 | Vision | Distributed sync, multi-tenancy, OTel | Future |
 | P2 | Release eng | Trusted Publishing (OIDC) for crates.io | Future |
+| P2 | CI cost | Reusable workflows/artifact handoff after required-gate correctness | Blocked by CIT-A1…A3 |
 | P2 | Security | Transitive Dependabot advisories | Monitor |
 | P2 | CLI | ADR-076 §5 `pattern extract` error-arm coverage | ✅ Done (#891) |
 | P2 | CLI | R-F8 relationship info box-drawing panel | ✅ Done (#893) |

--- a/plans/STATUS/CODEBASE_ANALYSIS_LATEST.md
+++ b/plans/STATUS/CODEBASE_ANALYSIS_LATEST.md
@@ -1,8 +1,8 @@
-# Codebase Analysis Latest — 2026-07-26
+# Codebase Analysis Latest — 2026-07-30
 
-**Branch**: `main` @ `648e11ad`  
-**Workspace**: `0.1.37` · **Released tag**: `v0.1.36`  
-**Companion**: `plans/GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`
+**Branch**: `main` @ `e66defdf`
+**Workspace**: `0.1.38` · **Released tag**: `v0.1.37`
+**Companion**: `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`
 
 ## Architecture (as implemented)
 
@@ -21,14 +21,16 @@
 
 | Check | Result |
 |-------|--------|
-| Production `todo!` / unimplemented | None |
+| Open gaps | 4 P0 (2 CI, 2 product), 6+ P1 contract/feature/automation gaps |
+| Live merge rules | Codacy required + CodeQL severity policy; no first-party build/test aggregate |
+| Cross-workflow waiters | 5; accept `success,skipped,cancelled` and missing checks |
 | Production LOC >500 (non-test `src`) | **0** |
-| Released tag | **v0.1.36** |
-| Workspace advanced post-tag | **0.1.37** |
+| Released tag | **v0.1.37** |
+| Workspace advanced post-tag | **0.1.38** |
 | Skills with evals / routes | 40/40 |
 | Fail-closed code execution | Preserved (ADR-073) |
-| Open issues | **0** |
-| Open PRs | **0** (none) |
+| Open issues | **1** (#913) |
+| Open PRs | **2** (#914, #915) |
 | ADR-071 | Accepted / Implemented (auto-checkpoint on Abstained) |
 | ADR-072 | Accepted / Implemented (authority + governance) |
 | ADR-073 | Accepted / Implemented (S1.1c NO-GO, fail-closed) |
@@ -36,22 +38,56 @@
 ## Strengths
 
 1. Correctness campaign (locks, eviction, cache identity, embedding health).  
-2. Gate honesty (deny, benchmarks, cancelled guards, docs integrity ship gate).  
+2. Broad automated coverage (deny, benchmarks, docs, storage matrices, skill evals).
 3. Skill eval schema + high- and medium-risk behavioral fixtures (40 skills, all routed).  
 4. Singular release path (`release-manager` + `release.yml`).  
 5. Rich episodic/pattern/playbook MCP+CLI surface.
 6. R-F8 CLI relationship box-drawing panel + R-F9 HNSW persistence/eviction (#893).
 
-## Weaknesses / residual
+## Verified weaknesses / missing implementation
 
-1. Historical ADR filename collisions (025/054 aliased — docs only, no code action).  
-2. Transitive Dependabot advisories (upstream chains, monitor only).  
-3. Remaining product/research epics spike-gated (R-F1…R-F7, R-F10).  
+1. Active ruleset `9591004` has no first-party required build/test aggregate;
+   the standalone echo anchor is neither required nor a substantive gate.
+2. Five workflows poll only the format/Clippy job and accept cancelled, skipped,
+   or missing outcomes. Commit lint is outside that observed result; PR #914 had
+   failed commit lint while downstream waiters passed.
+3. Dependabot is excluded from core CI tests/builds, coverage, security,
+   file-validation, semver, WASM, and benchmarks rather than receiving the same
+   assertions under reduced permissions.
+4. Local and CI contracts drift: CI excludes workspace packages from the test
+   surface, uses copied Clippy allowances, and implements only part of the local
+   quality bundle. The parity validator checks presence/keywords, not semantics.
+5. Release manual dispatch fails tag preflight by construction. Publish selection
+   can be suppressed by skipped dependencies, and fuzz failures can be continued
+   without triggering crash-artifact upload.
+6. `CascadeRetriever::retrieve` returns a successful empty result without `csm`,
+   hiding capability absence as “no matches.”
+7. CLI storage output presents fixed-size estimates, completed-count “recent”
+   values, and unavailable cache/connection data as observed telemetry.
+8. `eval set-threshold` is public but has no persistence or reward-consumption
+   path and always errors.
+9. Pattern recommendation does not create attribution sessions automatically;
+   playbook recommendation records `Uuid::nil()` and skips persistence.
+10. Session/feedback persistence is warning-only and trait defaults can report
+   success without writing; feedback integrity is not fully validated.
+
+## New feature decision
+
+ADR-078 proposes optional, episode-bound attributed pattern/playbook operations.
+Core derives a session from exact returned IDs and reports `persisted`,
+`partially_persisted`, `memory_only`, or `persistence_failed`. Legacy calls stay
+shape-compatible. The feature improves capture and feedback readiness, but does
+not yet change recommendation ranking.
 
 ## Recommended focus order
 
-1. #894 merged; ADR-077 A6 merged #897 — no open PRs.  
-2. Cut v0.1.37 once sufficient unreleased commits accumulate.  
-3. Research spikes only after individual GO artifacts under `plans/STATUS/spikes/`.
+1. Accept ADR-079; implement and fault-inject a same-run first-party aggregate.
+2. Restore fail-closed cancellation/commitlint and Dependabot/fork parity, then
+   stage the verified aggregate into the live ruleset with approval.
+3. Reconcile gate scope and repair release/publish/fuzz false-success paths.
+4. Fix P0 capability/telemetry truth defects (PTA-A1/A2).
+5. Remove the advertised threshold non-operation (PTA-A3).
+6. Accept and execute ADR-078 RAT-A1…A7.
+7. Design feedback-to-ranking adaptation only after capture integrity is proven.
 
-Full prioritized backlog: recommendations plan §3–4.
+Full prioritized plan: `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`.

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -1,25 +1,25 @@
 # Project Status — Self-Learning Memory System
 
-**Last Updated**: 2026-07-27  
+**Last Updated**: 2026-07-30
 **Released Version**: v0.1.37  
 **Workspace Version**: 0.1.38 (next release)  
 **Edition**: Rust 2024  
-**Active plan**: `plans/GOAP_RUNTIME_EMBEDDING_ACTIVATION_2026-07-26.md` (A1-A6 complete)  
-**Branch**: `main` @ `45c6eee8`
+**Active plan**: `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md` (proposed)
+**Branch**: `main` @ `e66defdf`
 
 ## Open tracker (live)
 
 | Kind | Items |
 |------|--------|
-| Open PRs | *(none)* |
-| Open issues | *(none)* |
+| Open PRs | #914 Nix CI evaluation (UNSTABLE), #915 ConceptGraph performance (CLEAN) |
+| Open issues | #913 Nix CI evaluation |
 
 ## Snapshot
 
 | Area | State |
 |------|--------|
-| Release **v0.1.36** | ✅ Shipped 2026-07-22 — [release](https://github.com/d-o-hub/rust-self-learning-memory/releases/tag/v0.1.36) |
-| Post-release workspace **0.1.37** | ✅ #886 merged |
+| Release **v0.1.37** | ✅ Tagged and shipped |
+| Post-release workspace **0.1.38** | ✅ `e66defdf` |
 | Recommendations + F4 + skill contracts | ✅ #878 |
 | Medium-risk skill evals (R-E2) | ✅ #883 |
 | Docs integrity ship gate | ✅ #885 |
@@ -32,13 +32,23 @@
 | ADR-077 A6 validate / document / gate | ✅ #897 merged |
 | Code execution | Fail-closed (S1.1c NO-GO) |
 | MCP provenance (`with_provenance`) | ✅ |
-| P0 plan gaps | **None open** |
+| First-party merge gate | **Absent** — ruleset requires Codacy + CodeQL policy only |
+| CI wait semantics | **Not fail-closed** — five waiters accept cancelled/skipped/missing fast check |
+| P0 plan gaps | **1 open** — required CI (PTA-A1/A2/A3 implemented) |
+| ADR-079 CI control plane | Proposed; implementation/ruleset unchanged |
+| ADR-078 automatic attribution | Proposed; implementation not started |
 
 ## Immediate priorities
 
 | Priority | Item | ID | Status |
 |----------|------|-----|--------|
-| P0 | Cut v0.1.37 release (31 commits ready) | release | 🚀 IN PROGRESS |
+| P0 | Add causal same-run aggregate, then stage into ruleset with approval | ADR-079 / CIT-A1 | Proposed |
+| P0 | Fail closed and restore Dependabot/fork assertion parity | CIT-A2 | Planned |
+| P0 | Return typed unavailable/absent API for non-`csm` cascade | PTA-A1 | ✅ Implemented |
+| P0 | Remove or label fabricated CLI storage telemetry | PTA-A2 | ✅ Implemented |
+| P1 | Reconcile gate contract; repair release/publish/fuzz truth | CIT-A3…A5 | Planned |
+| P1 | Automatic episode-bound recommendation attribution | ADR-078 / RAT-A1…A7 | Proposed |
+| P1 | Hide unsupported `eval set-threshold` command | PTA-A3 | ✅ Implemented |
 | P2 | Research/product spikes (R-F1…R-F7, R-F10) | R-F* | ⏸ DEFER |
 | P2 | Transitive Dependabot advisories | G-P1-9 | Monitor / upstream |
 

--- a/plans/STATUS/GAP_ANALYSIS_LATEST.md
+++ b/plans/STATUS/GAP_ANALYSIS_LATEST.md
@@ -1,18 +1,20 @@
-# Gap Analysis — 2026-07-26
+# Gap Analysis — 2026-07-30
 
-**Generated**: 2026-07-26  
-**Audit commit**: `648e11ad` (`main`; ADR-077 A6 merged #897)  
-**Workspace**: `0.1.37` · **Tag**: `v0.1.36` (published 2026-07-22)  
-**Full backlog**: [`../GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md`](../GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md)
+**Generated**: 2026-07-30
+**Audit commit**: `e66defdf` (`main`)
+**Workspace**: `0.1.38` · **Tag**: `v0.1.37`
+**Active plan**: [`../GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`](../GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md)
 
 ## Method
 
-- Live GitHub: open PRs **none**; open issues **none**  
-- Release: `gh release view v0.1.36` published  
-- Workspace version advanced post-tag (R-A2 / #886)  
-- Prior gap register closed for all P0 ship items  
-- R-F8 and R-F9 GO spikes implemented and merged (#893)  
-- 6 new domain skills added (40 total, all routed)  
+- Read active planning authority and ADR-039/044/077 constraints.
+- Traced recommendation generation through core, MCP, CLI, Turso, and redb.
+- Inspected feature-disabled cascade behavior, storage-stat output, evaluation
+  command dispatch, and embedding-provider activation boundaries.
+- Audited checked-in workflows, local gate scripts, recent Actions runs, and the
+  active GitHub repository ruleset through `gh`/REST evidence.
+- Kept intentional fail-closed code execution and deferred batch tools as non-gaps.
+- Ranked observable false-success behavior above additive provider work.
 
 ## Closed this wave
 
@@ -34,7 +36,12 @@
 
 ### P0
 
-*None.*
+| ID | Gap | Evidence | Track |
+|----|-----|----------|-------|
+| G-P0-12 | `main-protection` requires no first-party build/test context; the echo anchor is unused and non-substantive | Ruleset `9591004`, `pr-check-anchor.yml` | ADR-079 / CIT-A1 |
+| G-P0-13 | Five waiters permit cancelled/skipped/missing format/Clippy and ignore commit lint | waiter workflows; PR #914 | ADR-079 / CIT-A2 |
+| G-P0-10 | Cascade retrieval without `csm` returns a successful empty result, indistinguishable from no matches | `memory-core/src/retrieval/cascade/mod.rs` | ✅ PTA-A1 closed — typed `CascadeError::CapabilityUnavailable` |
+| G-P0-11 | CLI storage stats and connection status expose estimates/unknowns as measured values | `memory-cli/src/commands/storage/commands.rs`, `types.rs` | ✅ PTA-A2 closed — `MetricValue` provenance |
 
 ### P1
 
@@ -42,12 +49,20 @@
 |----|-----|----------|-------|
 | G-P1-8 | Historical ADR number reuse on disk | Dual 025/054 filenames; aliases in `plans/adr/README.md` | residual docs |
 | G-P1-9 | Transitive Dependabot advisories | Upstream chains (libsql/openssl/webpki) | security hygiene |
+| G-P1-10 | `eval set-threshold` is advertised but always fails; suggested `eval show` command does not exist | `memory-cli/src/commands/eval.rs` | ✅ PTA-A3 closed — command removed |
+| G-P1-11 | Pattern recommendations require manual session creation; playbooks record `Uuid::nil()` in memory only | core/MCP/CLI attribution paths | ADR-078 / RAT-A1…A7 |
+| G-P1-12 | Feedback accepts integrity states that can corrupt attribution statistics | tracker/API/persistence paths | ADR-078 / RAT-A4 |
+| G-P1-13 | Dependabot is excluded from most substantive code/test/security assertions | actor conditions across CI/coverage/security/file/benchmark workflows | ADR-079 / CIT-A2 |
+| G-P1-14 | Gate contract claims parity while tests, Clippy, LOC, and quality-bundle semantics differ; validator is presence-only | `GATE_CONTRACT.md`, `ci.yml`, `quick-check.yml`, `validate-gate-contract.sh` | ADR-079 / CIT-A3 |
+| G-P1-15 | Release manual dispatch is broken; publish selection and fuzz evidence have silent skip/green paths | release run `30301797956`, publish/fuzz workflow conditions | ADR-079 / CIT-A4/A5 |
 
 ### P2 (product / research)
 
 | ID | Gap | Notes | Track |
 |----|-----|-------|--------|
 | G-P2-1…7 | R-F1…R-F7, R-F10 epics | Spike-gated DEFER | R-F* |
+| G-P2-8 | Feedback does not idempotently update later recommendation ranking | ADR-078 captures data only | Follow-up ADR |
+| G-P2-9 | Azure/Custom/Cohere runtime embedding adapters absent | Honest rejection required by ADR-077 | Provider-specific ADR if prioritized |
 
 ## Explicit non-gaps
 
@@ -57,11 +72,17 @@
 | Batch MCP tools | Deferred product decision |
 | Production LOC >500 | Closed |
 | Medium-risk skill presence-only evals | Closed |
-| Release lag / commit_limit on tag | Closed by v0.1.36 ship |
+| Release lag / commit_limit on tag | Closed by v0.1.37 ship and 0.1.38 post-bump |
 | R-F8 relationship show polish | ✅ #893 |
 | R-F9 HNSW persistence | ✅ #893 |
+| Unsupported embedding adapters | Honest ADR-077 rejection; additive P2 work |
+| Automatic attribution changes ranking | **False** until a separate idempotent update design is implemented |
+| `Required Check Anchor` protects merges | **False** — not in the live ruleset and only echoes |
+| Green first-party workflow means merge-required | **False** — live ruleset does not require those contexts |
 
 ## Exit criteria for this register
 
-- G-P1-8 and G-P1-9 are monitor-only (no code action required)  
-- P2 rows remain spikes until GO artifacts under `plans/STATUS/spikes/`  
+- ADR-079 CIT-A1…A5 exits are implemented, including live aggregate protection.
+- PTA-A1…A3 have code and feature-matrix tests. ✅ (2026-08-01)
+- ADR-078 acceptance criteria and RAT-A1…A7 are implemented with evidence.
+- Ranking adaptation remains explicitly open until separately decided and tested.

--- a/plans/STATUS/VALIDATION_LATEST.md
+++ b/plans/STATUS/VALIDATION_LATEST.md
@@ -1,46 +1,74 @@
-# Validation Latest — 2026-07-26
+# Validation Latest — 2026-07-30
 
-**Goal**: Reconcile plans trackers with live post-v0.1.36 + ADR-077 (A1-A6) state.  
-**Workspace**: `0.1.37` · **Tag**: `v0.1.36` · **HEAD**: `648e11ad` (main; ADR-077 A6 merged #897)  
+**Goal**: Validate the GitHub Actions/CI audit and synchronize it with the
+product-truth and recommendation-attribution plan without changing workflows.
+
+**Workspace**: `0.1.38` · **Tag**: `v0.1.37` · **Audit HEAD**: `e66defdf`
 
 ## Evidence
 
 | Check | Observation | Result |
 |-------|-------------|--------|
-| Released tag | `v0.1.36` published 2026-07-22 | ✅ |
-| Workspace version | `Cargo.toml` `0.1.37` | ✅ |
-| Open issues | `gh issue list --state open` | empty |
-| Open PRs | none | — |
-| R-A1 / R-A2 | ship + post-bump | ✅ closed |
-| R-E2 / docs integrity | #883 / #885 | ✅ merged |
-| R-F8 / R-F9 | #893 | ✅ merged |
-| Skills | 40/40 routed | ✅ |
-| ADR-071 | auto-checkpoint on Abstained | ✅ Implemented |
-| ADR-072 | authority + governance | ✅ Implemented |
-| ADR-073 | S1.1c NO-GO, fail-closed | ✅ Implemented |
-| ADR-077 A1-A5 | runtime embedding activation (exact factory, atomic seam, MCP e2e) | ✅ main `9ef4b742`/`e0f7f712` |
-| ADR-077 A6 | activation docs + concurrency + zero-unsafe redaction regression tests | ✅ #897 merged |
-| Prod `todo!` / unimplemented | live search | 0 |
+| Version state | `Cargo.toml` `0.1.38`; latest tag `v0.1.37` | ✅ |
+| Live ruleset | REST `rulesets/9591004`: Codacy required; CodeQL severity policy; no first-party context | ⚠️ P0 |
+| Required Check Anchor | Echo-only workflow; absent from ruleset | ⚠️ misleading/dead |
+| Wait semantics | 5 workflows allow `success,skipped,cancelled` and `fail-on-no-checks: false` | ❌ not fail-closed |
+| PR #914 control case | Commit Message Lint failed; all downstream `Check Quick Check Status` jobs succeeded | ❌ split fast-gate contract |
+| Dependabot | Core CI/test/coverage/security/file/semver/WASM paths explicitly exclude actor | ❌ assertion gap |
+| Test contract | Local `cargo nextest run --all`; CI excludes benches/examples/test-utils | ❌ drift |
+| Quality contract | CI duplicates a subset; parity validator checks files/keywords only | ❌ drift |
+| Release dispatch | Run `30301797956`: `main` failed expected-tag preflight, all downstream skipped | ❌ broken trigger |
+| Action pinning | Inspected external `uses:` references are commit-SHA pinned | ✅ |
+| ADR-078 status | Proposed; no implementation claim | ✅ truthful |
+| ADR-079 status | Proposed; workflow and ruleset implementation unchanged | ✅ truthful |
+| PTA-A1…A3 | ✅ Implemented (2026-08-01): cascade `CapabilityUnavailable`, `MetricValue` storage provenance, `eval set-threshold` removed |
+| Patch whitespace | `git diff --check` | ✅ |
+| Active/version/ADR/ID/link plans validation | `validate-plans.sh --active-set --version-state --adrs --identifiers --links` | ✅; known historical ADR-025/054 warnings only |
+| Current gate validator | `validate-gate-contract.sh --ci-parity` | ✅ presence contract; not semantic proof |
+| Production tests | No production/workflow code changed | Not run |
 
-## Closed validation goals
+## Analysis evidence
 
-| Goal | Result |
-|------|--------|
-| Ship v0.1.36 | ✅ release-manager + release.yml |
-| Post-bump 0.1.37 | ✅ #886 |
-| Skill eval depth (R-E2) | ✅ #883 |
-| Docs integrity ship gate | ✅ #885 |
-| R-F8 relationship polish | ✅ #893 |
-| R-F9 HNSW persistence | ✅ #893 |
-| 6 new domain skills (40 total) | ✅ #894 |
-| ADR-071/072/073 status updated | ✅ #894 |
-| ADR-077 runtime embedding activation A1-A5 | ✅ main (`9ef4b742`, `e0f7f712`) |
-| ADR-077 A6 validate / document / gate | ✅ #897 merged |
+- Traced recommendation generation and attribution across core, MCP, CLI,
+  Turso, and redb.
+- Verified the non-`csm` cascade successful-empty path.
+- Verified CLI storage estimates/unavailable values are rendered as telemetry.
+- Verified `eval set-threshold` has no persisted/consumed override model.
+- Verified feedback currently feeds statistics but not later recommendation ranking.
+- Inspected Quick Check, CI, Coverage, Security, Benchmarks, File Structure,
+  Release, Publish, Fuzz, Mutation, Storage Matrix, Supply Chain, and gate scripts.
+- Queried recent Actions history. In the 14-day sample, superseding pushes account
+  for substantial cancellation churn (CI 12/38, Coverage 10/39, Benchmarks 12/26);
+  these counts are operational context, not failures by themselves. Acceptance of
+  cancellation by gate waiters is the independent correctness defect.
+- Verified the active ruleset was updated 2026-06-03 and has no first-party
+  required context. Classic branch protection returns “Branch not protected”
+  because protection is implemented as a repository ruleset.
+- Confirmed two open PRs (#914, #915) and one open issue (#913) at audit time.
 
-## Still open after this validation
+## Open after this validation
 
-| Item | Next step |
-|------|-----------|
-| ADR-077 A6 PR | ✅ Merged #897 |
-| R-F* remaining | DEFER until individual GO spikes |
-| v0.1.37 release | Trigger when unreleased commits accumulate |
+| Priority | Item | Next step |
+|----------|------|-----------|
+| P0 | ADR-079 required-check control plane | Maintainer decision; implement/fault-inject aggregate before ruleset change |
+| P0 | Cancelled/missing/commitlint and actor gaps | CIT-A2 after aggregate skeleton |
+| P0 | PTA-A1 cascade capability truth | Implement typed unavailable/compile-time exclusion |
+| P0 | PTA-A2 storage metric truth | Add provenance or omit unavailable fields |
+| P1 | Gate contract/release/publish/fuzz truth | CIT-A3…A5 |
+| P1 | PTA-A3 unsupported threshold surface | Remove/hide command |
+| P1 | ADR-078 attribution capture | Maintainer decision, then RAT-A1…A7 |
+| P2 | Feedback-to-ranking adaptation | Separate ADR after capture integrity |
+
+## Planning-document validation
+
+Executed successfully:
+
+```bash
+git diff --check
+./scripts/validate-plans.sh --active-set --version-state --adrs --identifiers --links
+./scripts/validate-gate-contract.sh --ci-parity
+```
+
+The last command validates the current presence-based contract only;
+ADR-079/CIT-A3 records why it is not yet semantic proof. Plan validation reported
+only the known historical ADR-025 and ADR-054 duplicate-number aliases.

--- a/plans/adr/ADR-078-Automatic-Recommendation-Attribution.md
+++ b/plans/adr/ADR-078-Automatic-Recommendation-Attribution.md
@@ -1,0 +1,152 @@
+# ADR-078: Automatic, Episode-Bound Recommendation Attribution
+
+- **Status**: Proposed
+- **Date**: 2026-07-30
+- **Deciders**: Project maintainers
+- **Plan**: [`../GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`](../GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md)
+- **Related**: ADR-039 (plans governance), ADR-044 (recommendation attribution), ADR-072 (authority/evidence), ADR-075 (durability truth)
+- **Code evidence**: `memory-core/src/memory/pattern_api.rs`, `memory-core/src/memory/retrieval/playbooks.rs`, `memory-core/src/memory/api.rs`, `memory-core/src/memory/persistence.rs`, `memory-mcp/src/mcp/tools/pattern_search.rs`, `memory-cli/src/commands/pattern/core/search.rs`
+
+## Context
+
+ADR-044 introduced recommendation sessions, feedback, aggregate effectiveness
+statistics, Turso/redb persistence, and MCP/CLI commands. The pieces exist, but
+normal recommendation operations do not use them consistently:
+
+- `recommend_patterns_for_task` returns recommendations without a session;
+- MCP and CLI require a separate manual `record-session` operation, so most
+  recommendation exposures are not attributable;
+- `retrieve_playbooks` records a hidden in-memory session against `Uuid::nil()`
+  and bypasses the public persistence path;
+- the public recorder returns `()` and logs persistence failures, while storage
+  trait defaults can return `Ok(())` without writing anything;
+- feedback can be accepted without proving that its session exists or that its
+  applied pattern IDs were among those recommended; and
+- each episode can legitimately have multiple recommendation exposures, while
+  the episode lookup contract is only implicitly “latest session.”
+
+This is an attribution-capture and contract-truth gap. It does **not** by itself
+close the ranking-learning loop: current feedback feeds statistics, but no
+production path idempotently applies attributed outcomes to later pattern scores.
+
+## Decision
+
+### 1. Add explicit attributed core operations
+
+Keep existing unattributed pattern and playbook APIs behavior-compatible. Add
+attributed variants that require a non-nil, existing episode ID and return the
+recommendations together with an attribution receipt.
+
+MCP and CLI accept an optional `episode_id`. When absent, they call the existing
+unattributed operation and preserve the current wire/output shape. When present,
+they call the attributed operation and add an `attribution` envelope. Ordinary
+search, analogous discovery, and explanation operations remain unattributed.
+
+### 2. Derive sessions from returned recommendations in core
+
+One shared core path creates the session from the exact pattern and playbook IDs
+returned to the caller. MCP and CLI do not reconstruct ID lists independently.
+The hidden `Uuid::nil()` side effect in playbook retrieval is removed.
+
+A valid recommendation operation that returns no matches may still create an
+empty session so abstention/coverage can be measured. A recommendation error
+must not create a session. The playbook API must therefore distinguish a valid
+empty result from generation failure instead of collapsing both to `Vec::new()`.
+
+### 3. Return a truthful persistence receipt
+
+The attributed operation remains successful when recommendation generation
+succeeds even if attribution persistence is degraded. Its receipt is a tagged,
+machine-stable state:
+
+| State | Meaning |
+|-------|---------|
+| `persisted` | At least one persistence backend is configured and every configured capable backend wrote the session |
+| `partially_persisted` | At least one configured capable backend wrote it and at least one failed |
+| `memory_only` | No persistence backend is configured; the session exists only in this process |
+| `persistence_failed` | Configured capable backends all failed; the session remains process-local |
+
+Every state includes `session_id` and `episode_id`; degraded states include
+stable backend identifiers, not raw backend errors or credentials. Detailed
+errors remain in logs. A failed persistence receipt never implies restart-safe
+feedback.
+
+The current warning-only recorder remains for source compatibility and delegates
+to a new checked recorder. Recommendation-attribution capability must be explicit:
+the checked path never counts the storage trait's successful no-op defaults as a
+write. Turso and redb advertise support; unsupported implementations are skipped
+or return a typed unsupported result.
+
+### 4. Make session and feedback integrity explicit
+
+- Reject malformed, nil, and nonexistent episode IDs before attribution.
+- Multiple exposures for one episode create distinct session IDs; do not upsert
+  or deduplicate by episode ID.
+- Preserve lookup by session ID. Define episode lookup as the latest session and
+  make tie-breaking deterministic beyond second-resolution timestamps.
+- Resolve a session from memory or storage before accepting feedback.
+- Reject applied pattern IDs that were not recommended in that session.
+- Treat replacement feedback for one session as idempotent replacement, not a
+  second application event.
+- Return the same persistence receipt semantics for manual session creation and
+  feedback writes so MCP/CLI success is truthful.
+
+Caller-provided retry/idempotency keys and list-all-sessions-by-episode are
+deferred until at-least-once retry behavior demonstrates a need.
+
+### 5. Defer ranking adaptation to a separate decision
+
+ADR-078 captures trustworthy data but does not mutate pattern effectiveness or
+recommendation ranking. A follow-up must define idempotent durable updates,
+replacement-feedback semantics, rollback behavior, and how attributed evidence
+changes ranking weights before the project claims the learning loop is closed.
+
+## Consequences
+
+### Positive
+
+- Normal recommendation use can produce feedback-ready session IDs automatically.
+- Pattern and playbook attribution share one core contract across library, MCP,
+  CLI, Turso, and redb.
+- Callers can distinguish durable, partial, process-only, and failed persistence.
+- Existing unattributed consumers retain their current output contract.
+- Orphan feedback and impossible applied-pattern claims are rejected.
+
+### Negative and trade-offs
+
+- Persistence reporting needs a capability-aware core seam across both backends.
+- Attributed calls validate episode existence and perform extra writes.
+- The separate manual session command remains for compatibility even though it
+  is unnecessary after an attributed recommendation.
+- Capture quality improves before ranking quality; this ADR intentionally avoids
+  overstating immediate self-learning behavior.
+
+## Alternatives considered
+
+1. **Always create sessions**: rejected because it breaks library and wire
+   compatibility and cannot bind recommendations to an episode reliably.
+2. **Create sessions only in MCP/CLI**: rejected because surfaces could diverge
+   and reconstruct IDs differently from the recommendations actually returned.
+3. **Fail the whole recommendation on persistence error**: rejected because
+   attribution telemetry must not suppress otherwise valid recommendations.
+4. **Keep warning-only persistence**: rejected because returning a session ID
+   without durability state misleads callers after restart.
+5. **Apply feedback to ranking in the same change**: rejected until idempotent,
+   durable update and replacement semantics are designed and tested.
+
+## Acceptance criteria
+
+- Legacy calls without `episode_id` preserve their existing response/output
+  shape and create no session.
+- Attributed calls reject malformed, nil, and nonexistent episode IDs.
+- Pattern and playbook sessions contain exactly the IDs returned to the caller.
+- No playbook path creates a nil-episode session or bypasses the checked recorder.
+- No configured persistence backend yields `memory_only`, never `persisted`.
+- All configured capable stores succeed → `persisted`; some fail →
+  `partially_persisted`; all fail → `persistence_failed` without losing results.
+- Persisted sessions remain retrievable by session ID after restart.
+- Two attributed calls for one episode create and retain two distinct sessions;
+  latest lookup is deterministic.
+- Unknown-session feedback and non-recommended applied IDs are rejected.
+- Manual MCP/CLI session and feedback commands use the checked semantics.
+- Documentation describes this as attribution capture, not ranking adaptation.

--- a/plans/adr/ADR-079-Fail-Closed-CI-Required-Check-Control-Plane.md
+++ b/plans/adr/ADR-079-Fail-Closed-CI-Required-Check-Control-Plane.md
@@ -1,0 +1,174 @@
+# ADR-079: Fail-Closed CI Required-Check Control Plane
+
+- **Status**: Proposed
+- **Date**: 2026-07-30
+- **Deciders**: Project maintainers
+- **Related**: ADR-029, ADR-030, ADR-038, ADR-039, ADR-042, ADR-072
+- **Plan**: `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`
+
+## Context
+
+The checked-in workflows run substantial validation, but the merge control plane
+does not require it. The active `main-protection` ruleset requires only Codacy
+status and high-severity CodeQL policy. Quick Check, tests, coverage, security,
+storage matrices, and the `Required Check Anchor` are not required contexts.
+The anchor itself only echoes a message and is not causally linked to validation.
+
+Five workflows independently poll one Quick Check job. Their waiters accept
+`cancelled` and `skipped`, permit a missing check, and ignore the separate commit
+lint job. PR #914 demonstrates the split contract: commit lint failed while all
+downstream `Check Quick Check Status` jobs passed. Dependabot is explicitly
+excluded from most CI, test, coverage, security, file-validation, semver, and
+WASM jobs. This means workflow presence and green status cannot be treated as a
+merge gate.
+
+There is also contract drift:
+
+- `plans/GATE_CONTRACT.md` advertises `cargo nextest run --all`, while required
+  CI excludes benches, examples, and test-utils;
+- the CI “Quality Gates” job does not execute the local quality-gate bundle;
+- CI Clippy has a broad copied allow-list that differs from the local command;
+- the gate-contract validator checks that files and keywords exist, not that
+  cancellation, dependency, command, and ruleset semantics are aligned;
+- Release exposes a manual dispatch that necessarily fails its tag preflight;
+- manual single-crate publish selections are constrained by a dependency chain
+  that can turn skipped prerequisites into skipped requested jobs; and
+- fuzz targets use `continue-on-error`, while crash upload is guarded by
+  `failure()`, allowing crashes to be green and lose their evidence.
+
+## Decision
+
+### 1. One causally complete required context
+
+Create one stable aggregate context, provisionally `CI / Required`, from a single
+PR orchestrator. Required jobs and their applicability decisions run in the same
+workflow invocation. The aggregate uses `if: always()` and evaluates every
+declared dependency result.
+
+The aggregate succeeds only when each applicable gate succeeded. `failure`,
+`cancelled`, missing/unknown state, and timeout fail closed. `skipped` is accepted
+only when an in-workflow path/event classifier explicitly marked that gate not
+applicable. A workflow-level path filter must not make the required context
+disappear.
+
+Cross-workflow polling is not part of the required control plane. Reusable
+workflows or composite actions may share implementation, but required outcomes
+must return to the orchestrator as same-run job dependencies.
+
+### 2. Aggregate the whole fast gate
+
+Formatting, Clippy, doctests/docs, ignored-test ceiling, YAML/frontmatter checks,
+and commit-message policy form the fast gate. A failure in any component fails the
+aggregate. A separate successful format/Clippy job cannot mask failed commit lint.
+Cancelled or absent fast checks never authorize expensive or required work.
+
+### 3. Actor parity with least privilege
+
+Dependabot and fork PRs receive the same code-quality and test assertions as
+maintainer PRs. Trust differences are handled with read-only permissions, no
+secrets, no cache writes, and explicit secret-dependent job applicability—not by
+omitting tests, semver, WASM, security, or structural checks wholesale.
+
+### 4. One executable gate contract
+
+Each gate has one canonical command or shared script used by local and CI entry
+points. `GATE_CONTRACT.md` records three distinct facts:
+
+1. command/scope implemented by the workflow;
+2. whether the job is merge-required by the live ruleset; and
+3. measured versus required versus target thresholds.
+
+The parity validator must inspect command arguments, aggregate dependencies,
+fail-closed result handling, actor conditions, and the expected ruleset context.
+Presence-only keyword checks are insufficient. Test exclusions must either be
+removed from the required Linux test surface or be documented as an explicit
+policy with a separately enforced owner; prose may not call the subset `--all`.
+
+### 5. Stage ruleset migration
+
+Repository rules are changed only after the new aggregate has emitted the stable
+context successfully on representative normal, Dependabot, fork, docs-only, and
+code PR fixtures. Migration order is:
+
+1. add the aggregate without changing protection;
+2. observe and fault-inject failure/cancellation/missing/applicability cases;
+3. add `CI / Required` to `main-protection` while retaining current external
+   Codacy and CodeQL controls;
+4. verify a deliberately failed aggregate blocks merge; and
+5. remove the unused echo anchor and obsolete polling waiters.
+
+Ruleset mutation is a shared-infrastructure action and requires explicit
+maintainer approval at implementation time. No bypass flag is used.
+
+### 6. Keep release and publish triggers truthful
+
+Release creation remains tag-only under ADR-072. Remove the broken Release
+`workflow_dispatch` surface rather than inventing a second release path.
+Publishing gets an explicit package plan/dependency closure, exact version
+preflight, `cargo publish --locked`, bounded sparse-index propagation polling,
+and a separate safe validation/dry-run mode. A requested package must publish,
+validate as already present, or fail with a reason; it must not disappear because
+an unrelated prerequisite job was skipped.
+
+### 7. Preserve evidence for informational gates
+
+Fuzz and mutation checks may remain non-merge-blocking while baselines mature,
+but crashes, surviving mutants, startup failures, and timeouts must be visible in
+the job summary and uploaded with `if: always()`. A top-level green conclusion
+must not be the only durable signal. Threshold promotion requires a measured
+baseline and a separate ratchet change.
+
+## Consequences
+
+### Positive
+
+- Branch protection becomes causally linked to first-party validation.
+- Cancellation, missing checks, commit lint, and actor differences cannot
+  silently produce approval.
+- Local and CI acceptance criteria become reviewable and machine-checked.
+- Required checks retain one stable context while internal jobs evolve.
+- Release, publish, fuzz, and mutation outcomes become truthful and actionable.
+
+### Negative
+
+- Consolidating orchestration touches several workflows and requires staged
+  ruleset coordination.
+- Dependabot/fork parity may increase CI minutes until duplication is removed.
+- A stable aggregate adds explicit applicability and result-mapping logic that
+  needs fixture tests.
+
+### Neutral
+
+- Coverage and performance need not become merge-blocking merely because they
+  are visible; their required status is an explicit policy choice.
+- External Codacy and CodeQL controls remain in place during and after migration.
+
+## Alternatives considered
+
+1. **Require every current job directly**: rejected because path-conditional jobs
+   can disappear and job names/topology become ruleset API.
+2. **Make the echo anchor query other workflows**: rejected because it repeats
+   the current cross-workflow race, missing-check, and cancellation problems.
+3. **Use `workflow_run` as the aggregate**: rejected because its status attaches
+   to another workflow run rather than providing a simple same-PR dependency DAG.
+4. **Keep only external analysis required**: rejected because it does not prove
+   Rust compilation, tests, documentation, or repository-specific contracts.
+5. **Skip untrusted actors**: rejected because dependency changes are precisely
+   where build, test, semver, and security validation are needed.
+
+## Acceptance criteria
+
+- The live ruleset requires `CI / Required` after staged verification.
+- Failed, cancelled, timed-out, or missing applicable jobs fail the aggregate.
+- Commit lint failure fails the aggregate.
+- Explicitly inapplicable path/secret jobs do not block and cannot masquerade as
+  applicable successes.
+- Normal, Dependabot, fork, docs-only, and code PR fixtures emit the same stable
+  aggregate context.
+- Required test and Clippy commands match the documented contract exactly.
+- A gate-contract fixture fails when cancellation is allowed, Dependabot is
+  excluded, a dependency is removed, or the ruleset context is absent.
+- Release manual dispatch is absent and tag release remains successful.
+- Publish selection/dependency fixtures cannot silently skip requested work.
+- Fuzz crashes upload evidence and produce a visible non-green signal even while
+  the workflow remains non-required.


### PR DESCRIPTION
## Summary

Implements PTA-A1/A2/A3 from `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md` (product truth wave). No ADR acceptance or ruleset mutation required — these are pure code/doc truth fixes.

## Changes

### PTA-A1: Cascade capability truth (`do-memory-core`)
- `CascadeRetriever::retrieve` now returns `Result<CascadeResult, CascadeError>`; non-`csm` builds return `Err(CascadeError::CapabilityUnavailable)` instead of a successful empty result.
- `CascadeError` implements `Display` + `std::error::Error`.
- Fixed a pre-existing `csm` build break: `merge_results(..., top_k)` signature (chaotic_semantic_memory 0.3.7).
- Feature-matrix tests updated/added; both default and `csm` feature sets compile, pass tests, and clippy-clean.

### PTA-A2: CLI storage metric provenance (`do-memory-cli`)
- New `MetricValue<T>`/`MetricProvenance` (measured/estimated/unavailable) in `storage/provenance.rs`.
- `storage stats` and `storage connections` no longer present estimates/unknowns as measured (removed "last 24h", zero cache-hit rate, fixed pool sizes).
- Human output labels `(estimate)`/`unavailable`; JSON carries `{"value", "provenance"}`.
- 9 new unit tests.

### PTA-A3: Remove advertised threshold non-operation (`do-memory-cli`)
- `eval set-threshold` removed from Clap enum, dispatch, help snapshot, README, and CLI_USER_GUIDE (no override model is persisted/consumed). Dangling `eval show` reference gone.
- Clap parse tests assert rejection.

### Docs
- `plans/` goal-state flags, roadmap, goals, actions, gap register, validation, and current status updated to mark PTA-A1/A2/A3 implemented. ADR-078/079 remain Proposed.

## Validation
- `cargo fmt --check`, `cargo clippy --workspace -D warnings`, `cargo build check`: pass
- `cargo nextest run --all`: 3697 passed, 182 skipped
- `cargo test --doc`, `cargo doc --no-deps --document-private-items`: pass
- `./scripts/validate-plans.sh --active-set --version-state --adrs --identifiers --links`: pass (known historical ADR aliases only)
- Independent code review completed; warnings addressed (Display/Error impl, dead code removal).

## Notes
- `scripts/quality-gates.sh` LOC gate flags 3 files (extract.rs 590, relationships/types.rs 583, semantic_service.rs 579) — pre-existing on `main` and untouched by this PR; CI's Quality Gates job does not run that script.