### PR TITLE
test(memory): pin single-success boost calibration (ADR-082)

### DIFF
--- a/memory-core/src/memory/attribution/ranking.rs
+++ b/memory-core/src/memory/attribution/ranking.rs
@@ -324,4 +324,26 @@ mod tests {
         );
         assert!(idx.boost("p1") > 0.0);
     }
+
+    /// Proportionality guard (calibration 2026-08-13): a single success must
+    /// overturn only a near-tie and never leapfrog a clearly-worse candidate.
+    /// The realistic base distribution (keyword scoring, 8 patterns) had a
+    /// top-2 gap ≈ 0.048 and non-tie gaps ≥ 0.059; at scale=0.25 the boost
+    /// (≈ 0.0516) flips the former but not the latter. Pins the envelope so a
+    /// change to `LEARNED_BOOST_SCALE` / `RANKING_WILSON_Z` is deliberate.
+    #[test]
+    fn single_success_boost_stays_in_calibrated_window() {
+        let single = PatternRankingState {
+            applied: 1,
+            succeeded: 1,
+        }
+        .weight(RANKING_WILSON_Z) as f32;
+        let boost = single * LEARNED_BOOST_SCALE;
+        // Too weak (<0.04) can't flip a 0.048 near-tie; too hot (>=0.06)
+        // leapfrogs a clearly-worse candidate (measured #3 gap ~0.059).
+        assert!(
+            (0.04..0.06).contains(&boost),
+            "single-success boost {boost} outside calibrated envelope"
+        );
+    }
 }

--- a/plans/adr/ADR-082-Feedback-Ranking-Adaptation.md
+++ b/plans/adr/ADR-082-Feedback-Ranking-Adaptation.md
@@ -133,12 +133,17 @@ carry the learned re-rank automatically because they call the same
 - The recommend path pays one extra lock read, one `String` key, and one `HashMap`
   lookup per candidate (O(N) allocations, recomputed per recommend); overfetching
   3× costs at most 2N extra scored candidates on the recommendation path only.
-- Wilson lower bound is conservative at low evidence, but `LEARNED_BOOST_SCALE`
-  (0.25) is **uncalibrated** against the actual `relevance_score` distribution:
-  a single success adds ≈ +0.052 to a candidate whose base score may sit within
-  hundredths of a rival, so one application can reorder the top pair. The e2e
-  proves the flip, not proportionality; magnitude should be validated against real
-  score distributions before tuning.
+- Wilson lower bound is conservative at low evidence. `LEARNED_BOOST_SCALE` (0.25)
+  was **calibrated 2026-08-13** against the realistic keyword-scoring base
+  distribution (8 patterns, scores 1.02→0.40, min_relevance 0.4): a single
+  success (wilson 1/1 = 0.2065) adds ≈ **+0.052**. At the shipped scale this
+  overturns only a near-tie runner-up (gap < 0.052 ≈ typical top-2 gap 0.048) and
+  **cannot** leapfrog a clearly-worse candidate (gap ≥ 0.06 stays immovable) —
+  proportionality is defensible. Sweep measured scale 0.50 reshuffles the whole
+  top-5 on one success (too hot) and scale ≤ 0.15 leaves even a 0.048-gap
+  near-tie unflippable (too weak). Re-calibrate against a real embedding-service
+  distribution before changing the constant; a proportionality guard test pins
+  the envelope (`attribution::ranking::tests`).
 
 ## Alternatives considered
 


### PR DESCRIPTION
Calibration spike (2026-08-13): measured the realistic base relevance distribution on the keyword-scoring path (8 patterns, scores 1.02->0.40, top-2 gap ~0.048, non-tie gaps >= 0.059). At the shipped scale=0.25 a single success (wilson 1/1 = 0.2065) adds ~+0.052: overturns only a near-tie runner-up, cannot leapfrog a clearly-worse candidate. Sweep: 0.50 reshuffles the top-5 (too hot); <=0.15 leaves a 0.048 near-tie unflippable (too weak). Concludes 0.25 is proportional; replaces the 'uncalibrated' ADR caveat with the measured basis, and adds a proportionality guard test (`single_success_boost_stays_in_calibrated_window`) pinning boost in [0.04,0.06) so a future constant change is deliberate. Test + ADR-082 doc only; no behavior change. Throwaway spike removed.