### PR TITLE
perf(embeddings): coalesce concurrent cache misses and batch provider requests

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -115,6 +115,11 @@ name = "cosine_similarity_benchmark"
 path = "cosine_similarity_benchmark.rs"
 harness = false
 
+[[bench]]
+name = "embedding_coalescing_benchmark"
+path = "embedding_coalescing_benchmark.rs"
+harness = false
+
 # Retrieval quality benchmarks using MTEB/BEIR metrics
 [[bench]]
 name = "retrieval_quality_benchmark"

--- a/benches/embedding_coalescing_benchmark.rs
+++ b/benches/embedding_coalescing_benchmark.rs
@@ -7,9 +7,7 @@ use std::time::Duration;
 use anyhow::Result;
 use async_trait::async_trait;
 use criterion::{Criterion, criterion_group, criterion_main};
-use do_memory_core::embeddings::{
-    BatchingConfig, CoalescedEmbeddingProvider, EmbeddingProvider,
-};
+use do_memory_core::embeddings::{BatchingConfig, CoalescedEmbeddingProvider, EmbeddingProvider};
 use tokio::runtime::Runtime;
 
 struct BenchProvider {

--- a/benches/embedding_coalescing_benchmark.rs
+++ b/benches/embedding_coalescing_benchmark.rs
@@ -1,0 +1,93 @@
+//! Benchmark for coalesced embedding provider batching and request coalescing performance.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use criterion::{Criterion, criterion_group, criterion_main};
+use do_memory_core::embeddings::{
+    BatchingConfig, CoalescedEmbeddingProvider, EmbeddingProvider,
+};
+use tokio::runtime::Runtime;
+
+struct BenchProvider {
+    batch_calls: Arc<AtomicUsize>,
+    latency: Duration,
+}
+
+#[async_trait]
+impl EmbeddingProvider for BenchProvider {
+    async fn embed_text(&self, text: &str) -> Result<Vec<f32>> {
+        if self.latency > Duration::ZERO {
+            tokio::time::sleep(self.latency).await;
+        }
+        let val = text.len() as f32;
+        Ok(vec![val, val])
+    }
+
+    async fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        self.batch_calls.fetch_add(1, Ordering::SeqCst);
+        if self.latency > Duration::ZERO {
+            tokio::time::sleep(self.latency).await;
+        }
+        let mut results = Vec::new();
+        for text in texts {
+            let val = text.len() as f32;
+            results.push(vec![val, val]);
+        }
+        Ok(results)
+    }
+
+    fn embedding_dimension(&self) -> usize {
+        2
+    }
+
+    fn model_name(&self) -> &'static str {
+        "bench-model"
+    }
+}
+
+fn bench_coalescing(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+
+    c.bench_function("concurrent_coalesced_embeddings", |b| {
+        b.to_async(&rt).iter(|| async {
+            let batch_calls = Arc::new(AtomicUsize::new(0));
+            let inner = BenchProvider {
+                batch_calls: batch_calls.clone(),
+                latency: Duration::from_millis(5),
+            };
+            let config = BatchingConfig {
+                enabled: true,
+                max_batch_size: 64,
+                max_wait_ms: 5,
+                max_in_flight: 8,
+                coalesce_in_flight: true,
+            };
+            let provider = Arc::new(CoalescedEmbeddingProvider::new(
+                Arc::new(inner),
+                config,
+                true,
+            ));
+
+            let mut handles = Vec::new();
+            // 20 concurrent requests with 5 unique texts
+            for i in 0..20 {
+                let p = provider.clone();
+                let text = format!("query_{}", i % 5);
+                handles.push(tokio::spawn(async move {
+                    let _ = p.embed_text(&text).await;
+                }));
+            }
+
+            for h in handles {
+                let _ = h.await;
+            }
+        });
+    });
+}
+
+criterion_group!(benches, bench_coalescing);
+criterion_main!(benches);

--- a/memory-core/examples/embedding_config_refactor.rs
+++ b/memory-core/examples/embedding_config_refactor.rs
@@ -218,6 +218,7 @@ fn main() {
         cache_embeddings: true,
         batch_size: 100,
         timeout_seconds: 30,
+        batch: Default::default(),
     };
 
     println!("Complete EmbeddingConfig:");

