### PR TITLE
fix(quality): resolve pre-existing warnings and clippy failures

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -40,3 +40,13 @@ slow-timeout = { period = "90s", terminate-after = 3 }
 [[profile.ci.overrides]]
 filter = "package(e2e-tests) and test(test_pattern_discovery)"
 slow-timeout = { period = "90s", terminate-after = 3 }
+
+# Pattern accuracy gate shells out to a nested `cargo test -p do-memory-core`
+# build; give it headroom for cold caches (same pattern as the perf gate).
+[[profile.default.overrides]]
+filter = "package(e2e-tests) and test(quality_gate_pattern_accuracy)"
+slow-timeout = { period = "180s", terminate-after = 2 }
+
+[[profile.ci.overrides]]
+filter = "package(e2e-tests) and test(quality_gate_pattern_accuracy)"
+slow-timeout = { period = "180s", terminate-after = 2 }

--- a/memory-cli/src/commands/storage/commands.rs
+++ b/memory-cli/src/commands/storage/commands.rs
@@ -51,7 +51,6 @@ pub async fn storage_stats(
     Ok(())
 }
 
-#[expect(clippy::excessive_nesting)]
 pub async fn sync_storage(
     memory: &do_memory_core::SelfLearningMemory,
     _config: &Config,
@@ -178,37 +177,36 @@ pub async fn sync_storage(
             &episode.episode_id.to_string()[..8]
         ));
 
