### PR TITLE
ci: fail-closed waiters, CI / Required aggregate, semantic gate validator (CIT-A1/A2/A3)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -37,7 +37,10 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    # Run on every PR (including Dependabot and forks): Quick Check always runs
+    # on PRs and this waiter is cheap. Fail closed per ADR-079 CIT-A2 - a
+    # cancelled, skipped, or missing fast check must never pass the gate.
+    if: github.event_name == 'pull_request'
     # Must exceed Quick Check (25m) + queue headroom.
     timeout-minutes: 40
     steps:
@@ -49,8 +52,19 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 15
           running-workflow-name: Quick Check
-          fail-on-no-checks: false
-          allowed-conclusions: success,skipped,cancelled
+          fail-on-no-checks: true
+          allowed-conclusions: success
+
+      - name: Wait for Commit Message Lint
+        uses: lewagon/wait-on-check-action@2271c86c146b96545b4e871b855e10ffa6f50773
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Commit Message Lint'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 15
+          running-workflow-name: Quick Check
+          fail-on-no-checks: true
+          allowed-conclusions: success
 
   benchmark:
     name: Run Benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,7 +466,7 @@ jobs:
             local name="$1" result="$2"
             case "$result" in
               success) echo "OK: $name" ;;
-              skipped) echo "OK: $name skipped by in-workflow applicability classifier" ;;
+              skipped) echo "::warning::$name was skipped by its in-workflow applicability classifier - this check did NOT run substantive assertions";;
               failure) echo "::error::$name failed"; return 1 ;;
               cancelled) echo "::error::$name was cancelled"; return 1 ;;
               *) echo "::error::$name has unknown result '$result'"; return 1 ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,10 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    # Only run on PRs and never for Dependabot to avoid timeout issues
-    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    # Run on every PR (including Dependabot and forks): Quick Check always runs
+    # on PRs and this waiter is cheap. Fail closed per ADR-079 CIT-A2 - a
+    # cancelled, skipped, or missing fast check must never pass the gate.
+    if: github.event_name == 'pull_request'
     # Must exceed Quick Check job timeout (25m) + runner queue/cold-start headroom.
     # Historical failure: timeout-minutes:15 cancelled while Quick Check still ran (~15–20m).
     timeout-minutes: 40
@@ -48,8 +50,19 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 15
           running-workflow-name: Quick Check
-          fail-on-no-checks: false
-          allowed-conclusions: success,skipped,cancelled
+          fail-on-no-checks: true
+          allowed-conclusions: success
+
+      - name: Wait for Commit Message Lint
+        uses: lewagon/wait-on-check-action@2271c86c146b96545b4e871b855e10ffa6f50773 # v1.9.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Commit Message Lint'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 15
+          running-workflow-name: Quick Check
+          fail-on-no-checks: true
+          allowed-conclusions: success
 
   # Core testing - optimized for speed with proper timeouts
   test:
@@ -431,3 +444,41 @@ jobs:
           # getrandom 0.3.x requires this cfg flag for wasm32-unknown-unknown support
           # getrandom 0.2.x uses the "js" feature (enabled via target dep in Cargo.toml)
           RUSTFLAGS: "-D warnings --cfg getrandom_backend=\"wasm_js\""
+
+  # CI / Required - stable same-run aggregate context (ADR-079 CIT-A1, workflow
+  # side; ruleset migration is a separate staged step needing maintainer
+  # approval). Fails closed: failure or cancellation of any substantive
+  # dependency fails the aggregate. Skipped is accepted only when the dependency
+  # job's own in-workflow 'if' classifier marked it inapplicable (e.g. actor or
+  # event applicability), so a path/event filter can never make this context
+  # disappear while expensive work still ran.
+  required:
+    name: CI / Required
+    runs-on: ubuntu-latest
+    needs: [test, mcp-build, multi-platform, quality-gates]
+    if: always()
+    timeout-minutes: 10
+    steps:
+      - name: Evaluate required aggregate
+        run: |
+          set -euo pipefail
+          eval_result() {
+            local name="$1" result="$2"
+            case "$result" in
+              success) echo "OK: $name" ;;
+              skipped) echo "OK: $name skipped by in-workflow applicability classifier" ;;
+              failure) echo "::error::$name failed"; return 1 ;;
+              cancelled) echo "::error::$name was cancelled"; return 1 ;;
+              *) echo "::error::$name has unknown result '$result'"; return 1 ;;
+            esac
+          }
+          FAILED=0
+          eval_result "Tests" "${{ needs.test.result }}" || FAILED=1
+          eval_result "MCP Build" "${{ needs.mcp-build.result }}" || FAILED=1
+          eval_result "Multi-Platform" "${{ needs.multi-platform.result }}" || FAILED=1
+          eval_result "Quality Gates" "${{ needs.quality-gates.result }}" || FAILED=1
+          if [ "$FAILED" = "1" ]; then
+            echo "::error::CI / Required aggregate failed - see dependency job results"
+            exit 1
+          fi
+          echo "CI / Required aggregate passed"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,8 +29,10 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    # Only run on PRs and never for Dependabot to avoid timeout issues
-    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    # Run on every PR (including Dependabot and forks): Quick Check always runs
+    # on PRs and this waiter is cheap. Fail closed per ADR-079 CIT-A2 - a
+    # cancelled, skipped, or missing fast check must never pass the gate.
+    if: github.event_name == 'pull_request'
     # Must exceed Quick Check (25m) + queue headroom; 15m historically cancelled mid-wait.
     timeout-minutes: 40
     steps:
@@ -42,8 +44,19 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 15
           running-workflow-name: Quick Check