--- a/memory-core/src/embeddings/coalescing.rs
+++ b/memory-core/src/embeddings/coalescing.rs
@@ -61,8 +61,8 @@ impl CoalescedEmbeddingProvider {
         config: BatchingConfig,
         cache_enabled: bool,
     ) -> Self {
-        let cache_capacity = NonZeroUsize::new(DEFAULT_CACHE_CAPACITY)
-            .expect("DEFAULT_CACHE_CAPACITY is non-zero");
+        let cache_capacity =
+            NonZeroUsize::new(DEFAULT_CACHE_CAPACITY).expect("DEFAULT_CACHE_CAPACITY is non-zero");
         let cache = Arc::new(Mutex::new(LruCache::new(cache_capacity)));
         let in_flight = Arc::new(Mutex::new(HashMap::new()));
 
@@ -273,7 +273,9 @@ impl EmbeddingProvider for CoalescedEmbeddingProvider {
         if is_first {
             struct SendGuard<'a> {
                 key: &'a str,
-                map: &'a Arc<Mutex<HashMap<String, watch::Sender<Option<Result<Vec<f32>, String>>>>>>,
+                map: &'a Arc<
+                    Mutex<HashMap<String, watch::Sender<Option<Result<Vec<f32>, String>>>>>,
+                >,
                 sent: bool,
             }
 

--- a/memory-core/src/embeddings/coalescing.rs
+++ b/memory-core/src/embeddings/coalescing.rs
@@ -1,0 +1,367 @@
+//! In-flight embedding request coalescing, batching, and atomic caching.
+
+use std::collections::{HashMap, HashSet};
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use lru::LruCache;
+use parking_lot::Mutex;
+use tokio::sync::{Semaphore, mpsc, watch};
+
+use super::config::BatchingConfig;
+use super::provider::{EmbeddingHealth, EmbeddingProvider};
+
+const DEFAULT_CACHE_CAPACITY: usize = 10000;
+
+#[derive(Debug)]
+struct BatchItem {
+    in_flight_key: String,
+    cache_key: String,
+    text: String,
+}
+
+struct InFlightGuard {
+    keys: Vec<String>,
+    in_flight: Arc<Mutex<HashMap<String, watch::Sender<Option<Result<Vec<f32>, String>>>>>>,
+    completed: bool,
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        if !self.completed {
+            let mut map = self.in_flight.lock();
+            for key in &self.keys {
+                if let Some(tx) = map.remove(key) {
+                    let _ = tx.send(Some(Err("Batch execution failed unexpectedly".to_string())));
+                }
+            }
+        }
+    }
+}
+
+/// Embedding provider wrapper that coalesces concurrent requests,
+/// batches requests within time/size bounds, and atomically caches results.
+pub struct CoalescedEmbeddingProvider {
+    inner: Arc<dyn EmbeddingProvider>,
+    config: BatchingConfig,
+    cache_enabled: bool,
+    cache: Arc<Mutex<LruCache<String, Vec<f32>>>>,
+    in_flight: Arc<Mutex<HashMap<String, watch::Sender<Option<Result<Vec<f32>, String>>>>>>,
+    batch_tx: mpsc::Sender<BatchItem>,
+}
+
+impl CoalescedEmbeddingProvider {
+    /// Create a new coalesced embedding provider wrapping an inner provider.
+    #[must_use]
+    pub fn new(
+        inner: Arc<dyn EmbeddingProvider>,
+        config: BatchingConfig,
+        cache_enabled: bool,
+    ) -> Self {
+        let cache_capacity = NonZeroUsize::new(DEFAULT_CACHE_CAPACITY)
+            .expect("DEFAULT_CACHE_CAPACITY is non-zero");
+        let cache = Arc::new(Mutex::new(LruCache::new(cache_capacity)));
+        let in_flight = Arc::new(Mutex::new(HashMap::new()));
+
+        let (batch_tx, batch_rx) = mpsc::channel(config.max_batch_size.max(1) * 16);
+
+        if config.enabled {
+            let inner_clone = inner.clone();
+            let cache_clone = cache.clone();
+            let in_flight_clone = in_flight.clone();
+            let config_clone = config.clone();
+            let cache_enabled_flag = cache_enabled;
+
+            tokio::spawn(async move {
+                Self::run_batch_worker(
+                    inner_clone,
+                    cache_clone,
+                    in_flight_clone,
+                    config_clone,
+                    cache_enabled_flag,
+                    batch_rx,
+                )
+                .await;
+            });
+        }
+
+        Self {
+            inner,
+            config,
+            cache_enabled,
+            cache,
+            in_flight,
+            batch_tx,
+        }
+    }
+
+    fn cache_key(&self, text: &str) -> String {
+        format!("{}:{}", self.inner.model_name(), text.trim())
+    }
+
+    async fn run_batch_worker(
+        inner: Arc<dyn EmbeddingProvider>,
+        cache: Arc<Mutex<LruCache<String, Vec<f32>>>>,
+        in_flight: Arc<Mutex<HashMap<String, watch::Sender<Option<Result<Vec<f32>, String>>>>>>,
+        config: BatchingConfig,
+        cache_enabled: bool,
+        mut rx: mpsc::Receiver<BatchItem>,
+    ) {
+        let semaphore = Arc::new(Semaphore::new(config.max_in_flight.max(1)));
+        let max_batch_size = config.max_batch_size.max(1);
+        let max_wait = Duration::from_millis(config.max_wait_ms);
+
+        while let Some(first) = rx.recv().await {
+            let mut batch = vec![first];
+            let deadline = tokio::time::Instant::now() + max_wait;
+
+            while batch.len() < max_batch_size {
+                let now = tokio::time::Instant::now();
+                if now >= deadline {
+                    break;
+                }
+                let timeout = deadline - now;
+                match tokio::time::timeout(timeout, rx.recv()).await {
+                    Ok(Some(item)) => {
+                        batch.push(item);
+                    }
+                    Ok(None) => break,
+                    Err(_) => break,
+                }
+            }
+
+            let permit = match semaphore.clone().acquire_owned().await {
+                Ok(permit) => permit,
+                Err(_) => break,
+            };
+
+            let inner = inner.clone();
+            let cache = cache.clone();
+            let in_flight = in_flight.clone();
+
+            tokio::spawn(async move {
+                let _permit = permit;
+                Self::execute_batch(inner, cache, in_flight, batch, cache_enabled).await;
+            });
+        }
+    }
+
+    async fn execute_batch(
+        inner: Arc<dyn EmbeddingProvider>,
+        cache: Arc<Mutex<LruCache<String, Vec<f32>>>>,
+        in_flight: Arc<Mutex<HashMap<String, watch::Sender<Option<Result<Vec<f32>, String>>>>>>,
+        batch: Vec<BatchItem>,
+        cache_enabled: bool,
+    ) {
+        let mut unique_texts = Vec::new();
+        let mut unique_keys = Vec::new();
+        let mut seen = HashSet::new();
+
+        for item in &batch {
+            if seen.insert(item.in_flight_key.clone()) {
+                unique_keys.push(item.in_flight_key.clone());
+                unique_texts.push(item.text.clone());
+            }
+        }
+
+        let mut cache_keys = Vec::new();
+        let mut seen_cache = HashSet::new();
+
+        for item in &batch {
+            if seen_cache.insert(item.cache_key.clone()) {
+                cache_keys.push(item.cache_key.clone());
+            }
+        }
+
+        let mut guard = InFlightGuard {
+            keys: unique_keys.clone(),
+            in_flight: in_flight.clone(),
+            completed: false,
+        };
+
+        let result = inner.embed_batch(&unique_texts).await;
+
+        match result {
+            Ok(embeddings) => {
+                if embeddings.len() == unique_keys.len() {
+                    if cache_enabled {
+                        let mut c = cache.lock();
+                        for (key, vec) in cache_keys.iter().zip(embeddings.iter()) {
+                            c.put(key.clone(), vec.clone());
+                        }
+                    }
+
+                    let mut map = in_flight.lock();
+                    for (key, vec) in unique_keys.into_iter().zip(embeddings) {
+                        if let Some(tx) = map.remove(&key) {
+                            let _ = tx.send(Some(Ok(vec)));
+                        }
+                    }
+                } else {
+                    let err_msg = format!(
+                        "Provider embed_batch returned {} embeddings for {} texts",
+                        embeddings.len(),
+                        unique_keys.len()
+                    );
+                    let mut map = in_flight.lock();
+                    for key in unique_keys {
+                        if let Some(tx) = map.remove(&key) {
+                            let _ = tx.send(Some(Err(err_msg.clone())));
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                let err_msg = err.to_string();
+                let mut map = in_flight.lock();
+                for key in unique_keys {
+                    if let Some(tx) = map.remove(&key) {
+                        let _ = tx.send(Some(Err(err_msg.clone())));
+                    }
+                }
+            }
+        }
+
+        guard.completed = true;
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for CoalescedEmbeddingProvider {
+    async fn embed_text(&self, text: &str) -> Result<Vec<f32>> {
+        if !self.config.enabled {
+            if self.cache_enabled {
+                let key = self.cache_key(text);
+                if let Some(vec) = self.cache.lock().get(&key) {
+                    return Ok(vec.clone());
+                }
+                let vec = self.inner.embed_text(text).await?;
+                self.cache.lock().put(key, vec.clone());
+                return Ok(vec);
+            }
+            return self.inner.embed_text(text).await;
+        }
+
+        let cache_key = self.cache_key(text);
+
+        if self.cache_enabled {
+            if let Some(vec) = self.cache.lock().get(&cache_key) {
+                return Ok(vec.clone());
+            }
+        }
+
+        let in_flight_key = if self.config.coalesce_in_flight {
+            cache_key.clone()
+        } else {
+            format!("{}:{}", cache_key, uuid::Uuid::new_v4())
+        };
+
+        let (mut rx, is_first) = {
+            let mut map = self.in_flight.lock();
+            if let Some(tx) = map.get(&in_flight_key) {
+                (tx.subscribe(), false)
+            } else {
+                let (tx, rx) = watch::channel(None);
+                map.insert(in_flight_key.clone(), tx);
+                (rx, true)
+            }
+        };
+
+        if is_first {
+            struct SendGuard<'a> {
+                key: &'a str,
+                map: &'a Arc<Mutex<HashMap<String, watch::Sender<Option<Result<Vec<f32>, String>>>>>>,
+                sent: bool,
+            }
+
+            impl<'a> Drop for SendGuard<'a> {
+                fn drop(&mut self) {
+                    if !self.sent {
+                        self.map.lock().remove(self.key);
+                    }
+                }
+            }
+
+            let mut send_guard = SendGuard {
+                key: &in_flight_key,
+                map: &self.in_flight,
+                sent: false,
+            };
+
+            let send_res = self
+                .batch_tx
+                .send(BatchItem {
+                    in_flight_key: in_flight_key.clone(),
+                    cache_key: cache_key.clone(),
+                    text: text.to_string(),
+                })
+                .await;
+
+            if send_res.is_err() {
+                anyhow::bail!("Embedding batch worker channel closed");
+            }
+            send_guard.sent = true;
+        }
+
+        if let Some(res) = rx.borrow().clone() {
+            return res.map_err(|e| anyhow::anyhow!(e));
+        }
+
+        if rx.changed().await.is_err() {
+            return Err(anyhow::anyhow!("In-flight request cancelled"));
+        }
+
+        match rx.borrow().clone() {
+            Some(res) => res.map_err(|e| anyhow::anyhow!(e)),
+            None => Err(anyhow::anyhow!("In-flight request closed without result")),
+        }
+    }
+
+    async fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        if !self.config.enabled {
+            return self.inner.embed_batch(texts).await;
+        }
+
+        let futures: Vec<_> = texts.iter().map(|t| self.embed_text(t)).collect();
+        futures::future::try_join_all(futures).await
+    }
+
+    fn embedding_dimension(&self) -> usize {
+        self.inner.embedding_dimension()
+    }
+
+    fn model_name(&self) -> &str {
+        self.inner.model_name()
+    }
+
+    async fn is_available(&self) -> bool {
+        self.inner.is_available().await
+    }
+
+    async fn health(&self) -> EmbeddingHealth {
+        self.inner.health().await
+    }
+
+    async fn warmup(&self) -> Result<()> {
+        self.inner.warmup().await
+    }
+
+    fn metadata(&self) -> serde_json::Value {
+        let mut meta = self.inner.metadata();
+        if let serde_json::Value::Object(ref mut obj) = meta {
+            obj.insert("coalesced".to_string(), serde_json::json!(true));
+            obj.insert(
+                "batch_config".to_string(),
+                serde_json::to_value(&self.config).unwrap_or_default(),
+            );
+        }
+        meta
+    }
+}

--- a/memory-core/src/embeddings/coalescing.rs
+++ b/memory-core/src/embeddings/coalescing.rs
@@ -133,9 +133,8 @@ impl CoalescedEmbeddingProvider {
                 }
             }
 
-            let permit = match semaphore.clone().acquire_owned().await {
-                Ok(permit) => permit,
-                Err(_) => break,
+            let Ok(permit) = semaphore.clone().acquire_owned().await else {
+                break;
             };
 
             let inner = inner.clone();
@@ -184,39 +183,44 @@ impl CoalescedEmbeddingProvider {
 
         let result = inner.embed_batch(&unique_texts).await;
 
+        let result_to_fanout = match result {
+            Ok(embeddings) if embeddings.len() == unique_keys.len() => {
+                if cache_enabled {
+                    let mut c = cache.lock();
+                    for (key, vec) in cache_keys.iter().zip(embeddings.iter()) {
+                        c.put(key.clone(), vec.clone());
+                    }
+                }
+                Ok(embeddings)
+            }
+            Ok(embeddings) => Err(format!(
+                "Provider embed_batch returned {} embeddings for {} texts",
+                embeddings.len(),
+                unique_keys.len()
+            )),
+            Err(err) => Err(err.to_string()),
+        };
+
+        Self::fanout_batch_result(in_flight, unique_keys, result_to_fanout);
+
+        guard.completed = true;
+    }
+
+    fn fanout_batch_result(
+        in_flight: Arc<Mutex<HashMap<String, watch::Sender<Option<Result<Vec<f32>, String>>>>>>,
+        unique_keys: Vec<String>,
+        result: Result<Vec<Vec<f32>>, String>,
+    ) {
+        let mut map = in_flight.lock();
         match result {
             Ok(embeddings) => {
-                if embeddings.len() == unique_keys.len() {
-                    if cache_enabled {
-                        let mut c = cache.lock();
-                        for (key, vec) in cache_keys.iter().zip(embeddings.iter()) {
-                            c.put(key.clone(), vec.clone());
-                        }
-                    }
-
-                    let mut map = in_flight.lock();
-                    for (key, vec) in unique_keys.into_iter().zip(embeddings) {
-                        if let Some(tx) = map.remove(&key) {
-                            let _ = tx.send(Some(Ok(vec)));
-                        }
-                    }
-                } else {
-                    let err_msg = format!(
-                        "Provider embed_batch returned {} embeddings for {} texts",
-                        embeddings.len(),
-                        unique_keys.len()
-                    );
-                    let mut map = in_flight.lock();
-                    for key in unique_keys {
-                        if let Some(tx) = map.remove(&key) {
-                            let _ = tx.send(Some(Err(err_msg.clone())));
-                        }
+                for (key, vec) in unique_keys.into_iter().zip(embeddings) {
+                    if let Some(tx) = map.remove(&key) {
+                        let _ = tx.send(Some(Ok(vec)));
                     }
                 }
             }
-            Err(err) => {
-                let err_msg = err.to_string();
-                let mut map = in_flight.lock();
+            Err(err_msg) => {
                 for key in unique_keys {
                     if let Some(tx) = map.remove(&key) {
                         let _ = tx.send(Some(Err(err_msg.clone())));
@@ -224,8 +228,6 @@ impl CoalescedEmbeddingProvider {
                 }
             }
         }
-
-        guard.completed = true;
     }
 }
 
@@ -279,7 +281,7 @@ impl EmbeddingProvider for CoalescedEmbeddingProvider {
                 sent: bool,
             }
 
-            impl<'a> Drop for SendGuard<'a> {
+            impl Drop for SendGuard<'_> {
                 fn drop(&mut self) {
                     if !self.sent {
                         self.map.lock().remove(self.key);

--- a/memory-core/src/embeddings/coalescing_tests.rs
+++ b/memory-core/src/embeddings/coalescing_tests.rs
@@ -78,8 +78,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_request_coalescing_and_batching() {
-        let (inner, _call_cnt, batch_cnt) =
-            TrackingProvider::new(Duration::from_millis(50), false);
+        let (inner, _call_cnt, batch_cnt) = TrackingProvider::new(Duration::from_millis(50), false);
         let config = BatchingConfig {
             enabled: true,
             max_batch_size: 10,
@@ -117,8 +116,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_hits_bypass_provider() {
-        let (inner, _call_cnt, batch_cnt) =
-            TrackingProvider::new(Duration::from_millis(10), false);
+        let (inner, _call_cnt, batch_cnt) = TrackingProvider::new(Duration::from_millis(10), false);
         let config = BatchingConfig {
             enabled: true,
             max_batch_size: 10,
@@ -146,8 +144,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_error_fanout_no_cache_poisoning() {
-        let (inner, _call_cnt, batch_cnt) =
-            TrackingProvider::new(Duration::from_millis(10), true);
+        let (inner, _call_cnt, batch_cnt) = TrackingProvider::new(Duration::from_millis(10), true);
         let config = BatchingConfig {
             enabled: true,
             max_batch_size: 10,
@@ -194,8 +191,8 @@ mod tests {
         let p2 = provider.clone();
 
         let h1 = tokio::spawn(async move {
-            let _ = tokio::time::timeout(Duration::from_millis(30), p1.embed_text("slow_text"))
-                .await;
+            let _ =
+                tokio::time::timeout(Duration::from_millis(30), p1.embed_text("slow_text")).await;
         });
 
         let h2 = tokio::spawn(async move { p2.embed_text("slow_text").await });

--- a/memory-core/src/embeddings/coalescing_tests.rs
+++ b/memory-core/src/embeddings/coalescing_tests.rs
@@ -1,0 +1,209 @@
+//! Tests for coalesced embedding provider
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use anyhow::Result;
+    use async_trait::async_trait;
+
+    use crate::embeddings::coalescing::CoalescedEmbeddingProvider;
+    use crate::embeddings::config::BatchingConfig;
+    use crate::embeddings::provider::EmbeddingProvider;
+
+    struct TrackingProvider {
+        call_count: Arc<AtomicUsize>,
+        batch_call_count: Arc<AtomicUsize>,
+        delay: Duration,
+        should_fail: bool,
+    }
+
+    impl TrackingProvider {
+        fn new(delay: Duration, should_fail: bool) -> (Self, Arc<AtomicUsize>, Arc<AtomicUsize>) {
+            let call_count = Arc::new(AtomicUsize::new(0));
+            let batch_call_count = Arc::new(AtomicUsize::new(0));
+            (
+                Self {
+                    call_count: call_count.clone(),
+                    batch_call_count: batch_call_count.clone(),
+                    delay,
+                    should_fail,
+                },
+                call_count,
+                batch_call_count,
+            )
+        }
+    }
+
+    #[async_trait]
+    impl EmbeddingProvider for TrackingProvider {
+        async fn embed_text(&self, text: &str) -> Result<Vec<f32>> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            if self.delay > Duration::ZERO {
+                tokio::time::sleep(self.delay).await;
+            }
+            if self.should_fail {
+                anyhow::bail!("Provider simulated error");
+            }
+            let val = text.len() as f32;
+            Ok(vec![val, val])
+        }
+
+        async fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+            self.batch_call_count.fetch_add(1, Ordering::SeqCst);
+            if self.delay > Duration::ZERO {
+                tokio::time::sleep(self.delay).await;
+            }
+            if self.should_fail {
+                anyhow::bail!("Provider simulated batch error");
+            }
+            let mut results = Vec::new();
+            for text in texts {
+                let val = text.len() as f32;
+                results.push(vec![val, val]);
+            }
+            Ok(results)
+        }
+
+        fn embedding_dimension(&self) -> usize {
+            2
+        }
+
+        fn model_name(&self) -> &'static str {
+            "tracking-model"
+        }
+    }
+
+    #[tokio::test]
+    async fn test_request_coalescing_and_batching() {
+        let (inner, _call_cnt, batch_cnt) =
+            TrackingProvider::new(Duration::from_millis(50), false);
+        let config = BatchingConfig {
+            enabled: true,
+            max_batch_size: 10,
+            max_wait_ms: 20,
+            max_in_flight: 4,
+            coalesce_in_flight: true,
+        };
+
+        let provider = Arc::new(CoalescedEmbeddingProvider::new(
+            Arc::new(inner),
+            config,
+            true,
+        ));
+
+        // 5 concurrent identical requests, 5 distinct requests
+        let mut handles = Vec::new();
+        for _ in 0..5 {
+            let p = provider.clone();
+            handles.push(tokio::spawn(async move { p.embed_text("same_text").await }));
+        }
+        for i in 0..5 {
+            let p = provider.clone();
+            let text = format!("text_{i}");
+            handles.push(tokio::spawn(async move { p.embed_text(&text).await }));
+        }
+
+        let results = futures::future::join_all(handles).await;
+        for res in results {
+            assert!(res.unwrap().is_ok());
+        }
+
+        // Only 1 batch call should have happened for all requests
+        assert_eq!(batch_cnt.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_cache_hits_bypass_provider() {
+        let (inner, _call_cnt, batch_cnt) =
+            TrackingProvider::new(Duration::from_millis(10), false);
+        let config = BatchingConfig {
+            enabled: true,
+            max_batch_size: 10,
+            max_wait_ms: 10,
+            max_in_flight: 4,
+            coalesce_in_flight: true,
+        };
+
+        let provider = Arc::new(CoalescedEmbeddingProvider::new(
+            Arc::new(inner),
+            config,
+            true,
+        ));
+
+        // Initial request
+        let res1 = provider.embed_text("cached_query").await;
+        assert!(res1.is_ok());
+        assert_eq!(batch_cnt.load(Ordering::SeqCst), 1);
+
+        // Subsequent identical request should hit cache
+        let res2 = provider.embed_text("cached_query").await;
+        assert!(res2.is_ok());
+        assert_eq!(batch_cnt.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_error_fanout_no_cache_poisoning() {
+        let (inner, _call_cnt, batch_cnt) =
+            TrackingProvider::new(Duration::from_millis(10), true);
+        let config = BatchingConfig {
+            enabled: true,
+            max_batch_size: 10,
+            max_wait_ms: 10,
+            max_in_flight: 4,
+            coalesce_in_flight: true,
+        };
+
+        let provider = Arc::new(CoalescedEmbeddingProvider::new(
+            Arc::new(inner),
+            config,
+            true,
+        ));
+
+        let res1 = provider.embed_text("error_query").await;
+        assert!(res1.is_err());
+        assert_eq!(batch_cnt.load(Ordering::SeqCst), 1);
+
+        // Next request should try again and not return cached error
+        let res2 = provider.embed_text("error_query").await;
+        assert!(res2.is_err());
+        assert_eq!(batch_cnt.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn test_cancellation_safety() {
+        let (inner, _call_cnt, batch_cnt) =
+            TrackingProvider::new(Duration::from_millis(100), false);
+        let config = BatchingConfig {
+            enabled: true,
+            max_batch_size: 10,
+            max_wait_ms: 20,
+            max_in_flight: 4,
+            coalesce_in_flight: true,
+        };
+
+        let provider = Arc::new(CoalescedEmbeddingProvider::new(
+            Arc::new(inner),
+            config,
+            true,
+        ));
+
+        let p1 = provider.clone();
+        let p2 = provider.clone();
+
+        let h1 = tokio::spawn(async move {
+            let _ = tokio::time::timeout(Duration::from_millis(30), p1.embed_text("slow_text"))
+                .await;
+        });
+
+        let h2 = tokio::spawn(async move { p2.embed_text("slow_text").await });
+
+        h1.await.unwrap();
+        let res2 = h2.await.unwrap();
+
+        assert!(res2.is_ok());
+        assert_eq!(batch_cnt.load(Ordering::SeqCst), 1);
+    }
+}

--- a/memory-core/src/embeddings/config/batching_config.rs
+++ b/memory-core/src/embeddings/config/batching_config.rs
@@ -1,0 +1,87 @@
+//! Configuration for embedding request batching and coalescing
+
+use serde::{Deserialize, Serialize};
+
+/// Configuration for embedding request batching and coalescing
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BatchingConfig {
+    /// Enable batching and coalescing of concurrent embedding requests
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    /// Maximum batch size for provider requests
+    #[serde(default = "default_max_batch_size")]
+    pub max_batch_size: usize,
+    /// Maximum time in milliseconds to wait before flushing a partial batch
+    #[serde(default = "default_max_wait_ms")]
+    pub max_wait_ms: u64,
+    /// Maximum number of concurrent in-flight requests sent to the provider
+    #[serde(default = "default_max_in_flight")]
+    pub max_in_flight: usize,
+    /// Enable coalescing identical in-flight embedding requests
+    #[serde(default = "default_coalesce_in_flight")]
+    pub coalesce_in_flight: bool,
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+fn default_max_batch_size() -> usize {
+    64
+}
+
+fn default_max_wait_ms() -> u64 {
+    10
+}
+
+fn default_max_in_flight() -> usize {
+    8
+}
+
+fn default_coalesce_in_flight() -> bool {
+    true
+}
+
+impl Default for BatchingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_enabled(),
+            max_batch_size: default_max_batch_size(),
+            max_wait_ms: default_max_wait_ms(),
+            max_in_flight: default_max_in_flight(),
+            coalesce_in_flight: default_coalesce_in_flight(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_batching_config_defaults() {
+        let config = BatchingConfig::default();
+        assert!(config.enabled);
+        assert_eq!(config.max_batch_size, 64);
+        assert_eq!(config.max_wait_ms, 10);
+        assert_eq!(config.max_in_flight, 8);
+        assert!(config.coalesce_in_flight);
+    }
+
+    #[test]
+    fn test_batching_config_serde() {
+        let json_str = r#"{
+            "enabled": true,
+            "max_batch_size": 128,
+            "max_wait_ms": 20,
+            "max_in_flight": 16,
+            "coalesce_in_flight": false
+        }"#;
+        let config: BatchingConfig = serde_json::from_str(json_str).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.max_batch_size, 128);
+        assert_eq!(config.max_wait_ms, 20);
+        assert_eq!(config.max_in_flight, 16);
+        assert!(!config.coalesce_in_flight);
+    }
+}

--- a/memory-core/src/embeddings/config/embedding_config.rs
+++ b/memory-core/src/embeddings/config/embedding_config.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use super::batching_config::BatchingConfig;
 use super::provider_config::ProviderConfig;
 
 /// Configuration for the embedding system
@@ -17,6 +18,9 @@ pub struct EmbeddingConfig {
     pub cache_embeddings: bool,
     /// Timeout for embedding requests (seconds)
     pub timeout_seconds: u64,
+    /// Configuration for request batching and coalescing
+    #[serde(default)]
+    pub batch: BatchingConfig,
 }
 
 impl Default for EmbeddingConfig {
@@ -27,6 +31,7 @@ impl Default for EmbeddingConfig {
             batch_size: 32,
             cache_embeddings: true,
             timeout_seconds: 30,
+            batch: BatchingConfig::default(),
         }
     }
 }
@@ -68,6 +73,7 @@ mod tests {
             batch_size: 64,
             cache_embeddings: false,
             timeout_seconds: 60,
+            batch: BatchingConfig::default(),
         };
 
         assert_eq!(config.similarity_threshold, 0.8);

--- a/memory-core/src/embeddings/config/mod.rs
+++ b/memory-core/src/embeddings/config/mod.rs
@@ -11,8 +11,11 @@ pub use provider_enum::EmbeddingProvider;
 // Optimization config (unchanged)
 pub use optimization_config::OptimizationConfig;
 
+pub use batching_config::BatchingConfig;
 // Top-level embedding config
 pub use embedding_config::EmbeddingConfig;
+
+mod batching_config;
 
 // Provider-specific modules
 pub mod mistral;

--- a/memory-core/src/embeddings/mod.rs
+++ b/memory-core/src/embeddings/mod.rs
@@ -39,6 +39,7 @@
 
 pub mod activation;
 mod circuit_breaker;
+pub mod coalescing;
 pub mod config;
 mod hnsw;
 mod index;
@@ -60,13 +61,14 @@ mod utils;
 
 pub use activation::EmbeddingActivation;
 pub use circuit_breaker::{CircuitBreaker, CircuitBreakerConfig, CircuitBreakerState};
+pub use coalescing::CoalescedEmbeddingProvider;
 #[cfg(feature = "hnsw")]
 pub use hnsw::HnswVectorIndex;
 pub use index::{SimpleVectorIndex, VectorHit, VectorIndex};
 // New configuration types
 pub use config::{
-    AzureOpenAIConfig, CustomConfig, EmbeddingConfig, LocalConfig, MistralConfig, OpenAIConfig,
-    OptimizationConfig, ProviderConfig,
+    AzureOpenAIConfig, BatchingConfig, CustomConfig, EmbeddingConfig, LocalConfig, MistralConfig,
+    OpenAIConfig, OptimizationConfig, ProviderConfig,
 };
 pub use local::{
     LocalEmbeddingProvider, LocalModelUseCase, get_recommended_model, list_available_models,
@@ -87,5 +89,7 @@ pub use storage::{EmbeddingStorage, EmbeddingStorageBackend, InMemoryEmbeddingSt
 
 #[cfg(all(test, feature = "mistral"))]
 mod mistral_tests;
+#[cfg(test)]
+mod coalescing_tests;
 #[cfg(test)]
 pub mod tests;

--- a/memory-core/src/embeddings/mod.rs
+++ b/memory-core/src/embeddings/mod.rs
@@ -87,9 +87,9 @@ pub use similarity::{
 };
 pub use storage::{EmbeddingStorage, EmbeddingStorageBackend, InMemoryEmbeddingStorage};
 
-#[cfg(all(test, feature = "mistral"))]
-mod mistral_tests;
 #[cfg(test)]
 mod coalescing_tests;
+#[cfg(all(test, feature = "mistral"))]
+mod mistral_tests;
 #[cfg(test)]
 pub mod tests;

--- a/memory-core/src/embeddings/semantic_service.rs
+++ b/memory-core/src/embeddings/semantic_service.rs
@@ -39,16 +39,16 @@ impl SemanticService {
         storage: Box<dyn EmbeddingStorageBackend>,
         config: EmbeddingConfig,
     ) -> Self {
-        let wrapped_provider: Box<dyn super::provider::EmbeddingProvider> =
-            if config.batch.enabled {
-                Box::new(super::coalescing::CoalescedEmbeddingProvider::new(
-                    std::sync::Arc::from(provider),
-                    config.batch.clone(),
-                    config.cache_embeddings,
-                ))
-            } else {
-                provider
-            };
+        let wrapped_provider: Box<dyn super::provider::EmbeddingProvider> = if config.batch.enabled
+        {
+            Box::new(super::coalescing::CoalescedEmbeddingProvider::new(
+                std::sync::Arc::from(provider),
+                config.batch.clone(),
+                config.cache_embeddings,
+            ))
+        } else {
+            provider
+        };
 
         Self {
             provider: wrapped_provider,

--- a/memory-core/src/embeddings/semantic_service.rs
+++ b/memory-core/src/embeddings/semantic_service.rs
@@ -39,8 +39,19 @@ impl SemanticService {
         storage: Box<dyn EmbeddingStorageBackend>,
         config: EmbeddingConfig,
     ) -> Self {
+        let wrapped_provider: Box<dyn super::provider::EmbeddingProvider> =
+            if config.batch.enabled {
+                Box::new(super::coalescing::CoalescedEmbeddingProvider::new(
+                    std::sync::Arc::from(provider),
+                    config.batch.clone(),
+                    config.cache_embeddings,
+                ))
+            } else {
+                provider
+            };
+
         Self {
-            provider,
+            provider: wrapped_provider,
             storage,
             config,
         }

--- a/memory-core/src/memory/tests/semantic_tests.rs
+++ b/memory-core/src/memory/tests/semantic_tests.rs
@@ -30,6 +30,7 @@ pub async fn test_with_semantic_config() {
         batch_size: 16,
         cache_embeddings: false,
         timeout_seconds: 60,
+        ..Default::default()
     };
 
     let memory = SelfLearningMemory::with_semantic_config(

--- a/memory-mcp/src/mcp/tools/embeddings/tool/execute/configure.rs
+++ b/memory-mcp/src/mcp/tools/embeddings/tool/execute/configure.rs
@@ -51,6 +51,7 @@ impl EmbeddingTools {
             batch_size: input.batch_size.unwrap_or(32),
             cache_embeddings: true,
             timeout_seconds: 30,
+            ..Default::default()
         };
 
         let service = match SemanticService::build_exact(

--- a/tests/load/embedding_coalescing_load_test.rs
+++ b/tests/load/embedding_coalescing_load_test.rs
@@ -1,0 +1,110 @@
+//! Load test for embedding request batching, coalescing, cancellation, and backpressure.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use do_memory_core::embeddings::{
+    BatchingConfig, CoalescedEmbeddingProvider, EmbeddingProvider,
+};
+
+struct SlowProvider {
+    batch_calls: Arc<AtomicUsize>,
+    total_embedded: Arc<AtomicUsize>,
+    latency: Duration,
+}
+
+#[async_trait]
+impl EmbeddingProvider for SlowProvider {
+    async fn embed_text(&self, text: &str) -> Result<Vec<f32>> {
+        tokio::time::sleep(self.latency).await;
+        self.total_embedded.fetch_add(1, Ordering::SeqCst);
+        let val = text.len() as f32;
+        Ok(vec![val, val])
+    }
+
+    async fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        self.batch_calls.fetch_add(1, Ordering::SeqCst);
+        tokio::time::sleep(self.latency).await;
+        self.total_embedded.fetch_add(texts.len(), Ordering::SeqCst);
+        let mut results = Vec::new();
+        for text in texts {
+            let val = text.len() as f32;
+            results.push(vec![val, val]);
+        }
+        Ok(results)
+    }
+
+    fn embedding_dimension(&self) -> usize {
+        2
+    }
+
+    fn model_name(&self) -> &'static str {
+        "slow-load-model"
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_coalescing_load_under_concurrency_and_cancellation() {
+    let batch_calls = Arc::new(AtomicUsize::new(0));
+    let total_embedded = Arc::new(AtomicUsize::new(0));
+
+    let inner = SlowProvider {
+        batch_calls: batch_calls.clone(),
+        total_embedded: total_embedded.clone(),
+        latency: Duration::from_millis(50),
+    };
+
+    let config = BatchingConfig {
+        enabled: true,
+        max_batch_size: 32,
+        max_wait_ms: 10,
+        max_in_flight: 4,
+        coalesce_in_flight: true,
+    };
+
+    let provider = Arc::new(CoalescedEmbeddingProvider::new(
+        Arc::new(inner),
+        config,
+        true,
+    ));
+
+    let mut handles = Vec::new();
+    let num_tasks = 100;
+    let start = Instant::now();
+
+    for i in 0..num_tasks {
+        let p = provider.clone();
+        // 5 unique prompts repeated 20 times each
+        let text = format!("prompt_{}", i % 5);
+
+        handles.push(tokio::spawn(async move {
+            if i % 10 == 0 {
+                // Simulate caller cancellation / timeout
+                let _ = tokio::time::timeout(Duration::from_millis(20), p.embed_text(&text)).await;
+            } else {
+                let res = p.embed_text(&text).await;
+                assert!(res.is_ok());
+            }
+        }));
+    }
+
+    for h in handles {
+        let _ = h.await;
+    }
+
+    let elapsed = start.elapsed();
+    println!(
+        "Load test completed in {:?}. Batch calls: {}, total embedded: {}",
+        elapsed,
+        batch_calls.load(Ordering::SeqCst),
+        total_embedded.load(Ordering::SeqCst)
+    );
+
+    // Without batching/coalescing, 100 requests @ 50ms = 5000ms sequentially or many individual provider calls.
+    // With coalescing into 5 unique keys, total embedded items sent to provider across all batches should be <= 5.
+    assert!(total_embedded.load(Ordering::SeqCst) <= 10);
+    assert!(batch_calls.load(Ordering::SeqCst) <= 5);
+}


### PR DESCRIPTION
Adds in-flight embedding request coalescing, batch queueing, concurrency limits, and atomic LRU caching to reduce provider call volume, prevent rate-limiting pressure, and improve P95/P99 latency.

Key additions:
- `BatchingConfig` added to `EmbeddingConfig` supporting `[embeddings.batch]` configuration (`enabled`, `max_batch_size`, `max_wait_ms`, `max_in_flight`, `coalesce_in_flight`).
- `CoalescedEmbeddingProvider` wrapping `EmbeddingProvider` instances in `SemanticService`.
- Singleflight coalescing via `tokio::sync::watch` and RAII guards for cancellation safety.
- Batch queueing and bounded semaphore concurrency.
- Unit tests, load tests, and benchmarks for batching/coalescing performance.

Fixes #964

---
*PR created automatically by Jules for task [17409011719326863687](https://jules.google.com/task/17409011719326863687) started by @d-o-hub*