### PR TITLE
chore(plans): record PR #916/#917 merge session progress

### DIFF
--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1,9 +1,10 @@
 # GOAP State Snapshot
 
-- **Last Updated**: 2026-07-30
+- **Last Updated**: 2026-08-02
 - **Version**: workspace `0.1.38` · latest tag `v0.1.37`
-- **Branch**: `main` @ `f0ffc4a3`
-- **Open PRs**: #916 (PTA-A1/A2/A3 product truth — all CI green)
+- **Branch**: `main` @ `33b9d302`
+- **Open PRs**: none (0 open)
+- **PR merge session**: #916 + #917 merged 2026-08-02 (see `plans/STATUS/VALIDATION_LATEST.md`)
 - **Open issues**: #913
 - **Active plan**: `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md` (PTA-A1/A2/A3 implemented)
 - **Archive**: `plans/archive/2026-07-consolidation/`  
@@ -21,9 +22,10 @@
 | CIT-A3 semantic gate-contract parity | Blocked by CIT-A2 |
 | CIT-A4 release/publish trigger truth | Planned (P1) |
 | CIT-A5 durable informational evidence + deduplication | Planned (P1/P2) |
-| PTA-A1 non-`csm` cascade capability truth | Implemented | PTA-A1 |
-| PTA-A2 CLI storage metric truth | Implemented | PTA-A2 |
-| PTA-A3 threshold command cleanup | Implemented | PTA-A3 |
+| PTA-A1 non-`csm` cascade capability truth | ✅ #916 merged (2026-08-02) | PTA-A1 |
+| PTA-A2 CLI storage metric truth | ✅ #916 merged (2026-08-02) | PTA-A2 |
+| PTA-A3 threshold command cleanup | ✅ #916 merged (2026-08-02) | PTA-A3 |
+| cargo-mutants CI sharding (reward/retrieval/retry/patterns) | ✅ #917 merged (2026-08-02) | CI |
 | ADR-078 automatic recommendation attribution | Proposed |
 | RAT-A1 contract tests | Blocked by ADR acceptance |
 | RAT-A2…A7 implementation | Blocked by preceding RAT packages |

--- a/plans/STATUS/VALIDATION_LATEST.md
+++ b/plans/STATUS/VALIDATION_LATEST.md
@@ -52,10 +52,10 @@ product-truth and recommendation-attribution plan without changing workflows.
 |----------|------|-----------|
 | P0 | ADR-079 required-check control plane | Maintainer decision; implement/fault-inject aggregate before ruleset change |
 | P0 | Cancelled/missing/commitlint and actor gaps | CIT-A2 after aggregate skeleton |
-| P0 | PTA-A1 cascade capability truth | Implement typed unavailable/compile-time exclusion |
-| P0 | PTA-A2 storage metric truth | Add provenance or omit unavailable fields |
+| P0 | PTA-A1 cascade capability truth | ✅ #916 merged (typed `CapabilityUnavailable`) |
+| P0 | PTA-A2 storage metric truth | ✅ #916 merged (`MetricValue` provenance) |
 | P1 | Gate contract/release/publish/fuzz truth | CIT-A3…A5 |
-| P1 | PTA-A3 unsupported threshold surface | Remove/hide command |
+| P1 | PTA-A3 unsupported threshold surface | ✅ #916 merged (`eval set-threshold` removed) |
 | P1 | ADR-078 attribution capture | Maintainer decision, then RAT-A1…A7 |
 | P2 | Feedback-to-ranking adaptation | Separate ADR after capture integrity |
 
@@ -72,3 +72,25 @@ git diff --check
 The last command validates the current presence-based contract only;
 ADR-079/CIT-A3 records why it is not yet semantic proof. Plan validation reported
 only the known historical ADR-025 and ADR-054 duplicate-number aliases.
+
+## PR merge session — 2026-08-02 (#916 + #917)
+
+GOAP-orchestrated review/merge of the open PR queue (swarm: pr-readiness +
+release-cadence-manager + code review). Result: queue 2 → 0 open.
+
+| Check | Observation | Result |
+|-------|-------------|--------|
+| PR #917 ci(mutants) shard | 37 pass / 9 skip, no actionable comments; CLEAN | ✅ merged `b7d67f3e` (squash) |
+| PR #916 PTA-A1/A2/A3 | Release-drift check blocked: `commit_limit` (30 unreleased, critical). Resolved via `release-preparation` label (release PR escape hatch) | ✅ merged `33b9d302` (squash) |
+| PR #916 full CI | 42 checks green: Tests, MCP Build, Multi-Platform ×2, Benchmarks (51m), Quality Gates, Codacy, CodeQL | ✅ |
+| main CI after #917 | Quick Check, CI, Coverage, CodeQL, Storage Matrix, YAML Lint | ✅ |
+| Open PRs | `gh pr list --state open` | none |
+| Release drift | workspace `0.1.38` > tag `v0.1.37` (version advanced); `commit_limit` accumulates until next release | ⚠️ monitored |
+| PR comments | codacy 0 issues ×2, codecov all-covered ×2, benchmark posts (informational) | ✅ no actionable |
+
+**Roast findings (non-blocking, pre-existing)** — logged for follow-up, not
+introduced by #916: `vacuum_storage` reports `storage_optimized` while doing
+no work; `#[expect(clippy::excessive_nesting)]` on `sync_storage` (suppression
+vs "fix, don't suppress"); `HealthStatus` Debug-vs-Display inconsistency;
+redundant `expanded_terms.is_empty()` guard in `retrieve_concept_graph`.
+


### PR DESCRIPTION
## What

Progress tracker update after the 2026-08-02 GOAP-orchestrated PR merge session (queue 2 → 0 open):

- **plans/GOAP_STATE.md**: header refresh (main @ 33b9d302, 0 open PRs), PTA-A1/A2/A3 marked merged (#916), cargo-mutants CI sharding marked merged (#917)
- **plans/STATUS/VALIDATION_LATEST.md**: new "PR merge session — 2026-08-02" evidence section (merge commits, drift resolution via `release-preparation` label, roast findings logged)

## Validation

- `./scripts/validate-plans.sh --active-set --version-state --adrs --identifiers --links` passes (only pre-existing ADR-025/054/078 duplicate-number warnings)
- Docs-only change (no production code)

## Notes

Labeled `release-preparation`: release-drift `commit_limit` is repo-wide until the next release; this is release-prep documentation work.