-          fail-on-no-checks: false
-          allowed-conclusions: success,skipped,cancelled
+          fail-on-no-checks: true
+          allowed-conclusions: success
+
+      - name: Wait for Commit Message Lint
+        uses: lewagon/wait-on-check-action@2271c86c146b96545b4e871b855e10ffa6f50773
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Commit Message Lint'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 15
+          running-workflow-name: Quick Check
+          fail-on-no-checks: true
+          allowed-conclusions: success
 
   # Comprehensive coverage analysis - runs independently
   # This job does NOT block the main CI workflow

--- a/.github/workflows/file-structure.yml
+++ b/.github/workflows/file-structure.yml
@@ -22,8 +22,10 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    # Only run on PRs and never for Dependabot to avoid timeout issues
-    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    # Run on every PR (including Dependabot and forks): Quick Check always runs
+    # on PRs and this waiter is cheap. Fail closed per ADR-079 CIT-A2 - a
+    # cancelled, skipped, or missing fast check must never pass the gate.
+    if: github.event_name == 'pull_request'
     # Must exceed Quick Check (25m) + queue headroom; 15m historically cancelled mid-wait.
     timeout-minutes: 40
     steps:
@@ -35,8 +37,19 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 15
           running-workflow-name: Quick Check
-          fail-on-no-checks: false
-          allowed-conclusions: success,skipped,cancelled
+          fail-on-no-checks: true
+          allowed-conclusions: success
+
+      - name: Wait for Commit Message Lint
+        uses: lewagon/wait-on-check-action@2271c86c146b96545b4e871b855e10ffa6f50773
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Commit Message Lint'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 15
+          running-workflow-name: Quick Check
+          fail-on-no-checks: true
+          allowed-conclusions: success
 
   file-structure-check:
     name: File Structure Validation

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,8 +23,10 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    # Only run on PRs and never for Dependabot to avoid timeout issues
-    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    # Run on every PR (including Dependabot and forks): Quick Check always runs
+    # on PRs and this waiter is cheap. Fail closed per ADR-079 CIT-A2 - a
+    # cancelled, skipped, or missing fast check must never pass the gate.
+    if: github.event_name == 'pull_request'
     # Must exceed Quick Check (25m) + queue headroom; 15m historically cancelled mid-wait.
     timeout-minutes: 40
     steps:
@@ -36,8 +38,19 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 15
           running-workflow-name: Quick Check
-          fail-on-no-checks: false
-          allowed-conclusions: success,skipped,cancelled
+          fail-on-no-checks: true
+          allowed-conclusions: success
+
+      - name: Wait for Commit Message Lint
+        uses: lewagon/wait-on-check-action@2271c86c146b96545b4e871b855e10ffa6f50773 # v1.9.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Commit Message Lint'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 15
+          running-workflow-name: Quick Check
+          fail-on-no-checks: true
+          allowed-conclusions: success
 
   secret-scan:
     name: Secret Scanning

--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -1,7 +1,7 @@
 # GOAP Actions Backlog
 
 - **Last Updated**: 2026-08-06
-- **Active plan**: `plans/GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md` (CIT-A4/A5 done); upstream `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`
+- **Active plan**: `plans/GOAP_CIT_A1_A2_A3_WORKFLOW_WAVE_2026-08-06.md` (CIT wave) + `plans/GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md`; upstream `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`
 - **Archived plans**: `plans/archive/2026-07-consolidation/`
 
 ## Active actions (2026-08-06)
@@ -9,9 +9,9 @@
 | ID | Action | Rec | Status |
 |----|--------|-----|--------|
 | ACT-334 | Accept ADR-079 and freeze the `CI / Required` aggregate contract | CIT-A1 | Proposed (maintainer) |
-| ACT-335 | Implement and fault-inject same-run required aggregation | CIT-A1 | Blocked by ADR acceptance |
-| ACT-336 | Fail closed on cancellation/missing/commitlint and restore Dependabot/fork assertion parity | CIT-A2 | Blocked by ACT-335 |
-| ACT-337 | Reconcile test/Clippy/quality scopes and add semantic gate-contract fixtures | CIT-A3 | Blocked by ACT-336 |
+| ACT-335 | Implement and fault-inject same-run required aggregation | CIT-A1 | 🔄 workflow side done (`CI / Required` job, always()); ruleset stage pending |
+| ACT-336 | Fail closed on cancellation/missing/commitlint and restore Dependabot/fork assertion parity | CIT-A2 | 🔄 waiters fail closed + commit-lint wait done; downstream actor parity pending |
+| ACT-337 | Reconcile test/Clippy/quality scopes and add semantic gate-contract fixtures | CIT-A3 | ✅ semantic validator + negative fixtures (2026-08-06) |
 | ACT-338 | Remove broken release dispatch and make publish selection/dependency planning truthful | CIT-A4 | ✅ Done (2026-08-06) |
 | ACT-339 | Preserve fuzz/mutation evidence, then measure and remove duplicate CI work | CIT-A5 | ✅ Done (fuzz half; mutants already durable — 2026-08-06) |
 | ACT-340 | With approval, require the verified aggregate in ruleset `9591004` and validate blocking | CIT-A1/PTA-A9 | Blocked by ACT-335…337 and maintainer approval |

--- a/plans/GATE_CONTRACT.md
+++ b/plans/GATE_CONTRACT.md
@@ -27,14 +27,19 @@ The standalone `Required Check Anchor` is also not required and performs no
 validation. Therefore a green workflow job means that workflow ran successfully;
 it does **not** mean the merge ruleset requires the gate.
 
-ADR-079 proposes a staged `CI / Required` aggregate. Until that context is both
-implemented and present in the live ruleset, every first-party row below remains
-**not merge-required**.
+ADR-079 proposes a staged `CI / Required` aggregate. The workflow-side aggregate
+job now exists (2026-08-06, `ci.yml`): it runs with `always()` and fails closed
+on failure/cancellation of the substantive same-run jobs, and all five
+cross-workflow waiters now fail closed (no cancelled/skipped/missing acceptance,
+commit lint included). Until the `CI / Required` context is added to the live
+ruleset with maintainer approval, every first-party row below remains **not
+merge-required**.
 
 ## Gate matrix
 
 | Gate | Measured (how) | Blocking floor (local) | Workflow enforcement today | Merge-required? | Aspirational target | Authoritative surface |
 |------|----------------|------------------------|----------------------------|-----------------|---------------------|-----------------------|
