### PR TITLE
docs(release): set Released Version to v0.1.38 for ship

### DIFF
--- a/.agents/skills/do-memory-cli-ops/SKILL.md
+++ b/.agents/skills/do-memory-cli-ops/SKILL.md
@@ -40,6 +40,12 @@ Options:
   --db-path <PATH>            Project-local DB path (env: MEMORY_DB_PATH)
 ```
 
+**Flag placement & logs** (verified against release v0.1.38):
+- `-f/--format`, `-v/--verbose`, `-c/--config`, `--storage-mode`, `--db-path` are **top-level** flags — place them **before** the subcommand: `do-memory-cli --format json episode list` works, `do-memory-cli episode list --format json` is rejected.
+- **Logs go to stderr**; stdout carries only command output, so `--format json` piped to `jq` stays machine-parseable.
+- `RUST_LOG=off` silences all logs; `RUST_LOG=debug` adds detail (equivalent to `-v`).
+  Note: an *empty* `RUST_LOG` also silences logs — prefer an explicit `RUST_LOG=off`.
+
 ### Storage / DB path notes (issues #830, #832)
 
 | Flag / env | Effect |
@@ -90,8 +96,8 @@ Each CLI invocation is a **separate process**. Patterns must be durable (postcar
 DB=./data/memory.redb
 CLI="do-memory-cli --storage-mode local --db-path $DB"
 
-# 1. Create
-ID=$($CLI episode create -t "Implement auth" --format json | jq -r .episode_id)
+# 1. Create (--format is a top-level flag: place it BEFORE the subcommand)
+ID=$($CLI --format json episode create -t "Implement auth" | jq -r .episode_id)
 
 # 2. Log steps (use --success for tool-sequence patterns)
 $CLI episode log-step "$ID" --tool compiler --action "build" --success
@@ -114,12 +120,25 @@ $CLI pattern search auth
 
 | Command | Alias | Purpose |
 |---------|-------|---------|
-| episode | ep | Episode management |
-| pattern | pat | Pattern analysis |
-| storage | st | Storage operations |
+| episode | ep | Episode management (create, list, view, log-step, complete, bulk, search) |
+| pattern | pat | Pattern analysis (list, view, analyze, effectiveness, extract, decay) |
+| storage | st | Storage operations (stats, sync, vacuum, health, connections) |
 | config | cfg | Configuration (`init`, `show-template`, `show`, `validate`) |
-| health | hp | Health monitoring |
-| backup | bak | Backup/restore |
-| monitor | mon | Metrics |
+| health | hp | Health monitoring (`check`, `status`, `monitor`) |
+| backup | bak | Backup/restore (`create`, `list`, `restore`, `verify`) |
+| monitor | mon | Metrics (`status`, `export`) |
+| logs | log | Log analysis (`analyze`, `search`, `export`, `stats`) |
+| eval | ev | Evaluation & calibration (`stats`, `calibration`) |
+| embedding | emb | Embedding providers (`list`, `test`, `configure`) |
+| tag | tg | Episode tags (`add`, `remove`, `set`, `get`, `search`) |
+| relationship | rel | Episode relationships (DAG + `info`) |
+| playbook | pb | Playbook recommendations & management |
+| feedback | fb | Recommendation feedback tracking |
+| external-signal | sig | External signal provider management |
+| completion | comp | Shell completions (`bash`, `zsh`, `fish`, …) |
+
+Subcommand help is authoritative: `do-memory-cli <cmd> --help`. Some leaf commands
+(`backup create`, `logs export`, `monitor export`) accept a **local** `--format`;
+all others use the top-level flag only.
 
 See **[commands.md](commands.md)** for detailed command documentation and **[examples.md](examples.md)** for common workflows.

--- a/.agents/skills/do-memory-cli-ops/SKILL.md
+++ b/.agents/skills/do-memory-cli-ops/SKILL.md
@@ -65,6 +65,31 @@ do-memory-cli --storage-mode local --db-path ./data/memory.redb episode list
 MEMORY_DB_PATH=./data/memory.redb MEMORY_STORAGE_MODE=local do-memory-cli episode list
 ```
 