-        match redb.store_episode(&episode).await {
-            Ok(_) => {
-                episodes_synced += 1;
-                progress.inc(1);
+        if let Err(e) = redb.store_episode(&episode).await {
+            eprintln!("Failed to sync episode {}: {}", episode.episode_id, e);
+            errors += 1;
+            progress.inc(1);
+            continue;
+        }
+        episodes_synced += 1;
+        progress.inc(1);
 
-                // Also sync patterns and heuristics if they exist
-                for pattern_id in &episode.patterns {
-                    // Try to get pattern from Turso and store in redb
-                    if let Ok(Some(pattern)) = turso.get_pattern(*pattern_id).await {
-                        if let Err(e) = redb.store_pattern(&pattern).await {
-                            eprintln!("Warning: Failed to sync pattern {}: {}", pattern_id, e);
-                        } else {
-                            patterns_synced += 1;
-                        }
-                    }
-                }
-                for heuristic_id in &episode.heuristics {
-                    // Try to get heuristic from Turso and store in redb
-                    if let Ok(Some(heuristic)) = turso.get_heuristic(*heuristic_id).await {
-                        if let Err(e) = redb.store_heuristic(&heuristic).await {
-                            eprintln!("Warning: Failed to sync heuristic {}: {}", heuristic_id, e);
-                        } else {
-                            heuristics_synced += 1;
-                        }
-                    }
-                }
+        // Also sync patterns and heuristics if they exist
+        for pattern_id in &episode.patterns {
+            // Try to get pattern from Turso and store in redb
+            let Ok(Some(pattern)) = turso.get_pattern(*pattern_id).await else {
+                continue;
+            };
+            if let Err(e) = redb.store_pattern(&pattern).await {
+                eprintln!("Warning: Failed to sync pattern {}: {}", pattern_id, e);
+            } else {
+                patterns_synced += 1;
             }
-            Err(e) => {
-                eprintln!("Failed to sync episode {}: {}", episode.episode_id, e);
-                errors += 1;
-                progress.inc(1);
+        }
+        for heuristic_id in &episode.heuristics {
+            // Try to get heuristic from Turso and store in redb
+            let Ok(Some(heuristic)) = turso.get_heuristic(*heuristic_id).await else {
+                continue;
+            };
+            if let Err(e) = redb.store_heuristic(&heuristic).await {
+                eprintln!("Warning: Failed to sync heuristic {}: {}", heuristic_id, e);
+            } else {
+                heuristics_synced += 1;
             }
         }
     }
@@ -244,15 +242,16 @@ pub async fn vacuum_storage(
     format: OutputFormat,
     dry_run: bool,
 ) -> anyhow::Result<()> {
-    let total_cleaned = 0usize;
-    let errors = 0usize;
-    let _storage_optimized = false;
-
+    // Vacuum is not supported through the generic `StorageBackend` trait, so
+    // there is nothing to execute. Report honestly (PTA-A2) rather than
+    // fabricating an "Optimized" success with zero items cleaned.
     if dry_run {
-        println!("DRY RUN: Would perform storage vacuum operations");
-        println!("- Would clean expired cache entries from redb");
-        println!("- Would optimize Turso database structures");
-        println!("- Would remove orphaned data and compact storage");
+        println!(
+            "DRY RUN: storage vacuum is not supported through the generic StorageBackend trait"
+        );
+        println!(
+            "- Would clean expired cache entries / optimize structures via backend-specific tools only"
+        );
 
         let result = VacuumResult {
             items_cleaned: 0, // Would calculate in real run
@@ -264,64 +263,14 @@ pub async fn vacuum_storage(
         return Ok(());
     }
 
-    // Interactive confirmation for vacuum
-    if format == OutputFormat::Human {
-        use colored::*;
-        use dialoguer::Confirm;
-
-        println!("{}", "Storage Vacuum".bold());
-        println!("{}", "==============".bold());
-        println!("This operation will:");
-        println!("  • Clean expired cache entries from redb");
-        println!("  • Optimize Turso database structures");
-        println!("  • Remove orphaned data and compact storage");
-        println!();
-        println!(
-            "{}",
-            "Note: This operation is generally safe but may take time.".yellow()
-        );
-        println!();
-
-        let confirmed = Confirm::new()
-            .with_prompt("Continue with vacuum operation?")
-            .default(true)
-            .interact()?;
-
-        if !confirmed {
-            println!("{}", "Operation cancelled.".yellow());
-            return Ok(());
-        }
-        println!();
-    }
-
-    println!("Starting storage vacuum operations...");
-
-    // Create progress bar for vacuum operations
-    let progress = ProgressBar::new_spinner();
-    progress.set_style(
-        ProgressStyle::default_spinner()
-            .template("{spinner:.blue} [{elapsed_precise}] {msg}")
-            .expect("ProgressStyle template is valid: uses standard format"),
-    );
-    progress.set_message("Analyzing storage for optimization opportunities...");
-
-    // Note: Vacuum operations are limited by the StorageBackend trait
-    // In a full implementation, we'd need to extend the trait with vacuum methods
-    println!("Note: Vacuum operations are limited through the generic StorageBackend trait");
-    println!("For full vacuum capabilities, backend-specific tools should be used directly");
-
-    // For now, we can only report that vacuum is not fully supported
-    // through the generic interface
-
-    // Mark as optimized if no errors occurred (which is always true for now)
-    let storage_optimized = errors == 0;
-
-    progress.finish_with_message("Storage vacuum completed");
+    println!("Storage vacuum is not supported through the generic StorageBackend trait.");
+    println!("For full vacuum capabilities, backend-specific tools should be used directly.");
+    println!("Nothing was cleaned or modified.");
 
     let result = VacuumResult {
-        items_cleaned: total_cleaned,
-        storage_optimized,
-        errors,
+        items_cleaned: 0,
+        storage_optimized: false,
+        errors: 0,
         dry_run: false,
     };
 

--- a/memory-cli/src/commands/storage/tests.rs
+++ b/memory-cli/src/commands/storage/tests.rs
@@ -312,3 +312,71 @@ fn connection_status_human_output_marks_metrics_unavailable() {
         "must not fabricate pool=10"
     );
 }
+
+// ---------------------------------------------------------------------------
+// vacuum_storage command (PTA-A2 honest reporting)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn vacuum_storage_dry_run_succeeds_and_reports_no_work() {
+    // Arrange
+    let memory = do_memory_core::SelfLearningMemory::new();
+    let config = crate::config::Config::default();
+
+    // Act
+    let result =
+        super::commands::vacuum_storage(&memory, &config, crate::output::OutputFormat::Json, true)
+            .await;
+
+    // Assert
+    assert!(result.is_ok(), "dry-run vacuum must succeed");
+}
+
+#[tokio::test]
+async fn vacuum_storage_live_succeeds_without_fabricating_optimization() {
+    // Arrange
+    let memory = do_memory_core::SelfLearningMemory::new();
+    let config = crate::config::Config::default();
+
+    // Act
+    let result =
+        super::commands::vacuum_storage(&memory, &config, crate::output::OutputFormat::Json, false)
+            .await;
+
+    // Assert
+    assert!(result.is_ok(), "live vacuum must succeed without error");
+}
+
+#[tokio::test]
+async fn vacuum_storage_live_human_output_is_not_misleading() {
+    // Arrange
+    let memory = do_memory_core::SelfLearningMemory::new();
+    let config = crate::config::Config::default();
+
+    // Act
+    let result = super::commands::vacuum_storage(
+        &memory,
+        &config,
+        crate::output::OutputFormat::Human,
+        false,
+    )
+    .await;
+
+    // Assert
+    assert!(result.is_ok());
+    let rendered = {
+        let mut buffer = Vec::new();
+        let stats = super::types::VacuumResult {
+            items_cleaned: 0,
+            storage_optimized: false,
+            errors: 0,
+            dry_run: false,
+        };
+        stats.write_human(&mut buffer).unwrap();
+        String::from_utf8(buffer).unwrap()
+    };
+    assert!(
+        !rendered.contains("Optimized"),
+        "must not render a fabricated Optimized status"
+    );
+}

--- a/memory-cli/src/commands/storage/tests.rs
+++ b/memory-cli/src/commands/storage/tests.rs
@@ -380,3 +380,85 @@ async fn vacuum_storage_live_human_output_is_not_misleading() {
         "must not render a fabricated Optimized status"
     );
 }
+
+// ---------------------------------------------------------------------------
+// sync_storage command (Turso -> redb reconciliation, ADR-076)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sync_storage_reconciles_episodes_between_backends() {
+    // Arrange: dual-backend memory (file-backed redb stands in for Turso).
+    let dir = tempfile::tempdir().expect("temp dir for storage backends");
+    let turso = do_memory_storage_redb::RedbStorage::new(&dir.path().join("turso.redb"))
+        .await
+        .expect("turso backend");
+    let cache = do_memory_storage_redb::RedbStorage::new(&dir.path().join("cache.redb"))
+        .await
+        .expect("cache backend");
+    // Lower quality threshold so the fixture episode is accepted (same
+    // convention as the e2e pattern workflow tests).
+    let memory = do_memory_core::SelfLearningMemory::with_storage(
+        do_memory_core::MemoryConfig {
+            quality_threshold: 0.3,
+            ..Default::default()
+        },
+        std::sync::Arc::new(turso),
+        std::sync::Arc::new(cache),
+    );
+
+    // Create a completed episode with a logged step so the durable backend
+    // holds episode + pattern rows to reconcile into the cache.
+    let context = do_memory_core::types::TaskContext {
+        domain: "web-api".to_string(),
+        ..Default::default()
+    };
+    let episode_id = memory
+        .start_episode(
+            "sync fixture episode".to_string(),
+            context,
+            do_memory_core::types::TaskType::CodeGeneration,
+        )
+        .await;
+    let mut step = do_memory_core::episode::ExecutionStep::new(
+        1,
+        "code_editor".to_string(),
+        "write_function".to_string(),
+    );
+    step.result = Some(do_memory_core::types::ExecutionResult::Success {
+        output: "fixture step completed".to_string(),
+    });
+    memory.log_step(episode_id, step).await;
+    let _ = memory.flush_steps(episode_id).await;
+    memory
+        .complete_episode(
+            episode_id,
+            do_memory_core::types::TaskOutcome::Success {
+                verdict: "completed".to_string(),
+                artifacts: vec![],
+            },
+        )
+        .await
+        .expect("complete episode");
+    // Let async pattern extraction finish so `episode.patterns` is populated.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let patterns = memory.get_all_patterns().await.expect("patterns query");
+    assert!(
+        !patterns.is_empty(),
+        "fixture episode must produce a pattern so the sync loop exercises "
+    );
+
+    let config = crate::config::Config::default();
+
+    // Act
+    let result = super::commands::sync_storage(
+        &memory,
+        &config,
+        crate::output::OutputFormat::Json,
+        false,
+        false,
+    )
+    .await;
+
+    // Assert
+    assert!(result.is_ok(), "live sync must succeed with dual backends");
+}

--- a/memory-cli/src/commands/storage/types.rs
+++ b/memory-cli/src/commands/storage/types.rs
@@ -151,7 +151,7 @@ impl Output for StorageHealth {
         writeln!(
             writer,
             "Overall: {}",
-            format!("{:?}", self.overall).color(overall_color).bold()
+            self.overall.to_string().color(overall_color).bold()
         )?;
 
         writeln!(writer, "\nTurso:")?;
@@ -163,7 +163,7 @@ impl Output for StorageHealth {
         writeln!(
             writer,
             "  Status: {}",
-            format!("{:?}", self.turso.status).color(turso_color)
+            self.turso.status.to_string().color(turso_color)
         )?;
         if let Some(latency) = self.turso.latency_ms {
             writeln!(writer, "  Latency: {}ms", latency)?;
@@ -181,7 +181,7 @@ impl Output for StorageHealth {
         writeln!(
             writer,
             "  Status: {}",
-            format!("{:?}", self.redb.status).color(redb_color)
+            self.redb.status.to_string().color(redb_color)
         )?;
         if let Some(latency) = self.redb.latency_ms {
             writeln!(writer, "  Latency: {}ms", latency)?;

--- a/memory-core/src/retrieval/cascade/mod.rs
+++ b/memory-core/src/retrieval/cascade/mod.rs
@@ -332,11 +332,9 @@ impl CascadeRetriever {
                     .count();
 
                 // Score based on term overlap density
-                let score = if expanded_terms.is_empty() {
-                    0.0
-                } else {
-                    match_count as f32 / expanded_terms.len() as f32
-                };
+                // (`expanded_terms` is non-empty here; an empty expansion is
+                // handled by the early return above)
+                let score = match_count as f32 / expanded_terms.len() as f32;
 
                 (id.clone(), score)
             })

--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -33,7 +33,7 @@
 | ACT-341 | Make non-`csm` cascade retrieval capability-truthful | PTA-A1 | ✅ Implemented |
 | ACT-342 | Make CLI storage metrics measured/estimated/unavailable explicitly | PTA-A2 | ✅ Implemented |
 | ACT-343 | Hide unsupported `eval set-threshold` command | PTA-A3 | ✅ Implemented |
-| ACT-328 | Accept ADR-078 and freeze attributed contracts | RAT-A1 | Proposed |
+| ACT-328 | Accept ADR-080 and freeze attributed contracts | RAT-A1 | Proposed |
 | ACT-329 | Add capability-aware checked attribution persistence | RAT-A2 | Blocked by ADR acceptance |
 | ACT-330 | Add core attributed pattern/playbook operations | RAT-A3 | Blocked by ACT-329 |
 | ACT-331 | Enforce session and feedback integrity | RAT-A4 | Blocked by ACT-330 |

--- a/plans/GOALS.md
+++ b/plans/GOALS.md
@@ -1,7 +1,7 @@
 # GOAP Goals Index
 
 - **Last Updated**: 2026-07-30
-- **Status**: CI trust, product-truth remediation, and ADR-078 attribution capture proposed
+- **Status**: CI trust, product-truth remediation, and ADR-080 attribution capture proposed
 - **Workspace**: `0.1.38` · **Tag**: `v0.1.37`
 - **Plan**: `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`
 - **Archive**: `plans/archive/2026-07-consolidation/`
@@ -17,13 +17,13 @@
 | Make disabled cascade capability truthful | PTA-A1 | P0 | ✅ Implemented |
 | Make storage metrics provenance-truthful | PTA-A2 | P0 | ✅ Implemented |
 | Remove unsupported threshold command from CLI help | PTA-A3 | P1 | ✅ Implemented |
-| Capture episode-bound recommendation attribution automatically | RAT-A1…A7 / ADR-078 | P1 | Proposed |
+| Capture episode-bound recommendation attribution automatically | RAT-A1…A7 / ADR-080 | P1 | Proposed |
 | Design idempotent feedback-to-ranking updates | Follow-up ADR | P2 | Deferred |
 | R-F10 OIDC trusted publishing (publish-crates.yml) | R-F10 | P2 | 🔄 In progress |
 | R-F4 SIMD cosine acceleration + benchmark variants | R-F4 | P2 | 🔄 In progress |
 | Optional research/product spikes (R-F1…R-F3, R-F5…R-F7) | R-F* | P3 | ⏸ DEFER |
 
-The ranking-learning loop remains open: ADR-078 captures trustworthy evidence but
+The ranking-learning loop remains open: ADR-080 captures trustworthy evidence but
 does not yet apply feedback to recommendation scores. First-party CI is also not
 currently merge-required; green workflow runs must not be described as branch
 protection until ADR-079's staged ruleset migration completes. Active campaign:

--- a/plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md
+++ b/plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md
@@ -3,7 +3,7 @@
 - **Status**: Proposed
 - **Date**: 2026-07-30
 - **Audit checkout**: `main` at `e66defdf`
-- **Decisions**: [ADR-078](adr/ADR-078-Automatic-Recommendation-Attribution.md) and [ADR-079](adr/ADR-079-Fail-Closed-CI-Required-Check-Control-Plane.md) — Proposed
+- **Decisions**: [ADR-080](adr/ADR-080-Automatic-Recommendation-Attribution.md) and [ADR-079](adr/ADR-079-Fail-Closed-CI-Required-Check-Control-Plane.md) — Proposed
 - **Relevant constraints**: ADR-039, ADR-044, ADR-072, ADR-075, Tokio-only async, postcard, zero clippy warnings
 - **Strategy**: Restore a fail-closed merge control plane first, fix product false-success contracts, then implement attribution integrity from storage/core to MCP/CLI, with converging end-to-end validation
 
@@ -24,7 +24,7 @@ the capture half of ADR-044.
 | P1 | Dependabot is excluded from most substantive CI and gate contracts overstate parity | workflow actor conditions; `plans/GATE_CONTRACT.md` | Actor parity plus semantic contract validation |
 | P1 | Release manual dispatch is broken; publish selection and fuzz evidence have false-success paths | release run `30301797956`, workflow conditions | Truthful trigger/planner/evidence remediation |
 | P1 | `eval set-threshold` is advertised but always errors; its help suggests nonexistent `eval show` | `memory-cli/src/commands/eval.rs` | ✅ Implemented — command removed/hidden |
-| P1 | Recommendation generation does not automatically create truthful episode-bound sessions | ADR-078 evidence | Implement this plan's RAT packages |
+| P1 | Recommendation generation does not automatically create truthful episode-bound sessions | ADR-080 evidence | Implement this plan's RAT packages |
 | P2 | Azure/Custom/Cohere embedding adapters are absent | ADR-077, embedding factory | Remain unavailable until a provider-specific ADR and adapter tests exist |
 | Non-gap | `execute_agent_code` and batch MCP tools are unavailable | ADR-073 and standing product decisions | Preserve fail-closed/deferred state |
 
@@ -249,7 +249,7 @@ do not claim the learning loop is closed until that work has its own ADR/tests.
 
 ### PTA-A9: Validate and update authority documents
 
-Run focused crate tests after each package, then workspace gates. Update ADR-078
+Run focused crate tests after each package, then workspace gates. Update ADR-080
 and ADR-079 to Accepted/Implemented only after code, live ruleset state, and
 evidence exist. Record commit, feature set, UTC timestamp, and validation
 artifacts per ADR-072.
@@ -279,7 +279,7 @@ backend, partial failure, total failure, and restart retrieval.
 
 ## Promotion gates
 
-1. Accept ADR-078 before RAT-A2 changes public persistence semantics.
+1. Accept ADR-080 before RAT-A2 changes public persistence semantics.
 2. Accept ADR-079 before replacing required-check topology; obtain explicit
    approval immediately before mutating the repository ruleset.
 3. Review the receipt/capability model before MCP/CLI wire changes.
@@ -292,5 +292,5 @@ backend, partial failure, total failure, and restart retrieval.
 
 - CIT-A1…A5, PTA-A1…A3, and RAT-A1…A7 exits are met.
 - All quality gates pass with evidence recorded.
-- ADR-078, ADR-079, and canonical trackers reflect actual, not intended, implementation.
+- ADR-080, ADR-079, and canonical trackers reflect actual, not intended, implementation.
 - No plan or user documentation claims feedback changes ranking until verified.

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -26,7 +26,7 @@
 | PTA-A2 CLI storage metric truth | ✅ #916 merged (2026-08-02) | PTA-A2 |
 | PTA-A3 threshold command cleanup | ✅ #916 merged (2026-08-02) | PTA-A3 |
 | cargo-mutants CI sharding (reward/retrieval/retry/patterns) | ✅ #917 merged (2026-08-02) | CI |
-| ADR-078 automatic recommendation attribution | Proposed |
+| ADR-080 automatic recommendation attribution | Proposed |
 | RAT-A1 contract tests | Blocked by ADR acceptance |
 | RAT-A2…A7 implementation | Blocked by preceding RAT packages |
 | Feedback-to-ranking adaptation | Deferred to separate ADR |
@@ -98,7 +98,7 @@ runtime_embedding_activation      = true  (ADR-077 Implemented A1-A6 — configu
 cascade_capability_truthful       = true  (PTA-A1 — non-csm `retrieve` returns `Err(CascadeError::CapabilityUnavailable)`)
 storage_metrics_truthful          = true  (PTA-A2 — `MetricValue` provenance: measured/estimated/unavailable)
 unsupported_threshold_hidden      = true  (PTA-A3 — `eval set-threshold` removed from Clap + docs)
-automatic_attribution_capture     = false (ADR-078 Proposed)
+automatic_attribution_capture     = false (ADR-080 Proposed)
 feedback_integrity_checked        = false (RAT-A4)
 feedback_updates_ranking          = false (follow-up ADR required)
 r_f_spikes_go                     = true  (R-F1…R-F7 + R-F10 GO spike artifacts written + validated 2026-07-28)

--- a/plans/README.md
+++ b/plans/README.md
@@ -19,7 +19,7 @@
 | [ACTIONS.md](ACTIONS.md) | Action backlog |
 | [GOAP_STATE.md](GOAP_STATE.md) | GOAP phase snapshot |
 | [GATE_CONTRACT.md](GATE_CONTRACT.md) | Local/CI quality gate matrix |
-| [GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md](GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md) | **Active**: CI trust + product-truth fixes + ADR-078 attribution capture |
+| [GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md](GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md) | **Active**: CI trust + product-truth fixes + ADR-080 attribution capture |
 | [GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md](GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md) | Reference recommendations backlog |
 | [ANALYSIS_GH_CLI_SKILLS_AND_BEST_PRACTICES_2026-07-20.md](ANALYSIS_GH_CLI_SKILLS_AND_BEST_PRACTICES_2026-07-20.md) | Official `gh` / `gh skill` skills + manual vs repo policy |
 
@@ -36,7 +36,7 @@
 
 See [adr/README.md](adr/README.md) for the ADR index (including number-collision aliases).
 
-Current proposals: [ADR-078 automatic recommendation attribution](adr/ADR-078-Automatic-Recommendation-Attribution.md)
+Current proposals: [ADR-080 automatic recommendation attribution](adr/ADR-080-Automatic-Recommendation-Attribution.md)
 and [ADR-079 fail-closed CI control plane](adr/ADR-079-Fail-Closed-CI-Required-Check-Control-Plane.md).
 
 ## Spikes

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -3,7 +3,7 @@
 **Last Updated**: 2026-07-30
 **Released Version**: v0.1.37 (latest tag)  
 **Workspace Version**: 0.1.38 (next release)  
-**Active Sprint**: CI trust + product truth + ADR-078 automatic recommendation attribution (proposed)
+**Active Sprint**: CI trust + product truth + ADR-080 automatic recommendation attribution (proposed)
 **Plan**: `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`
 **Branch**: `main` @ `e66defdf`
 **Open PRs**: #914, #915
@@ -41,7 +41,7 @@
 | P1 | CIT-A3 | Exact local/CI command scope and semantic gate-contract validation | Planned |
 | P1 | CIT-A4/A5 | Truthful release/publish triggers and durable fuzz/mutation evidence | Planned |
 | P1 | PTA-A3 threshold CLI truth | Hide advertised `eval set-threshold` non-operation | ✅ #916 |
-| P1 | ADR-078 / RAT-A1…A7 | Episode-bound automatic attribution with truthful persistence receipts | Proposed |
+| P1 | ADR-080 / RAT-A1…A7 | Episode-bound automatic attribution with truthful persistence receipts | Proposed |
 | P2 | Ranking adaptation | Idempotent feedback-to-ranking update; requires separate ADR | Deferred |
 
 ---

--- a/plans/STATUS/CODEBASE_ANALYSIS_LATEST.md
+++ b/plans/STATUS/CODEBASE_ANALYSIS_LATEST.md
@@ -70,7 +70,7 @@
 
 ## New feature decision
 
-ADR-078 proposes optional, episode-bound attributed pattern/playbook operations.
+ADR-080 proposes optional, episode-bound attributed pattern/playbook operations.
 Core derives a session from exact returned IDs and reports `persisted`,
 `partially_persisted`, `memory_only`, or `persistence_failed`. Legacy calls stay
 shape-compatible. The feature improves capture and feedback readiness, but does
@@ -82,7 +82,7 @@ not yet change recommendation ranking.
 2. Restore fail-closed cancellation/commitlint and Dependabot/fork parity, then
    stage the verified aggregate into the live ruleset with approval.
 3. Reconcile gate scope and repair release/publish/fuzz false-success paths.
-4. Accept and execute ADR-078 RAT-A1…A7.
+4. Accept and execute ADR-080 RAT-A1…A7.
 5. Design feedback-to-ranking adaptation only after capture integrity is proven.
 6. Residual: historical ADR filename collisions (025/054 aliased — docs only),
    transitive Dependabot advisories (monitor), R-F10 (OIDC) / R-F4 (SIMD) in progress.

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -36,7 +36,7 @@
 | CI wait semantics | **Not fail-closed** — five waiters accept cancelled/skipped/missing fast check |
 | P0 plan gaps | **1 open** — required CI (PTA-A1/A2/A3 implemented) |
 | ADR-079 CI control plane | Proposed; implementation/ruleset unchanged |
-| ADR-078 automatic attribution | Proposed; implementation not started |
+| ADR-080 automatic attribution | Proposed; implementation not started |
 
 ## Immediate priorities
 
@@ -47,7 +47,7 @@
 | P0 | Return typed unavailable/absent API for non-`csm` cascade | PTA-A1 | ✅ Implemented |
 | P0 | Remove or label fabricated CLI storage telemetry | PTA-A2 | ✅ Implemented |
 | P1 | Reconcile gate contract; repair release/publish/fuzz truth | CIT-A3…A5 | Planned |
-| P1 | Automatic episode-bound recommendation attribution | ADR-078 / RAT-A1…A7 | Proposed |
+| P1 | Automatic episode-bound recommendation attribution | ADR-080 / RAT-A1…A7 | Proposed |
 | P1 | Hide unsupported `eval set-threshold` command | PTA-A3 | ✅ Implemented |
 | P2 | Research/product spikes (R-F1…R-F7, R-F10) | R-F* | ⏸ DEFER |
 | P2 | Transitive Dependabot advisories | G-P1-9 | Monitor / upstream |

--- a/plans/STATUS/GAP_ANALYSIS_LATEST.md
+++ b/plans/STATUS/GAP_ANALYSIS_LATEST.md
@@ -53,8 +53,8 @@
 | G-P1-8 | Historical ADR number reuse on disk | Dual 025/054 filenames; aliases in `plans/adr/README.md` | residual docs |
 | G-P1-9 | Transitive Dependabot advisories | Upstream chains (libsql/openssl/webpki) | security hygiene |
 | G-P1-10 | `eval set-threshold` is advertised but always fails; suggested `eval show` command does not exist | `memory-cli/src/commands/eval.rs` | ✅ PTA-A3 closed — command removed |
-| G-P1-11 | Pattern recommendations require manual session creation; playbooks record `Uuid::nil()` in memory only | core/MCP/CLI attribution paths | ADR-078 / RAT-A1…A7 |
-| G-P1-12 | Feedback accepts integrity states that can corrupt attribution statistics | tracker/API/persistence paths | ADR-078 / RAT-A4 |
+| G-P1-11 | Pattern recommendations require manual session creation; playbooks record `Uuid::nil()` in memory only | core/MCP/CLI attribution paths | ADR-080 / RAT-A1…A7 |
+| G-P1-12 | Feedback accepts integrity states that can corrupt attribution statistics | tracker/API/persistence paths | ADR-080 / RAT-A4 |
 | G-P1-13 | Dependabot is excluded from most substantive code/test/security assertions | actor conditions across CI/coverage/security/file/benchmark workflows | ADR-079 / CIT-A2 |
 | G-P1-14 | Gate contract claims parity while tests, Clippy, LOC, and quality-bundle semantics differ; validator is presence-only | `GATE_CONTRACT.md`, `ci.yml`, `quick-check.yml`, `validate-gate-contract.sh` | ADR-079 / CIT-A3 |
 | G-P1-15 | Release manual dispatch is broken; publish selection and fuzz evidence have silent skip/green paths | release run `30301797956`, publish/fuzz workflow conditions | ADR-079 / CIT-A4/A5 |
@@ -64,7 +64,7 @@
 | ID | Gap | Notes | Track |
 |----|-----|-------|--------|
 | G-P2-1…7 | R-F1…R-F7, R-F10 epics | GO spikes validated 2026-07-28 — awaiting ADR + implementation PRs (R-F10 ACT-325, R-F4 ACT-326 in progress) | R-F* active |
-| G-P2-8 | Feedback does not idempotently update later recommendation ranking | ADR-078 captures data only | Follow-up ADR |
+| G-P2-8 | Feedback does not idempotently update later recommendation ranking | ADR-080 captures data only | Follow-up ADR |
 | G-P2-9 | Azure/Custom/Cohere runtime embedding adapters absent | Honest rejection required by ADR-077 | Provider-specific ADR if prioritized |
 
 ## Explicit non-gaps
@@ -87,7 +87,7 @@
 
 - ADR-079 CIT-A1…A5 exits are implemented, including live aggregate protection.
 - PTA-A1…A3 have code and feature-matrix tests. ✅ (2026-08-01)
-- ADR-078 acceptance criteria and RAT-A1…A7 are implemented with evidence.
+- ADR-080 acceptance criteria and RAT-A1…A7 are implemented with evidence.
 - Ranking adaptation remains explicitly open until separately decided and tested.
 - G-P1-8 and G-P1-9 are monitor-only (no code action required).
 - P2 GO spike gate cleared 2026-07-28; next gate is ADR draft + implementation PR per epic.

--- a/plans/STATUS/VALIDATION_LATEST.md
+++ b/plans/STATUS/VALIDATION_LATEST.md
@@ -19,7 +19,7 @@ product-truth and recommendation-attribution plan without changing workflows.
 | Quality contract | CI duplicates a subset; parity validator checks files/keywords only | ❌ drift |
 | Release dispatch | Run `30301797956`: `main` failed expected-tag preflight, all downstream skipped | ❌ broken trigger |
 | Action pinning | Inspected external `uses:` references are commit-SHA pinned | ✅ |
-| ADR-078 status | Proposed; no implementation claim | ✅ truthful |
+| ADR-080 status | Proposed; no implementation claim | ✅ truthful |
 | ADR-079 status | Proposed; workflow and ruleset implementation unchanged | ✅ truthful |
 | PTA-A1…A3 | ✅ Implemented (2026-08-01): cascade `CapabilityUnavailable`, `MetricValue` storage provenance, `eval set-threshold` removed |
 | Patch whitespace | `git diff --check` | ✅ |
@@ -56,7 +56,7 @@ product-truth and recommendation-attribution plan without changing workflows.
 | P0 | PTA-A2 storage metric truth | ✅ #916 merged (`MetricValue` provenance) |
 | P1 | Gate contract/release/publish/fuzz truth | CIT-A3…A5 |
 | P1 | PTA-A3 unsupported threshold surface | ✅ #916 merged (`eval set-threshold` removed) |
-| P1 | ADR-078 attribution capture | Maintainer decision, then RAT-A1…A7 |
+| P1 | ADR-080 attribution capture | Maintainer decision, then RAT-A1…A7 |
 | P2 | Feedback-to-ranking adaptation | Separate ADR after capture integrity |
 
 ## Planning-document validation
@@ -88,9 +88,13 @@ release-cadence-manager + code review). Result: queue 2 → 0 open.
 | Release drift | workspace `0.1.38` > tag `v0.1.37` (version advanced); `commit_limit` accumulates until next release | ⚠️ monitored |
 | PR comments | codacy 0 issues ×2, codecov all-covered ×2, benchmark posts (informational) | ✅ no actionable |
 
-**Roast findings (non-blocking, pre-existing)** — logged for follow-up, not
-introduced by #916: `vacuum_storage` reports `storage_optimized` while doing
-no work; `#[expect(clippy::excessive_nesting)]` on `sync_storage` (suppression
-vs "fix, don't suppress"); `HealthStatus` Debug-vs-Display inconsistency;
-redundant `expanded_terms.is_empty()` guard in `retrieve_concept_graph`.
+**Roast findings (pre-existing)** — all fixed 2026-08-02 in the warnings-
+remediation PR: `vacuum_storage` now reports honestly (no fabricated
+`storage_optimized`); `#[expect(clippy::excessive_nesting)]` removed via
+`sync_storage` flatten refactor; `HealthStatus` rendering switched Debug→Display;
+redundant `expanded_terms.is_empty()` guard removed from `retrieve_concept_graph`.
+Also fixed pre-existing `clippy::uninlined_format_args` in `tests/arch_fitness.rs`,
+renumbered duplicate ADR-078 (attribution → ADR-080; OIDC keeps 078), and added
+a nextest slow-timeout override for the nested-build `quality_gate_pattern_accuracy`
+test (cold-cache local timeout, passes in CI).
 

--- a/plans/adr/ADR-080-Automatic-Recommendation-Attribution.md
+++ b/plans/adr/ADR-080-Automatic-Recommendation-Attribution.md
@@ -1,4 +1,4 @@
-# ADR-078: Automatic, Episode-Bound Recommendation Attribution
+# ADR-080: Automatic, Episode-Bound Recommendation Attribution
 
 - **Status**: Proposed
 - **Date**: 2026-07-30
@@ -96,7 +96,7 @@ deferred until at-least-once retry behavior demonstrates a need.
 
 ### 5. Defer ranking adaptation to a separate decision
 
-ADR-078 captures trustworthy data but does not mutate pattern effectiveness or
+ADR-080 captures trustworthy data but does not mutate pattern effectiveness or
 recommendation ranking. A follow-up must define idempotent durable updates,
 replacement-feedback semantics, rollback behavior, and how attributed evidence
 changes ranking weights before the project claims the learning loop is closed.

--- a/tests/arch_fitness.rs
+++ b/tests/arch_fitness.rs
@@ -55,7 +55,7 @@ fn enforce_crate_layering() {
     for &(from, to) in FORBIDDEN_EDGES {
         if let Some(deps) = dep_graph.get(from) {
             if deps.contains(&to.to_string()) {
-                violations.push(format!("  {} → {}", from, to));
+                violations.push(format!("  {from} → {to}"));
             }
         }
     }


### PR DESCRIPTION
## What

Addresses ALL pre-existing warnings/failings (per request), verified with `cargo clippy --workspace --all-targets -- -D warnings` (was failing), `cargo fmt --check`, and 2422 passing tests:

1. **tests/arch_fitness.rs** — `clippy::uninlined_format_args` (real clippy failure)
2. **vacuum_storage** — no longer fabricates `storage_optimized: true` with zero work; reports honestly that vacuum is unsupported through the generic trait (PTA-A2) + 3 new unit tests
3. **sync_storage** — removed `#[expect(clippy::excessive_nesting)]` via let-else/continue flatten (behavior-preserving)
4. **HealthStatus rendering** — Debug → Display consistency
5. **retrieve_concept_graph** — removed dead `is_empty()` guard
6. **ADR-078 duplicate** — attribution ADR renumbered to ADR-080 (OIDC keeps 078); `validate-plans.sh` duplicate warning resolved
7. **nextest.toml** — slow-timeout override for `quality_gate_pattern_accuracy` (cold-cache nested build; previously timed out locally, passes in CI)

## Validation
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo fmt --all --check` ✅
- `cargo nextest run -p do-memory-cli -p do-memory-core -p e2e-tests` → 2422 passed ✅
- `./scripts/validate-plans.sh` ✅ (only historical ADR-025/054 duplicate warnings remain)