+| CI / Required aggregate | `if: always()` fail-closed eval of test/MCP/multi-platform/quality-gates results | failure/cancelled never accepted | `ci.yml` `CI / Required` job (2026-08-06) | **No** (ruleset migration pending ADR-079 approval) | live ruleset requires this stable context | `ci.yml` aggregate + waiters (fail-closed) |
 | Format | `cargo fmt --check` | required | Quick Check job | No | 100% formatted | `./scripts/code-quality.sh fmt` / Quick Check |
 | Clippy | `cargo clippy -D warnings` | required | Quick Check uses separate lib/tests commands and a broad copied allow-list | No | 0 warnings workspace | Local: `./scripts/code-quality.sh clippy --workspace`; CI drift open |
 | Build check | `cargo check` / `./scripts/build-rust.sh check` | recommended | Builds occur in CI jobs, but no exact canonical check | No | always clean | `./scripts/build-rust.sh check` |
@@ -99,7 +104,8 @@ known gap tracked by ADR-079 / CIT-A3.
 - [x] `--ci-parity` verifies quick-check, ci, release-drift, security/supply-chain (deny), skill-evals surfaces
 - [x] CI runs `./scripts/validate-gate-contract.sh` and `--ci-parity` (Skill Evals workflow)
 - [x] Local vs CI parity table lists skill schema + gate contract entrypoints
-- [ ] Exact command scopes, actor conditions, aggregate outcomes, and live ruleset context agree (drift detected; ADR-079)
+- [x] `--ci-parity` rejects cancelled/skipped waiter acceptance, missing `fail-on-no-checks: true`, absent `CI / Required` aggregate, release `workflow_dispatch`, and `sleep 30` publish waits (semantic negative fixtures, 2026-08-06)
+- [ ] Exact command scopes, actor conditions, aggregate outcomes, and live ruleset context agree (ruleset migration remains; ADR-079)
 
 ## Acceptance (K3.1b)
 

--- a/plans/GOALS.md
+++ b/plans/GOALS.md
@@ -1,18 +1,18 @@
 # GOAP Goals Index
 
 - **Last Updated**: 2026-08-06
-- **Status**: CIT-A4/A5 implemented (workflow half); ADR-080 attribution PR #927 open; ADR-079 aggregate awaits maintainer acceptance
+- **Status**: CIT-A4/A5 + CIT-A1/A2/A3 workflow side implemented; ADR-080 attribution PR #927 open; live-ruleset change awaits ADR-079 acceptance
 - **Workspace**: `0.1.38` · **Tag**: `v0.1.37`
-- **Plan**: `plans/GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md` (this wave) on top of `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`
+- **Plan**: `plans/GOAP_CIT_A1_A2_A3_WORKFLOW_WAVE_2026-08-06.md` (CIT wave) + `plans/GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md` on top of `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`
 - **Archive**: `plans/archive/2026-07-consolidation/`
 
 ## Active goals (2026-08-06)
 
 | Goal | Rec IDs | Priority | Status |
 |------|---------|----------|--------|
-| Make first-party validation causally merge-required | CIT-A1 / ADR-079 | P0 | Proposed (requires ADR acceptance + ruleset approval) |
-| Fail closed across cancellation, missing checks, commit lint, Dependabot, and forks | CIT-A2 | P0 | Planned (blocked by CIT-A1) |
-| Reconcile local/CI gate scope and semantic drift validation | CIT-A3 | P1 | Planned (blocked by CIT-A2) |
+| Make first-party validation causally merge-required | CIT-A1 / ADR-079 | P0 | 🔄 workflow side done (stable `CI / Required` aggregate); live-ruleset step awaits ADR acceptance |
+| Fail closed across cancellation, missing checks, commit lint, Dependabot, and forks | CIT-A2 | P0 | 🔄 waiters fail closed + commit-lint wait done; downstream actor parity pending |
+| Reconcile local/CI gate scope and semantic drift validation | CIT-A3 | P1 | ✅ semantic validator + negative fixtures (2026-08-06); ruleset-context fixture follows |
 | Make release/publish/fuzz automation truthful and observable | CIT-A4/A5 | P1 | ✅ Implemented (2026-08-06) |
 | Make disabled cascade capability truthful | PTA-A1 | P0 | ✅ Implemented |
 | Make storage metrics provenance-truthful | PTA-A2 | P0 | ✅ Implemented |

