### PR TITLE
fix(docs): correct ADR-072 link target in CIT-A4/A5 plan

### DIFF
--- a/plans/GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md
+++ b/plans/GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-06
 - **Baseline**: `main` at `92db07bf` · workspace `0.1.38` · tag `v0.1.37`
 - **Decisions**: [ADR-079](adr/ADR-079-Fail-Closed-CI-Required-Check-Control-Plane.md) §6/§7 (Proposed; the workflow-side half implemented here, ruleset half still requires maintainer approval)
-- **Related**: [ADR-072](adr/ADR-072-Release-Authority.md), [ADR-078](adr/ADR-078-Trusted-Publishing-OIDC.md), `agent_docs/LESSONS.md` LESSON-014, `scripts/test-release-workflow.sh`
+- **Related**: [ADR-072](adr/ADR-072-Authority-Evidence-Enforcement-Governance.md), [ADR-078](adr/ADR-078-Trusted-Publishing-OIDC.md), `agent_docs/LESSONS.md` LESSON-014, `scripts/test-release-workflow.sh`
 - **Orchestration**: GOAP agent skill — hybrid strategy: parallel research swarm → parallel workflow implementation → sequential validation → PR
 
 ## Scope and non-scope


### PR DESCRIPTION
## Summary

- `plans/GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md` linked to `adr/ADR-072-Release-Authority.md`, which does not exist.
- ADR-072 actually lives at `adr/ADR-072-Authority-Evidence-Enforcement-Governance.md`.
- The stale target failed `scripts/check-docs-integrity.sh`, blocking the v0.1.38 ship gate (release-manager Phase 1).

## Verification

- `./scripts/check-docs-integrity.sh` → all checks passed

## Context

Found while executing the v0.1.38 release ship (issue #918). One-line fix; no code changes.