+### Verifying Turso/SQLite entries
+
+With the `turso` feature, `--db-path x.redb` opens **two sibling files**: the
+Turso/SQLite database at `x.db` (durable) and the redb cache at `x.redb`.
+
+Inspect the SQLite side directly (no `sqlite3` CLI needed — python3 ships sqlite3):
+
+```bash
+python3 - <<'PY'
+import sqlite3
+con = sqlite3.connect("data/cache.db")   # sibling of data/cache.redb
+cur = con.cursor()
+print([t[0] for t in cur.execute("SELECT name FROM sqlite_master WHERE type='table'")])
+print("episodes:", cur.execute("SELECT COUNT(*) FROM episodes").fetchone()[0])
+print(cur.execute("SELECT episode_id, substr(task_description,1,40) FROM episodes").fetchall())
+PY
+```
+
+Notes:
+
+- `episodes.outcome` is a **JSON string** (e.g. `{"Success":{"verdict":"..."}}`); there is no `status` column.
+- Steps live inside the `episodes.steps` JSON column, not a separate table.
+- CLI-side verification: `episode list`, `pattern list`, `storage stats`, `health check`.
+- **`storage sync` is Turso → redb only** (ADR-076 reconciliation): it refreshes the cache from durable storage and can never push cache-only episodes into Turso. `backup create` also reads Turso only. Episodes that exist only in the redb cache stay cache-only — recreate them or add a cache→Turso path to make them durable.
+
 ## Config discovery (issue #829)
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - route CLI tracing to stderr and honor `RUST_LOG` so `--format json`/`yaml`
   output stays machine-parseable for scripts
 
+- fix `local-embeddings` build/clippy: adopt the ort 2.0.0-rc.13 `ep::CPU`
+  provider API and drop unfulfilled lint expectations
+
 ### Performance
 
 - optimize ConceptGraph domain-term expand allocations and sorting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.38] - 2026-08-02
+## [0.1.38] - 2026-08-07
 
 ### Added
 
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - r-f10 OIDC trusted publishing for crates.io
 