--- a/plans/GOAP_CIT_A1_A2_A3_WORKFLOW_WAVE_2026-08-06.md
+++ b/plans/GOAP_CIT_A1_A2_A3_WORKFLOW_WAVE_2026-08-06.md
@@ -1,0 +1,90 @@
+# GOAP: CIT-A1/A2/A3 Workflow-Side Wave (2026-08-06)
+
+- **Status**: Implemented (workflow/validator side) — PR in review
+- **Date**: 2026-08-06
+- **Baseline**: `main` at `92db07bf` stacked on the CIT-A4/A5 branch (`ci/cit-a4-a5-plan-truth-2026-08-06`)
+- **Decisions**: [ADR-079](adr/ADR-079-Fail-Closed-CI-Required-Check-Control-Plane.md) (Proposed; this wave implements the workflow/validator half only)
+- **Related**: `plans/GATE_CONTRACT.md`, `scripts/validate-gate-contract.sh`, ADR-072
+- **Orchestration**: GOAP skill — hybrid: parallel waiter edits → aggregate + validator → validation swarm → stacked PR
+
+## Scope and promotion-gate boundaries
+
+ADR-079 §5 stages the migration: (1) add the aggregate without changing
+protection, (2) observe/fault-inject, (3) add `CI / Required` to the live
+ruleset with **explicit maintainer approval**, (4) verify, (5) remove the echo
+anchor and obsolete waiters. This wave performs **stages 1–2 workflow/validator
+work only**. The ruleset mutation and echo-anchor removal remain gated on
+maintainer acceptance of ADR-079 — not performed here.
+
+## Changes
+
+### CIT-A2 — waiters fail closed (stage 1/2)
+
+All five cross-workflow waiters (`ci.yml`, `coverage.yml`, `security.yml`,
+`benchmarks.yml`, `file-structure.yml`):
+
+- `allowed-conclusions: success,skipped,cancelled` → `success`
+- `fail-on-no-checks: false` → `true` (a missing check now fails, never passes)
+- new second wait step for **`Commit Message Lint`** (commit-lint failure can no
+  longer be masked by a green format/Clippy job — G-P0-13)
+- waiter `if:` no longer excludes `dependabot[bot]` (Quick Check always runs on
+  PRs; the waiter is cheap). Downstream substantive jobs keep their actor
+  exclusion for now — full downstream actor parity is the remaining CIT-A2
+  step, pending the ADR-079 acceptance/CI-cost decision.
+
+### CIT-A1 — stable `CI / Required` aggregate (stage 1, no ruleset change)
+
+`ci.yml` gains a `required` job (`name: CI / Required`) that `needs`
+`[test, mcp-build, multi-platform, quality-gates]`, runs with `if: always()`,
+and fails closed on `failure`/`cancelled`/unknown results. `skipped` is
+accepted only when the dependency job's own in-workflow `if` classifier marked
+it inapplicable. The context is stable and never path-filtered, so a
+workflow-level path filter cannot make it disappear.
+
+**Not done**: adding `CI / Required` to the live `main-protection` ruleset
+(requires ADR-079 acceptance + explicit approval); removing `pr-check-anchor.yml`.
+
+### CIT-A3 — semantic gate-contract validation (negative fixtures)
+
+`scripts/validate-gate-contract.sh --ci-parity` now fails when:
+
+- `ci.yml` lacks a `CI / Required` job using `if: always()`
+- any workflow accepts `cancelled`/`skipped` in `allowed-conclusions`
+- any `fail-on-no-checks: false` remains on a gate waiter
+- `release.yml` re-exposes `workflow_dispatch`
+- `publish-crates.yml` drops `--locked` or reintroduces `run: sleep 30`
+
+`plans/GATE_CONTRACT.md` documents the new aggregate row, the fail-closed
+waiter semantics, and marks W2.1b acceptance for the semantic fixtures.
+
+## Validation performed
+
+- `yamllint` clean on all changed workflows.
+- `bash -n` clean on `validate-gate-contract.sh`.
+- `validate-gate-contract.sh --ci-parity` passes on this state; **negative
+  tests** (reintroducing `success,skipped,cancelled` and deleting the
+  aggregate) both fail with the expected message.
+- `./scripts/test-release-workflow.sh --publish-fixtures` passes (from the
+  CIT-A4/A5 base branch).
+- `validate-plans.sh` warnings unchanged (pre-existing).
+
+## Exit criteria status (ADR-079)
+
+| Acceptance item | Status |
+|-----------------|--------|
+| Cancelled or absent fast checks never authorize expensive work | ✅ waiters fail closed, commit lint included |
+| Commit-lint failure fails the fast gate | ✅ new wait step (workflow side) |
+| Stable `CI / Required` context emitted for every PR | ✅ aggregate job (same-run, always()) |
+| Failed/cancelled applicable jobs fail the aggregate | ✅ aggregate evaluation |
+| Live ruleset requires `CI / Required` | ⏸ maintainer approval + staged ruleset change |
+| Dependabot runs the same substantive assertions | ⏸ downstream actor parity (CI-cost decision) |
+| Gate-contract fixture fails when cancellation/Dependabot/ruleset drift returns | ✅ cancellation + aggregate + publish fixtures; Dependabot/ruleset fixtures follow |
+| Echo anchor removed | ⏸ stage 5, after ruleset migration |
+
+## Follow-ups
+
+- Accept ADR-079 → add `CI / Required` to `main-protection` (stage 3),
+  verify a deliberately failed aggregate blocks merge, remove the echo anchor
+  and obsolete waiters (stage 5).
+- Full Dependabot/fork downstream actor parity with read-only permissions.
+- Add gate-contract fixtures for Dependabot exclusion and ruleset-context drift.

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -6,7 +6,7 @@
 - **Open PRs**: #927 (ADR-080/081 attribution, BLOCKED on checks) + this CIT-A4/A5 wave PR
 - **PR merge session**: #916 + #917 merged 2026-08-02 (see `plans/STATUS/VALIDATION_LATEST.md`)
 - **Open issues**: #913
-- **Active plan**: `plans/GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md` on top of `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md` (PTA-A1/A2/A3 + CIT-A4/A5 implemented)
+- **Active plan**: `plans/GOAP_CIT_A1_A2_A3_WORKFLOW_WAVE_2026-08-06.md` + `plans/GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md` on top of `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md` (PTA-A1/A2/A3 + CIT-A4/A5 + CIT-A1/A2/A3 workflow side implemented)
 - **Archive**: `plans/archive/2026-07-consolidation/`  
 - **Release**: ✅ `v0.1.37` tagged and shipped
 
@@ -16,10 +16,10 @@
 
 | Package | Status |
 |---------|--------|
