### PR TITLE
chore(release): bump workspace to 0.1.40 after shipping v0.1.39

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.1.39"
+version = "0.1.40"
 edition = "2024"
 authors = ["Self-Learning Memory Contributors"]
 license = "MIT"

--- a/memory-mcp/Cargo.toml
+++ b/memory-mcp/Cargo.toml
@@ -27,9 +27,9 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 # Local dependencies
-do-memory-core = { path = "../memory-core", version = "0.1.39", features = ["agentfs"] }
-do-memory-storage-turso = { path = "../memory-storage-turso", version = "0.1.39" }
-do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.39" }
+do-memory-core = { path = "../memory-core", version = "0.1.40", features = ["agentfs"] }
+do-memory-storage-turso = { path = "../memory-storage-turso", version = "0.1.40" }
+do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.40" }
 
 # MCP-specific dependencies
 parking_lot = "0.12.5"

--- a/memory-storage-redb/Cargo.toml
+++ b/memory-storage-redb/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/do-memory-storage-redb"
 
 [dependencies]
 # Core dependencies
-do-memory-core = { path = "../memory-core", version = "0.1.39" }
+do-memory-core = { path = "../memory-core", version = "0.1.40" }
 
 # Async runtime
 tokio = { workspace = true, features = ["full"] }

--- a/memory-storage-turso/Cargo.toml
+++ b/memory-storage-turso/Cargo.toml
@@ -34,8 +34,8 @@ compression-gzip = ["flate2"]
 
 [dependencies]
 # Core dependencies
-do-memory-core = { path = "../memory-core", version = "0.1.39", features = ["hybrid_search"] }
-do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.39" }
+do-memory-core = { path = "../memory-core", version = "0.1.40", features = ["hybrid_search"] }
+do-memory-storage-redb = { path = "../memory-storage-redb", version = "0.1.40" }
 
 # Async runtime
 tokio = { workspace = true, features = ["full"] }


### PR DESCRIPTION
Post-release AGENTS rule: advance the workspace version immediately after a tag so new feat/fix work is not flagged as `version_not_advanced` by release-drift (v0.1.39 shipped 2026-08-11).

Bumps workspace package version (0.1.39 -> 0.1.40) and inter-crate dependency pins (memory-mcp, memory-storage-redb, memory-storage-turso). Cargo.lock regenerated via cargo check. Matches the v0.1.38->0.1.39 bump pattern (3983292e).