### PR TITLE
docs(plans): re-point trackers after PR 952 merge

### DIFF
--- a/plans/ACTIONS.md
+++ b/plans/ACTIONS.md
@@ -8,8 +8,8 @@
 
 | ID | Action | Rec | Status |
 |----|--------|-----|--------|
-| ACT-362 | Implement feedback-to-ranking adaptation (ADR-082) — derived Wilson weight, capability-gated `list_recommendation_*` methods on Turso/redb, recommend re-rank, e2e tests | ADR-082 §5 exit | ✅ evidence-backed (e2e + backend contract + unit tests in this PR) |
-| ACT-363 | Canonicalize ADR-025/054 aliases (move to `plans/adr/_aliases/`) to make the ADR registry unique | G-P1-8 | ✅ `validate-plans.sh --identifiers` now sees 51 unique ADR numbers |
+| ACT-362 | Implement feedback-to-ranking adaptation (ADR-082) — derived Wilson weight, capability-gated `list_recommendation_*` methods on Turso/redb, recommend re-rank, e2e tests | ADR-082 §5 exit | ✅ merged in PR #952 (2026-08-13) — evidence-backed (e2e + backend contract + unit tests) |
+| ACT-363 | Canonicalize ADR-025/054 aliases (move to `plans/adr/_aliases/`) to make the ADR registry unique | G-P1-8 | ✅ merged in PR #952 (2026-08-13) — `validate-plans.sh --identifiers` sees 51 unique ADR numbers |
 
 ## Completed actions (2026-08-11 — #947, merged 2026-08-12)
 

--- a/plans/GOALS.md
+++ b/plans/GOALS.md
@@ -35,7 +35,7 @@
 | Remove unsupported threshold command from CLI help | PTA-A3 | P1 | ✅ Implemented |
 | Capture episode-bound recommendation attribution automatically | RAT-A1…A7 / ADR-080 | P1 | ✅ code-side closed in closure PR (#927 + #930 + episode validation + checked receipts + cold-restart tests); ADR-080 stays Proposed pending maintainer acceptance |
 | Advertise and enforce attribution persistence capability | ADR-081 §2 | P1 | ✅ `StorageBackend::supports_recommendation_attribution` + capability-gated receipts (2026-08-10) + concrete-backend capability tests (closure PR) |
-| Design idempotent feedback-to-ranking updates | ADR-082 | P2 | ✅ code-side in this PR — derived Wilson weight, capability-gated `list_recommendation_*` read surface, recommend re-rank, e2e tests (ADR-082 Proposed; lifecycle = maintainer) |
+| Design idempotent feedback-to-ranking updates | ADR-082 | P2 | ✅ merged in PR #952 (2026-08-13) — derived Wilson weight, capability-gated `list_recommendation_*` read surface, recommend re-rank, e2e tests (ADR-082 Proposed; lifecycle = maintainer) |
 | R-F10 OIDC trusted publishing (publish-crates.yml) | R-F10 | P2 | ✅ Implemented (ACT-325) |
 | R-F4 SIMD cosine acceleration + benchmark variants | R-F4 | P2 | ✅ Implemented (ACT-326) |
 | Optional research/product spikes (R-F1…R-F3, R-F5…R-F7) | R-F* | P3 | ⏸ DEFER |

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -4,8 +4,8 @@
 **Released Version**: v0.1.39 (latest tag)
 **Workspace Version**: 0.1.40 (post-v0.1.39 bump)
 **Edition**: Rust 2024  
-**Active plan**: `feat/ranking-adaptation` — feedback-to-ranking adaptation (ADR-082, Proposed) + ADR-025/054 alias canonicalization (G-P1-8)
-**Branch**: `feat/ranking-adaptation`
+**Active plan**: merged #952 (2026-08-13) — ADR-082 + ADR-025/054 canonicalization landed; no in-flight code plan; ADR-080/081/082 lifecycle acceptance remains an external-maintainer item
+**Branch**: main @ `9c8bfa79` (PR #952 merged 2026-08-13)
 
 ## Open tracker (live)
 
@@ -18,6 +18,7 @@
 
 | Wave | Result |
 |------|--------|
+| 2026-08-13 merge (#952) | ✅ squash-merged `9c8bfa79` by the controller; trackers re-pointed; ADR-082 stays `Proposed` pending maintainer acceptance |
 | Feedback-to-ranking (ADR-082, Proposed) | ✅ derived per-pattern Wilson weight; capability-gated `list_recommendation_*` (Turso+redb); recommend re-rank (overfetch→boost→truncate); tracker-authoritative merge (stale durable rows don't shadow fresh feedback); e2e `ranking_adaptation_e2e.rs` 7/7 |
 | Backend contracts | ✅ redb/turso `capability_attribution_test.rs` extended: `supports_ranking_adaptation` true + list round-trip |
 | ADR 025/054 canonicalization (G-P1-8) | ✅ aliases moved to `plans/adr/_aliases/`; `validate-plans.sh --identifiers` now 51 unique, no duplicate warning |

--- a/plans/STATUS/VALIDATION_LATEST.md
+++ b/plans/STATUS/VALIDATION_LATEST.md
@@ -23,6 +23,7 @@ on the recommend path — plus canonicalize the ADR-025/054 alias filenames
 | `cargo doc --no-deps --document-private-items` | rustdoc gate (bare-URL/re-export) | ✅ clean, exit 0 |
 | `./scripts/quality-gates.sh` | `quality_gates.rs` 16 passed / 0 failed / 2 ignored; source-file-size PASS (the two new `ranking.rs` files are 80 and 323 LOC; `storage/backend.rs` 480, turso `resilient.rs` 498 after trimming the pre-existing-at-cap files pushed over by ADR-082 surface) | ✅ PASS |
 | `./scripts/validate-plans.sh --active-set --version-state --adrs --identifiers --links` | exit 0; **no duplicate-ADR warning** (aliases now under `plans/adr/_aliases/`, outside `-maxdepth 1`); `adrs count=51`, `identifiers count=51` (52 − 2 aliases + 1 new ADR-082) | ✅ |
+| 2026-08-13 merge | PR #952 squash-merged (`9c8bfa79`) onto main by the controller; trackers re-pointed; ADR-082 stays `Proposed` pending maintainer acceptance | ✅ |
 
 ## Open after this validation
 


### PR DESCRIPTION
Docs-only: CURRENT.md active-plan/branch re-pointed to main @ 9c8bfa79 (PR #952 squash-merged 2026-08-13) + merge row added; ACTIONS.md ACT-362/363 marked merged in #952; GOALS.md row 38 marked merged; VALIDATION_LATEST 2026-08-12 section records the merge. ADR-082 stays Proposed pending maintainer acceptance.