+- implement ADR-080/081 automatic recommendation attribution, with
+  `failed_backends` ordering and no-op re-persist assertions (#927, #930)
+
 ### Fixed
 
 - resolve pre-existing quality warnings: honest storage vacuum reporting,
@@ -31,13 +34,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - remove unsafe AVX2 intrinsics in favor of autovectorized scalar cosine
 
+- dedupe similarity reference helpers (clippy)
+
+- route CLI tracing to stderr and honor `RUST_LOG` so `--format json`/`yaml`
+  output stays machine-parseable for scripts
+
 ### Performance
 
 - optimize ConceptGraph domain-term expand allocations and sorting
 
+- single-row DP and streamed char similarity for pattern scoring (#925)
+
+### Test
+
+- unit tests for `semantic_text` text builders (#922)
+
+- evals fixtures for the `perf-pr-guardrails` review skill
+
+### CI
+
+- fail-closed waiters, CI / Required aggregate, semantic gate validator
+  (CIT-A1/A2/A3) (#929)
+
+- locked publish with bounded polling and dependency closure; publish/release
+  fixtures wired into skill evals (CIT-A4)
+
+- durable fuzz crash evidence and non-green status (CIT-A5)
+
 ### Chore
 
 - record PR merge session progress in plans trackers (#919)
+
+- record PR #925 review and perf-PR guard rails; route `perf-pr-guardrails`
+  skill and fix skills index
 
 - bump workspace to 0.1.38 after shipping v0.1.37
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix `local-embeddings` build/clippy: adopt the ort 2.0.0-rc.13 `ep::CPU`
   provider API and drop unfulfilled lint expectations
 
+- fix `csm` feature build: resolve the stale lock mix (chaotic_semantic_memory
+  0.3.8 with csm-* sub-crates at 0.3.7) by aligning all csm crates at 0.3.8
+
 ### Performance
 
 - optimize ConceptGraph domain-term expand allocations and sorting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -188,7 +188,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -993,7 +993,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1263,18 +1263,18 @@ dependencies = [
 
 [[package]]
 name = "csm-chaos"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc23d1afe59a02336c75587a741e838f9776f6f8e7c9524d9ffe5ddb89858c2e"
+checksum = "f2a0c0c391a00c401b5b230724c4434fe02f5fce261dd75d5d1a0b43fdecef25"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "csm-core-lib"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d617dda8104d82d7ec815025649636bfc42209758d62437b2a5acb24103eada"
+checksum = "4bdb85b891fb15dd9688c9ec99575b83a0b2e43795d358df9ba7d086bd45a8a6"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -1290,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "csm-embedding"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93dd81cde13477657c1fa0af9ebce14d7b6a3d27df533889e34900056e6c8f54"
+checksum = "438c157701d37ffceef16e0e2a7e3065a68db9bc97210ac20a0a5eaebee07ee8"
 dependencies = [
  "async-trait",
  "csm-core-lib",
@@ -1306,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "csm-memory"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134b0d8e1740f5a9feac90e81501be9db66b12e95a825ec6031f43fb738dfc70"
+checksum = "f9b841021ce8df7dc14f32d1885537d898ccb6f2f1df30e460d45896a232f5c6"
 dependencies = [
  "csm-core-lib",
  "js-sys",
@@ -1322,9 +1322,9 @@ dependencies = [
 
 [[package]]
 name = "csm-persistence"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b4a58d2fe18287c78b6e0f53f4908affeb7d604f40bbcb1ce560a8385af96b"
+checksum = "b6af56ac1a9cc4f26a511f3e08df3fd10e1e2f2008139fbe9b73d140bf6e1b90"
 dependencies = [
  "csm-core-lib",
  "csm-memory",
@@ -1339,11 +1339,12 @@ dependencies = [
 
 [[package]]
 name = "csm-retrieval"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8382c261fdf0763564624dbec72002fbe6ff63ebad4725e4f33cea2cf0bc44"
+checksum = "bd9aaf1ea01a12f3afc624a8566b2f0c6500d42ceb7d3fc8a37253bbe5152bdb"
 dependencies = [
  "async-trait",
+ "chrono",
  "csm-core-lib",
  "csm-memory",
  "serde",
@@ -1355,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "csm-traits"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1230a644b82b3c82811dcdba5ec73b266058b4ca99dc96eba2de29ea845ccc27"
+checksum = "980a2037cf025db5caf14d1e9fbddd524ca998977416d26b25708293a092bef0"
 dependencies = [
  "csm-core-lib",
  "js-sys",
@@ -1652,7 +1653,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2085,7 +2086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3201,7 +3202,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4041,7 +4042,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5289,7 +5290,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5382,7 +5383,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5892,7 +5893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6145,7 +6146,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6154,7 +6155,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7312,7 +7313,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # API Reference
 
-**Version**: v0.1.22 (current workspace release)
-**Last Updated**: 2026-03-24
+**Version**: v0.1.38 (current workspace release)
+**Last Updated**: 2026-08-07
 **Protocol**: MCP over JSON-RPC 2.0 (protocol negotiation supports `2025-11-25` and `2024-11-05`)
 
 ---

--- a/memory-cli/CLI_BULK_OPERATIONS.md
+++ b/memory-cli/CLI_BULK_OPERATIONS.md
@@ -16,10 +16,10 @@ Retrieve multiple episodes by their IDs in a single efficient operation.
 do-memory-cli episode bulk abc123...,def456...,ghi789...
 
 # JSON output
-do-memory-cli episode bulk abc123...,def456... --format json
+do-memory-cli --format json episode bulk abc123...,def456...
 
 # YAML output  
-do-memory-cli episode bulk abc123...,def456... --format yaml
+do-memory-cli --format yaml episode bulk abc123...,def456...
 ```
 
 **Features:**
@@ -221,7 +221,7 @@ cargo build --features turso
 ./target/debug/do-memory-cli episode bulk <id1>,invalid-uuid,<id2>
 
 # Test JSON output
-./target/debug/do-memory-cli episode bulk <id1>,<id2> --format json
+./target/release/do-memory-cli --format json episode bulk <id1>,<id2>
 ```
 
 ### Expected Behavior
@@ -240,16 +240,18 @@ cargo build --features turso
 ```bash
 $ do-memory-cli episode bulk --help
 
-Retrieve multiple episodes by their IDs (bulk operation)
+Retrieve multiple episodes by IDs (comma-separated)
 
-Usage: do-memory-cli episode bulk <IDS>
+Usage: do-memory-cli episode bulk <EPISODE_IDS>
 
 Arguments:
-  <IDS>  Comma-separated list of episode UUIDs
+  <EPISODE_IDS>  Comma-separated episode IDs
 
 Options:
-  -f, --format <FORMAT>  Output format [default: human] [possible values: human, json, yaml]
-  -h, --help             Print help
+  -h, --help  Print help
+```
+
+> Note: `--format` is a top-level flag — use `do-memory-cli --format json episode bulk <ids>`.
 ```
 
 ### User Guide Addition

--- a/memory-cli/CLI_USER_GUIDE.md
+++ b/memory-cli/CLI_USER_GUIDE.md
@@ -82,7 +82,7 @@ do-memory-cli storage health
 All commands support these global options:
 
 - `--config <FILE>`: Path to configuration file
-- `--format <FORMAT>`: Output format (human/json/yaml)
+- `--format <FORMAT>`: Output format (human/json/yaml) — **top-level flag**, place it *before* the subcommand (e.g. `do-memory-cli --format json episode list`)
 - `--verbose`: Enable verbose logging
 - `--dry-run`: Preview operations without executing
 - `--help`: Show help information
@@ -151,7 +151,7 @@ do-memory-cli episode list --semantic-search "authentication issues" --limit 10
 do-memory-cli episode list --semantic-search "database errors" --enable-embeddings --embedding-provider openai
 
 # JSON output for scripting
-do-memory-cli episode list --format json
+do-memory-cli --format json episode list
 ```
 
 #### `do-memory-cli episode view`
@@ -167,7 +167,7 @@ Display detailed information about a specific episode.
 do-memory-cli episode view 12345678-1234-1234-1234-123456789abc
 
 # JSON output for processing
-do-memory-cli episode view 12345678-1234-1234-1234-123456789abc --format json
+do-memory-cli --format json episode view 12345678-1234-1234-1234-123456789abc
 ```
 
 #### `do-memory-cli episode complete`
@@ -294,7 +294,7 @@ Display detailed information about a specific pattern.
 do-memory-cli pattern view pattern-123
 
 # JSON output
-do-memory-cli pattern view pattern-123 --format json
+do-memory-cli --format json pattern view pattern-123
 ```
 
 #### `do-memory-cli pattern analyze`
@@ -362,7 +362,7 @@ Display storage statistics and usage information.
 do-memory-cli storage stats
 
 # JSON output for monitoring
-do-memory-cli storage stats --format json
+do-memory-cli --format json storage stats
 ```
 
 #### `do-memory-cli storage sync`
@@ -411,7 +411,7 @@ Check storage backend health.
 do-memory-cli storage health
 
 # JSON output for monitoring
-do-memory-cli storage health --format json
+do-memory-cli --format json storage health
 ```
 
 #### `do-memory-cli storage connections`
@@ -460,7 +460,7 @@ View detailed statistics for a specific domain.
 do-memory-cli eval stats web-development
 
 # JSON output for automation
-do-memory-cli eval stats web-development --format json
+do-memory-cli --format json eval stats web-development
 ```
 
 ### Meta Commands
@@ -618,10 +618,10 @@ Solution: Use a valid UUID format
 #!/bin/bash
 # Export recent episodes to JSON files
 
-do-memory-cli episode list --limit 50 --format json | \
+do-memory-cli --format json episode list --limit 50 | \
   jq -r '.episodes[].episode_id' | \
   while read episode_id; do
-    do-memory-cli episode view "$episode_id" --format json > "episode_$episode_id.json"
+    do-memory-cli --format json episode view "$episode_id" > "episode_$episode_id.json"
   done
 ```
 
@@ -631,7 +631,7 @@ do-memory-cli episode list --limit 50 --format json | \
 # Alert on low-effectiveness patterns
 
 threshold=0.7
-do-memory-cli pattern effectiveness --format json | \
+do-memory-cli --format json pattern effectiveness | \
   jq --arg threshold "$threshold" '.rankings[] | select(.effectiveness_score < ($threshold | tonumber))' | \
   while read pattern; do
     echo "Low effectiveness pattern detected:"
@@ -644,7 +644,7 @@ do-memory-cli pattern effectiveness --format json | \
 #!/bin/bash
 # Check system health for monitoring
 
-if ! do-memory-cli storage health --format json | jq -e '.overall == "healthy"' > /dev/null; then
+if ! do-memory-cli --format json storage health | jq -e '.overall == "healthy"' > /dev/null; then
   echo "Storage health check failed!" >&2
   do-memory-cli storage health
   exit 1
@@ -677,10 +677,10 @@ echo "Running memory system health checks..."
 do-memory-cli config || exit 1
 
 # Check storage health
-do-memory-cli storage health --format json | jq -e '.overall == "healthy"' || exit 1
+do-memory-cli --format json storage health | jq -e '.overall == "healthy"' || exit 1
 
 # Check recent episodes
-episode_count=$(do-memory-cli episode list --limit 1 --format json | jq '.total_count')
+episode_count=$(do-memory-cli --format json episode list --limit 1 | jq '.total_count')
 if [ "$episode_count" -lt 0 ]; then
   echo "Episode count check failed"
   exit 1

--- a/memory-cli/README.md
+++ b/memory-cli/README.md
@@ -473,12 +473,12 @@ total_count: 150
 #!/bin/bash
 
 # Get recent episodes as JSON
-episodes=$(do-memory-cli episode list --limit 10 --format json)
+episodes=$(do-memory-cli --format json episode list --limit 10)
 
 # Process each episode
 echo "$episodes" | jq -r '.episodes[].episode_id' | while read episode_id; do
     echo "Processing episode: $episode_id"
-    do-memory-cli episode view "$episode_id" --format json > "episode_$episode_id.json"
+    do-memory-cli --format json episode view "$episode_id" > "episode_$episode_id.json"
 done
 ```
 
@@ -487,7 +487,7 @@ done
 #!/bin/bash
 
 # Get pattern effectiveness as JSON
-effectiveness=$(do-memory-cli pattern effectiveness --top 5 --format json)
+effectiveness=$(do-memory-cli --format json pattern effectiveness --top 5)
 
 # Check for patterns below threshold
 echo "$effectiveness" | jq '.patterns[] | select(.effectiveness < 0.7)' | while read pattern; do
@@ -501,7 +501,7 @@ done
 #!/bin/bash
 
 # Check storage health
-if ! do-memory-cli storage health --format json | jq -e '.overall == "healthy"' > /dev/null; then
+if ! do-memory-cli --format json storage health | jq -e '.overall == "healthy"' > /dev/null; then
     echo "Storage health check failed!"
     do-memory-cli storage health
     exit 1
@@ -572,7 +572,7 @@ sudo journalctl -u do-memory-cli -f
 do-memory-cli health monitor --interval 30 --duration 3600
 
 # Health check in scripts
-if do-memory-cli health check --format json | jq -e '.overall_status == "Healthy"'; then
+if do-memory-cli --format json health check | jq -e '.overall_status == "Healthy"'; then
     echo "System is healthy"
 else
     echo "Health check failed"
@@ -624,17 +624,17 @@ do-memory-cli backup restore ./backups --backup-id daily_20251117_020000 --force
 do-memory-cli logs analyze --since 24h > daily_report.json
 
 # Error trend analysis
-do-memory-cli logs search "error timeout" --since 7d --format json | \
+do-memory-cli --format json logs search "error timeout" --since 7d | \
     jq '.results | group_by(.episode_id) | map({episode: .[0].episode_id, errors: length})'
 ```
 
 #### Performance Monitoring
 ```bash
 # Export performance metrics
-do-memory-cli logs stats --since 1h --format json
+do-memory-cli --format json logs stats --since 1h
 
 # Identify slow operations
-do-memory-cli logs analyze --since 24h --format json | \
+do-memory-cli --format json logs analyze --since 24h | \
     jq '.performance_trends[] | select(.average_latency_ms > 1000)'
 ```
 

--- a/memory-cli/src/commands/episode/core/complete.rs
+++ b/memory-cli/src/commands/episode/core/complete.rs
@@ -179,7 +179,7 @@ fn print_complete_success(
             outcome: outcome_str,
         };
 
-        return format.print_output(&result);
+        format.print_output(&result)
     }
 
     #[cfg(not(feature = "turso"))]

--- a/memory-cli/src/main.rs
+++ b/memory-cli/src/main.rs
@@ -217,16 +217,16 @@ async fn main() -> anyhow::Result<()> {
 
     let cli = Cli::parse();
 
-    // Initialize tracing
-    if cli.verbose {
-        tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::DEBUG)
-            .init();
-    } else {
-        tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::INFO)
-            .init();
-    }
+    // Initialize tracing. Logs go to stderr so `--format json`/`yaml` output
+    // on stdout stays machine-parseable for scripts; RUST_LOG (when set)
+    // overrides the default level (debug with -v, info otherwise).
+    let default_level = if cli.verbose { "debug" } else { "info" };
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(default_level));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .init();
 
     // Load configuration with validation
     let mut config = match &cli.config {

--- a/memory-core/src/embeddings/real_model/model.rs
+++ b/memory-core/src/embeddings/real_model/model.rs
@@ -166,16 +166,8 @@ impl RealEmbeddingModel {
 
                 tracing::info!("Model download completed successfully");
             }
-
-            #[cfg(not(feature = "reqwest"))]
-            {
-                return Err(anyhow::anyhow!(
-                    "Model files not found at {} and {}\n\
-                     Enable 'reqwest' feature for automatic download or manually download from https://huggingface.co/{model_name}",
-                    model_path.display(),
-                    tokenizer_path.display()
-                ));
-            }
+            // `local-embeddings` always enables `reqwest` (via `reqwest/stream`),
+            // so the manual-download fallback below is unreachable and removed.
         }
 
         // Load tokenizer

--- a/memory-core/src/embeddings/real_model/model.rs
+++ b/memory-core/src/embeddings/real_model/model.rs
@@ -10,9 +10,7 @@ use anyhow::Result;
 use anyhow::Context;
 
 #[cfg(feature = "local-embeddings")]
-use {
-    ort::execution_providers::CPUExecutionProvider, ort::session::Session, tokenizers::Tokenizer,
-};
+use {ort::ep::CPU, ort::session::Session, tokenizers::Tokenizer};
 
 #[cfg(all(feature = "local-embeddings", feature = "reqwest"))]
 use crate::embeddings::real_model::download::download_model;
@@ -140,7 +138,6 @@ impl RealEmbeddingModel {
     /// Attempts to load the model from cache. If files don't exist and
     /// the `reqwest` feature is enabled, automatically downloads them
     /// from `HuggingFace` Hub.
-    #[expect(clippy::unused_async)] // Required for API compatibility with async trait methods
     pub async fn try_load_from_cache(
         config: &LocalConfig,
         cache_dir: &std::path::Path,
@@ -188,7 +185,7 @@ impl RealEmbeddingModel {
         // Load ONNX session
         let session = Session::builder()
             .map_err(|e| anyhow::anyhow!("Failed to create session builder: {e}"))?
-            .with_execution_providers([CPUExecutionProvider::default().build()])
+            .with_execution_providers([CPU::default().build()])
             .map_err(|e| anyhow::anyhow!("Failed to configure execution providers: {e}"))?
             .commit_from_file(&model_path)
             .map_err(|e| anyhow::anyhow!("Failed to load ONNX model: {e}"))?;

--- a/memory-mcp/package.json
+++ b/memory-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "do-memory-mcp-server",
-  "version": "0.1.26",
+  "version": "0.1.38",
   "description": "Model Context Protocol server with secure code execution sandbox for AI agents",
   "main": "index.js",
   "scripts": {

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -1,12 +1,12 @@
 # Active Development Roadmap
 
 **Last Updated**: 2026-08-06
-**Released Version**: v0.1.37 (latest tag)
+**Released Version**: v0.1.38 (latest tag)
 **Workspace Version**: 0.1.38 (next release)
-**Active Sprint**: CI trust + product truth + ADR-080 automatic recommendation attribution (PR #927) + CIT-A4/A5 (done) + CIT-A1/A2/A3 workflow wave
+**Active Sprint**: CI trust + product truth + ADR-080 automatic recommendation attribution (#927) + receipt-matrix test hardening (#930) + CIT-A4/A5 (#928) + CIT-A1/A2/A3 workflow wave
 **Plan**: `plans/GOAP_CIT_A1_A2_A3_WORKFLOW_WAVE_2026-08-06.md` + `plans/GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md` on top of `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`
 **Branch**: `main` @ `92db07bf`
-**Open PRs**: #927, + this CIT-A4/A5 wave
+**Open PRs**: none (v0.1.38 release-docs bump in flight)
 **Open issues**: #913
 
 ---
@@ -41,7 +41,7 @@
 | P1 | CIT-A3 | Exact local/CI command scope and semantic gate-contract validation | ✅ semantic validator + negative fixtures (2026-08-06) |
 | P1 | CIT-A4/A5 | Truthful release/publish triggers and durable fuzz/mutation evidence | ✅ 2026-08-06 |
 | P1 | PTA-A3 threshold CLI truth | Hide advertised `eval set-threshold` non-operation | ✅ #916 |
-| P1 | ADR-080 / RAT-A1…A7 | Episode-bound automatic attribution with truthful persistence receipts | 🔄 PR #927 open |
+| P1 | ADR-080 / RAT-A1…A7 | Episode-bound automatic attribution with truthful persistence receipts | ✅ #927 merged + #930 test extension |
 | P2 | Ranking adaptation | Idempotent feedback-to-ranking update; requires separate ADR | Deferred |
 
 ---

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -1,17 +1,17 @@
 # Project Status — Self-Learning Memory System
 
 **Last Updated**: 2026-08-07
-**Released Version**: v0.1.37 (⚠️ `v0.1.38` prepared in #921 but not yet shipped)
+**Released Version**: v0.1.38 (latest tag)
 **Workspace Version**: 0.1.38 (next release)
 **Edition**: Rust 2024  
 **Active plan**: `plans/GOAP_PR_REVIEW_CI_FIX_WAVE_2026-08-07.md` on top of `plans/GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md` + `plans/GOAP_CODEBASE_TRUTH_AND_ATTRIBUTION_2026-07-30.md`
-**Branch**: `main` @ `92db07bf`
+**Branch**: `main` @ `fe623250`
 
 ## Open tracker (live)
 
 | Kind | Items |
 |------|--------|
-| Open PRs | #928 CIT-A4/A5 wave + plan truth (CI green) · #927 ADR-080/081 attribution (CI green) — both awaiting terminal-state re-run |
+| Open PRs | None — #927/#928/#930 merged; v0.1.38 release-docs bump in flight |
 | Open issues | #913 Nix CI evaluation |
 
 ## Recent completed (2026-08-07 — PR review & CI fix wave)
@@ -22,7 +22,8 @@
 | #927 release drift | ✅ `commit_limit` deadlock broken via `release-preparation` label (v0.1.38 ship remains TODO) |
 | #927 Codecov patch | ✅ receipt matrix + MCP envelope tests + CLI render dedup (`attribution_output`) |
 | Main cancelled runs | ✅ Skill Evals + Performance Benchmarks re-run |
-| Memory CLI validation | ✅ 3 episodes learned; `pattern recommend --episode-id` receipt `Persisted` e2e |
+| Memory CLI validation | ✅ 4 episodes learned; `pattern recommend --episode-id` receipt `Persisted` e2e |
+| #930 receipt-matrix extension | ✅ `failed_backends` ordering + no-op re-persist tests merged |
 
 ## Snapshot
 
@@ -46,7 +47,7 @@
 | CI wait semantics | ✅ **Fail-closed** — five waiters reject cancelled/skipped/missing; commit lint waited on |
 | P0 plan gaps | **1 open** — live ruleset required aggregate (ADR-079 acceptance); PTA + CIT-A1/A2/A3 workflow side + CIT-A4/A5 done |
 | ADR-079 CI control plane | Proposed; workflow aggregate + fail-closed waiters + semantic validator implemented 2026-08-06; ruleset unchanged |
-| ADR-080 automatic attribution | 🔄 PR #927 open (implementation landed on branch) |
+| ADR-080 automatic attribution | ✅ #927 merged + #930 test extension |
 
 ## Immediate priorities
 
@@ -58,7 +59,7 @@
 | P0 | Remove or label fabricated CLI storage telemetry | PTA-A2 | ✅ Implemented |
 | P1 | Reconcile gate contract | CIT-A3 | ✅ semantic validator + negative fixtures (2026-08-06) |
 | P1 | Repair release/publish/fuzz truth | CIT-A4/A5 | ✅ Implemented (2026-08-06) |
-| P1 | Automatic episode-bound recommendation attribution | ADR-080 / RAT-A1…A7 | 🔄 PR #927 open |
+| P1 | Automatic episode-bound recommendation attribution | ADR-080 / RAT-A1…A7 | ✅ #927 merged + #930 test extension |
 | P1 | Hide unsupported `eval set-threshold` command | PTA-A3 | ✅ Implemented |
 | P2 | Research/product spikes (R-F1…R-F7, R-F10) | R-F* | ⏸ DEFER |
 | P2 | Transitive Dependabot advisories | G-P1-9 | Monitor / upstream |


### PR DESCRIPTION
## Summary

Pre-ship release-docs gate for **v0.1.38** (workspace already at 0.1.38, CHANGELOG entry present, drift `commit_limit` critical at 45 commits):

- `plans/ROADMAPS/ROADMAP_ACTIVE.md` + `plans/STATUS/CURRENT.md` → **Released Version: v0.1.38**
- Plan truth refresh: #927 / #928 / #930 merged, open PRs none, ADR-080 marked done, branch pointer → `fe623250`

Verified: `./scripts/verify-release-state.sh --check-unreleased` now **PASSES** (exit 0, informational warning only).

After merge: `./scripts/release-manager.sh ship --execute` → tag `v0.1.38` → `release.yml`.,