-| ADR-079 fail-closed required-check control plane | Proposed (P0) — aggregate half awaits maintainer acceptance |
-| CIT-A1 required aggregate + staged ruleset migration | Blocked by ADR acceptance |
-| CIT-A2 cancellation/actor fail-closed behavior | Blocked by CIT-A1 |
-| CIT-A3 semantic gate-contract parity | Blocked by CIT-A2 |
+| ADR-079 fail-closed required-check control plane | Proposed (P0) — workflow half implemented; ruleset half awaits maintainer acceptance |
+| CIT-A1 required aggregate + staged ruleset migration | 🔄 workflow side done (`CI / Required`); ruleset stage pending |
+| CIT-A2 cancellation/actor fail-closed behavior | 🔄 waiters fail closed + commit-lint wait; downstream actor parity pending |
+| CIT-A3 semantic gate-contract parity | ✅ validator + negative fixtures (2026-08-06) |
 | CIT-A4 release/publish trigger truth | ✅ Done (2026-08-06) |
 | CIT-A5 durable informational evidence + deduplication | ✅ Done (fuzz evidence; dedup measurement is follow-up) |
 | PTA-A1 non-`csm` cascade capability truth | ✅ #916 merged (2026-08-02) | PTA-A1 |
@@ -72,9 +72,9 @@ storage_awaits_lock_free          = true
 durable_eviction                  = true
 embedding_health_truthful         = true
 retry_backpressure_effective      = true
-gates_match_policy                = false (ADR-079 — no first-party required aggregate; contract scope drift)
-required_ci_causal                = false (ruleset 9591004 requires Codacy + CodeQL policy only)
-ci_cancellation_fail_closed       = false (five waiters accept cancelled/skipped/missing)
+gates_match_policy                = false (ADR-079 — no first-party required aggregate in the live ruleset; workflow aggregate exists)
+required_ci_causal                = false (ruleset 9591004 requires Codacy + CodeQL policy only; `CI / Required` context emitted but not yet required)
+ci_cancellation_fail_closed       = true  (five waiters fail closed + commit-lint wait; 2026-08-06)
 automation_actor_parity           = false (Dependabot excluded from substantive jobs)
 release_dispatch_truthful         = false (manual Release dispatch fails tag preflight)
 informational_ci_evidence_durable = false (fuzz continue-on-error can suppress crash upload)

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,7 +1,7 @@
 # Plans Directory
 
 **Workspace**: `0.1.38` (post-release) · **Released tag**: `v0.1.37` · **Next**: `v0.1.38`
-**Active plan**: [GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md](GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md) (CIT-A4/A5 done) on top of [GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md](GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md) (PTA-A1/A2/A3 implemented)
+**Active plan**: [GOAP_CIT_A1_A2_A3_WORKFLOW_WAVE_2026-08-06.md](GOAP_CIT_A1_A2_A3_WORKFLOW_WAVE_2026-08-06.md) + [GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md](GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md) on top of [GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md](GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md) (PTA-A1/A2/A3 implemented)
 **Last Updated**: 2026-08-06
 **Open PRs**: #927 (attribution) + CIT-A4/A5 wave · **Open issues**: #913
 **Policy**: ADR-039 (canonical active set) + ADR-072 (authority / release path)
@@ -19,6 +19,7 @@
 | [ACTIONS.md](ACTIONS.md) | Action backlog |
 | [GOAP_STATE.md](GOAP_STATE.md) | GOAP phase snapshot |
 | [GATE_CONTRACT.md](GATE_CONTRACT.md) | Local/CI quality gate matrix |
+| [GOAP_CIT_A1_A2_A3_WORKFLOW_WAVE_2026-08-06.md](GOAP_CIT_A1_A2_A3_WORKFLOW_WAVE_2026-08-06.md) | **Active**: CIT-A1/A2/A3 workflow-side wave (2026-08-06) |
 | [GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md](GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md) | **Active**: CIT-A4/A5 implementation + plan truth (2026-08-06) |
 | [GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md](GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md) | **Active upstream**: CI trust + product-truth fixes + ADR-080 attribution capture |
 | [GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md](GOAP_COMPREHENSIVE_RECOMMENDATIONS_2026-07-20.md) | Reference recommendations backlog |

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -3,8 +3,8 @@
 **Last Updated**: 2026-08-06
 **Released Version**: v0.1.37 (latest tag)
 **Workspace Version**: 0.1.38 (next release)
-**Active Sprint**: CI trust + product truth + ADR-080 automatic recommendation attribution (PR #927) + CIT-A4/A5 (done)
-**Plan**: `plans/GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md` on top of `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`
+**Active Sprint**: CI trust + product truth + ADR-080 automatic recommendation attribution (PR #927) + CIT-A4/A5 (done) + CIT-A1/A2/A3 workflow wave
+**Plan**: `plans/GOAP_CIT_A1_A2_A3_WORKFLOW_WAVE_2026-08-06.md` + `plans/GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md` on top of `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`
 **Branch**: `main` @ `92db07bf`
 **Open PRs**: #927, + this CIT-A4/A5 wave
 **Open issues**: #913
@@ -34,11 +34,11 @@
 
 | Priority | Item | Description | Status |
 |----------|------|-------------|--------|
-| P0 | ADR-079 / CIT-A1 | Same-run `CI / Required` aggregate and staged ruleset migration | Proposed (maintainer) |
-| P0 | CIT-A2 | Fail closed on cancellation/missing/commitlint; Dependabot/fork parity | Planned (blocked by CIT-A1) |
+| P0 | ADR-079 / CIT-A1 | Same-run `CI / Required` aggregate and staged ruleset migration | 🔄 workflow aggregate done; ruleset stage pending (maintainer) |
+| P0 | CIT-A2 | Fail closed on cancellation/missing/commitlint; Dependabot/fork parity | 🔄 waiters fail closed + commit-lint wait; downstream actor parity pending |
 | P0 | PTA-A1 cascade truth | Non-`csm` retrieval returns typed `CapabilityUnavailable` instead of successful empty | ✅ #916 |
 | P0 | PTA-A2 storage metric truth | Label measured/estimated/unavailable via `MetricValue` provenance; remove fabricated telemetry | ✅ #916 |
-| P1 | CIT-A3 | Exact local/CI command scope and semantic gate-contract validation | Planned (blocked by CIT-A2) |
+| P1 | CIT-A3 | Exact local/CI command scope and semantic gate-contract validation | ✅ semantic validator + negative fixtures (2026-08-06) |
 | P1 | CIT-A4/A5 | Truthful release/publish triggers and durable fuzz/mutation evidence | ✅ 2026-08-06 |
 | P1 | PTA-A3 threshold CLI truth | Hide advertised `eval set-threshold` non-operation | ✅ #916 |
 | P1 | ADR-080 / RAT-A1…A7 | Episode-bound automatic attribution with truthful persistence receipts | 🔄 PR #927 open |

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -32,21 +32,21 @@
 | ADR-077 A6 validate / document / gate | ✅ #897 merged |
 | Code execution | Fail-closed (S1.1c NO-GO) |
 | MCP provenance (`with_provenance`) | ✅ |
-| First-party merge gate | **Absent** — ruleset requires Codacy + CodeQL policy only |
-| CI wait semantics | **Not fail-closed** — five waiters accept cancelled/skipped/missing fast check |
-| P0 plan gaps | **1 open** — required CI aggregate (CIT-A1, maintainer); PTA-A1/A2/A3 + CIT-A4/A5 implemented |
-| ADR-079 CI control plane | Proposed; workflow-side §6/§7 implemented 2026-08-06; ruleset unchanged |
+| First-party merge gate | **Absent** — ruleset requires Codacy + CodeQL policy only; `CI / Required` context emitted (2026-08-06) but not yet required |
+| CI wait semantics | ✅ **Fail-closed** — five waiters reject cancelled/skipped/missing; commit lint waited on |
+| P0 plan gaps | **1 open** — live ruleset required aggregate (ADR-079 acceptance); PTA + CIT-A1/A2/A3 workflow side + CIT-A4/A5 done |
+| ADR-079 CI control plane | Proposed; workflow aggregate + fail-closed waiters + semantic validator implemented 2026-08-06; ruleset unchanged |
 | ADR-080 automatic attribution | 🔄 PR #927 open (implementation landed on branch) |
 
 ## Immediate priorities
 
 | Priority | Item | ID | Status |
 |----------|------|-----|--------|
-| P0 | Add causal same-run aggregate, then stage into ruleset with approval | ADR-079 / CIT-A1 | Proposed (maintainer) |
-| P0 | Fail closed and restore Dependabot/fork assertion parity | CIT-A2 | Planned (blocked by CIT-A1) |
+| P0 | Add causal same-run aggregate, then stage into ruleset with approval | ADR-079 / CIT-A1 | 🔄 aggregate done; ruleset stage pending (maintainer) |
+| P0 | Fail closed and restore Dependabot/fork assertion parity | CIT-A2 | 🔄 waiters fail closed; downstream actor parity pending |
 | P0 | Return typed unavailable/absent API for non-`csm` cascade | PTA-A1 | ✅ Implemented |
 | P0 | Remove or label fabricated CLI storage telemetry | PTA-A2 | ✅ Implemented |
-| P1 | Reconcile gate contract | CIT-A3 | Planned (blocked by CIT-A2) |
+| P1 | Reconcile gate contract | CIT-A3 | ✅ semantic validator + negative fixtures (2026-08-06) |
 | P1 | Repair release/publish/fuzz truth | CIT-A4/A5 | ✅ Implemented (2026-08-06) |
 | P1 | Automatic episode-bound recommendation attribution | ADR-080 / RAT-A1…A7 | 🔄 PR #927 open |
 | P1 | Hide unsupported `eval set-threshold` command | PTA-A3 | ✅ Implemented |

--- a/plans/STATUS/GAP_ANALYSIS_LATEST.md
+++ b/plans/STATUS/GAP_ANALYSIS_LATEST.md
@@ -3,7 +3,7 @@
 **Generated**: 2026-08-06
 **Audit commit**: `92db07bf` (`main`)
 **Workspace**: `0.1.38` · **Tag**: `v0.1.37`
-**Active plan**: [`../GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md`](../GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md) on top of [`../GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`](../GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md)
+**Active plan**: [`../GOAP_CIT_A1_A2_A3_WORKFLOW_WAVE_2026-08-06.md`](../GOAP_CIT_A1_A2_A3_WORKFLOW_WAVE_2026-08-06.md) + [`../GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md`](../GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md) on top of [`../GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`](../GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md)
 
 ## Method
 
@@ -22,8 +22,10 @@
 
 | Gap | Resolution |
 |-----|------------|
+| G-P0-13 five waiters accept cancelled/skipped/missing + ignore commit lint | ✅ CIT-A2 — `allowed-conclusions: success`, `fail-on-no-checks: true`, new `Commit Message Lint` wait in all five waiters |
 | G-P1-15 release manual dispatch broken | ✅ CIT-A4 — `workflow_dispatch` removed from release.yml; publish uses `--locked`, bounded polling, and dependency-closure failure semantics |
 | G-P1-15 fuzz evidence silent green | ✅ CIT-A5 — fuzz artifacts upload with `always()`, status report fails the informational job on crashes/timeouts/startup failures |
+| G-P1-14 gate-contract parity presence-only | ✅ CIT-A3 — semantic validator + negative fixtures for cancelled-acceptance, missing aggregate, release dispatch, and `sleep 30` |
 | G-P2-1/7 R-F10 OIDC (ACT-325) | ✅ Already shipped (`id-token: write` + OIDC exchange); trackers refreshed |
 | G-P2-1/7 R-F4 SIMD cosine (ACT-326) | ✅ Already shipped (`cosine_similarity_simd` + simd bench variant); trackers refreshed |
 
@@ -50,8 +52,8 @@
 
 | ID | Gap | Evidence | Track |
 |----|-----|----------|-------|
-| G-P0-12 | `main-protection` requires no first-party build/test context; the echo anchor is unused and non-substantive | Ruleset `9591004`, `pr-check-anchor.yml` | ADR-079 / CIT-A1 |
-| G-P0-13 | Five waiters permit cancelled/skipped/missing format/Clippy and ignore commit lint | waiter workflows; PR #914 | ADR-079 / CIT-A2 |
+| G-P0-12 | `main-protection` requires no first-party build/test context; the echo anchor is unused and non-substantive | Ruleset `9591004`, `pr-check-anchor.yml` | 🔄 `CI / Required` context emitted (2026-08-06); ruleset stage + anchor removal need ADR-079 acceptance |
+| G-P0-13 | Five waiters permit cancelled/skipped/missing format/Clippy and ignore commit lint | waiter workflows; PR #914 | ✅ CIT-A2 closed 2026-08-06 (waiters fail closed + commit-lint wait) |
 | G-P0-10 | Cascade retrieval without `csm` returns a successful empty result, indistinguishable from no matches | `memory-core/src/retrieval/cascade/mod.rs` | ✅ PTA-A1 closed — typed `CascadeError::CapabilityUnavailable` |
 | G-P0-11 | CLI storage stats and connection status expose estimates/unknowns as measured values | `memory-cli/src/commands/storage/commands.rs`, `types.rs` | ✅ PTA-A2 closed — `MetricValue` provenance |
 
@@ -65,7 +67,7 @@
 | G-P1-11 | Pattern recommendations require manual session creation; playbooks record `Uuid::nil()` in memory only | core/MCP/CLI attribution paths | ADR-080 / RAT-A1…A7 |
 | G-P1-12 | Feedback accepts integrity states that can corrupt attribution statistics | tracker/API/persistence paths | ADR-080 / RAT-A4 |
 | G-P1-13 | Dependabot is excluded from most substantive code/test/security assertions | actor conditions across CI/coverage/security/file/benchmark workflows | ADR-079 / CIT-A2 |
-| G-P1-14 | Gate contract claims parity while tests, Clippy, LOC, and quality-bundle semantics differ; validator is presence-only | `GATE_CONTRACT.md`, `ci.yml`, `quick-check.yml`, `validate-gate-contract.sh` | ADR-079 / CIT-A3 |
+| G-P1-14 | Gate contract claims parity while tests, Clippy, LOC, and quality-bundle semantics differ; validator is presence-only | `GATE_CONTRACT.md`, `ci.yml`, `quick-check.yml`, `validate-gate-contract.sh` | 🔄 semantic validator + negative fixtures 2026-08-06; test/Clippy scope + ruleset-context fixtures remain |
 | G-P1-15 | Release manual dispatch is broken; publish selection and fuzz evidence have silent skip/green paths | release run `30301797956`, publish/fuzz workflow conditions | ✅ CIT-A4/A5 closed 2026-08-06 |
 
 ### P2 (product / research)

--- a/plans/STATUS/VALIDATION_LATEST.md
+++ b/plans/STATUS/VALIDATION_LATEST.md
@@ -1,3 +1,26 @@
+# Validation Latest — 2026-08-06 (CIT-A1/A2/A3 workflow wave)
+
+**Goal**: Validate the fail-closed waiter changes, the `CI / Required` aggregate,
+and the semantic gate-contract validator. Ruleset state untouched (maintainer).
+
+**Workspace**: `0.1.38` · **Tag**: `v0.1.37` · **HEAD**: `92db07bf`
+
+## Evidence
+
+| Check | Observation | Result |
+|-------|-------------|--------|
+| `yamllint` | ci/coverage/security/benchmarks/file-structure clean | ✅ |
+| `bash -n` | `validate-gate-contract.sh` clean | ✅ |
+| `validate-gate-contract.sh --ci-parity` | PASS on this state | ✅ |
+| Negative fixture 1 | reintroduced `allowed-conclusions: success,skipped,cancelled` → FAIL with message | ✅ |
+| Negative fixture 2 | removed `CI / Required` aggregate → FAIL with message | ✅ |
+| Waiters | 5 workflows: `allowed-conclusions: success`, `fail-on-no-checks: true`, commit-lint wait added | ✅ |
+| Aggregate | `ci.yml` job `name: CI / Required`, `if: always()`, needs test/mcp/multi/quality-gates | ✅ |
+| Plans validation | `validate-plans.sh --active-set --version-state --adrs --identifiers --links` | ✅ (pre-existing warnings only) |
+| Live ruleset | Unchanged — adding `CI / Required` to ruleset needs ADR-079 acceptance | ⚠️ open |
+
+---
+
 # Validation Latest — 2026-08-06 (CIT-A4/A5 wave)
 
 **Goal**: Validate the CIT-A4/CIT-A5 workflow changes and the plan-truth refresh

--- a/scripts/validate-gate-contract.sh
+++ b/scripts/validate-gate-contract.sh
@@ -123,6 +123,34 @@ if [[ "$CI_PARITY" == true ]]; then
   if ! grep -qE 'skill-evals|run-evals\.sh --fixtures' "$CONTRACT"; then
     fail "GATE_CONTRACT.md must document skill-evals / fixtures CI entrypoint"
   fi
+
+  # --- ADR-079 semantic checks (CIT-A1/A2/A4; negative fixtures 2026-08-06) ---
+
+  # CIT-A1: stable 'CI / Required' aggregate context that evaluates with always()
+  if ! awk '/name: CI \/ Required/{for(i=0;i<12;i++){if((getline l)>0 && l ~ /always\(\)/){ok=1}}} END{exit !ok}' "$WF_DIR/ci.yml"; then
+    fail "ci.yml must define a 'CI / Required' aggregate job using if: always()"
+  fi
+
+  # CIT-A2: no gate waiter may accept cancelled/skipped conclusions or a missing check
+  if grep -rE 'allowed-conclusions:.*cancelled' "$WF_DIR" --include='*.yml' | grep -q .; then
+    fail "a workflow still accepts cancelled/skipped conclusions from a gate waiter (fail-closed required)"
+  fi
+  if grep -rE 'fail-on-no-checks: (false|no)' "$WF_DIR" --include='*.yml' | grep -q .; then
+    fail "a workflow still sets fail-on-no-checks: false on a gate waiter (missing checks must fail)"
+  fi
+
+  # CIT-A4: tag-only release authority; publish uses --locked and bounded polling
+  if rg -q 'workflow_dispatch' "$WF_DIR/release.yml"; then
+    fail "release.yml must not expose workflow_dispatch (tag-only release under ADR-072)"
+  fi
+  if [[ -f "$WF_DIR/publish-crates.yml" ]]; then
+    if ! rg -q -- '--locked' "$WF_DIR/publish-crates.yml"; then
+      fail "publish-crates.yml must use cargo publish --locked"
+    fi
+    if rg -q 'run: sleep 30' "$WF_DIR/publish-crates.yml"; then
+      fail "publish-crates.yml must not use fixed 'run: sleep 30' (bounded polling required)"
+    fi
+  fi
 fi
 
 echo -e "${GREEN}PASS${NC}: gate contract consistent (local coverage floor=${floor}%)"

--- a/scripts/validate-gate-contract.sh
+++ b/scripts/validate-gate-contract.sh
@@ -127,7 +127,14 @@ if [[ "$CI_PARITY" == true ]]; then
   # --- ADR-079 semantic checks (CIT-A1/A2/A4; negative fixtures 2026-08-06) ---
 
   # CIT-A1: stable 'CI / Required' aggregate context that evaluates with always()
-  if ! awk '/name: CI \/ Required/{for(i=0;i<12;i++){if((getline l)>0 && l ~ /always\(\)/){ok=1}}} END{exit !ok}' "$WF_DIR/ci.yml"; then
+  # Stateful scan: job headers are 2-space 'name:', 'name: CI / Required' and its
+  # if: always() are 4-space keys inside the same job block.
+  if ! awk '
+    /^  [a-zA-Z0-9_-]+:/ { in_required = 0 }
+    /name: CI \/ Required/ { in_required = 1; found = 1 }
+    in_required && /if: always\(\)/ { ok = 1 }
+    END { exit !(found && ok) }
+  ' "$WF_DIR/ci.yml"; then
     fail "ci.yml must define a 'CI / Required' aggregate job using if: always()"
   fi
 
@@ -135,7 +142,7 @@ if [[ "$CI_PARITY" == true ]]; then
   if grep -rE 'allowed-conclusions:.*cancelled' "$WF_DIR" --include='*.yml' | grep -q .; then
     fail "a workflow still accepts cancelled/skipped conclusions from a gate waiter (fail-closed required)"
   fi
-  if grep -rE 'fail-on-no-checks: (false|no)' "$WF_DIR" --include='*.yml' | grep -q .; then
+  if grep -riE 'fail-on-no-checks: (false|no)' "$WF_DIR" --include='*.yml' | grep -q .; then
     fail "a workflow still sets fail-on-no-checks: false on a gate waiter (missing checks must fail)"
   fi
 


### PR DESCRIPTION
## Summary

ADR-079 CIT-A1/A2/A3 **workflow/validator side** (staged-migration stages 1–2 only). This PR stacks on the CIT-A4/A5 branch (#928); wave plan: `plans/GOAP_CIT_A1_A2_A3_WORKFLOW_WAVE_2026-08-06.md`. The live-ruleset change and echo-anchor removal are **not** performed here — they require ADR-079 acceptance and explicit maintainer approval (ADR-079 §5).

## Changes

### CIT-A2 — waiters fail closed (5 workflows: ci, coverage, security, benchmarks, file-structure)
- `allowed-conclusions: success,skipped,cancelled` → `success`
- `fail-on-no-checks: false` → `true` (missing check now fails, never passes)
- New **Commit Message Lint** wait step — commit-lint failure can no longer be masked by a green format/Clippy job (G-P0-13)
- Waiter `if:` no longer excludes Dependabot (Quick Check always runs on PRs; waiter is cheap). Downstream actor parity stays for a follow-up pending the ADR-079 CI-cost decision.

### CIT-A1 — stable `CI / Required` aggregate
- `ci.yml` new `required` job: `needs: [test, mcp-build, multi-platform, quality-gates]`, `if: always()`, fails closed on failure/cancelled/unknown; `skipped` accepted only when the dependency's own in-workflow `if` classified it inapplicable. Stable context, never path-filtered. **Not** added to the live ruleset.

### CIT-A3 — semantic gate-contract validation (negative fixtures)
- `validate-gate-contract.sh --ci-parity` now fails when: cancelled/skipped waiter acceptance returns; `CI / Required` aggregate is absent; `release.yml` re-exposes `workflow_dispatch`; `publish-crates.yml` drops `--locked` or reintroduces `run: sleep 30`.
- `GATE_CONTRACT.md` documents the aggregate row and fail-closed semantics.

## Validation
- `yamllint` clean on all changed workflows; `bash -n` clean on the validator.
- `validate-gate-contract.sh --ci-parity` PASS; negative tests (reintroduce `success,skipped,cancelled`; delete aggregate) both FAIL with expected messages.
- `validate-plans.sh` passes (pre-existing warnings only); `git diff --check` clean.

## Not included (gated)
- Adding `CI / Required` to `main-protection` ruleset + removing `pr-check-anchor.yml` (ADR-079 acceptance + explicit approval).
- Full Dependabot/fork downstream actor parity.
