### PR TITLE
fix(framework): cap reranker top_k to MAX_QUERY_LIMIT

### DIFF
--- a/memory-core/src/retrieval/gist/reranker.rs
+++ b/memory-core/src/retrieval/gist/reranker.rs
@@ -108,6 +108,7 @@ impl HierarchicalReranker {
         query: &str,
         top_k: usize,
     ) -> Vec<GistScoredItem> {
+        let top_k = top_k.min(crate::storage::MAX_QUERY_LIMIT);
         if episodes.is_empty() || top_k == 0 {
             return Vec::new();
         }
@@ -293,5 +294,28 @@ impl HierarchicalReranker {
             .map(|s| s.trim())
             .filter(|s| s.len() >= 3)
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rerank_with_query_unbounded_top_k() {
+        use crate::types::enums::TaskType;
+        use crate::types::structs::TaskContext;
+
+        let reranker = HierarchicalReranker::default();
+        let episode = Arc::new(Episode::new(
+            "test task".to_string(),
+            TaskContext::default(),
+            TaskType::CodeGeneration,
+        ));
+        let episodes = vec![(episode, 0.9)];
+
+        // Passing usize::MAX should be capped to MAX_QUERY_LIMIT and not panic
+        let results = reranker.rerank_with_query(episodes, "test", usize::MAX);
+        assert!(!results.is_empty());
     }
 }

--- a/progress/LEARNINGS.md
+++ b/progress/LEARNINGS.md
@@ -8,3 +8,8 @@
 **Vulnerability:** Public MCP tools accepted unbounded arrays of field names for JSON projection, leading to potential CWE-770 (Resource Exhaustion).
 **Learning:** Security bounds must be applied not just to scalar 'limit' parameters, but also to collection sizes (vectors/arrays) provided by users.
 **Prevention:** Use `.truncate(MAX_CONSTANT)` for user-provided lists and ensure all numeric/floating-point inputs are clamped to safe ranges.
+
+## 2026-03-06 — Unbounded top_k in HierarchicalReranker::rerank_with_query
+**Vulnerability:** `HierarchicalReranker::rerank_with_query` accepted an unbounded `top_k: usize` parameter which was passed directly to `Vec::with_capacity(top_k)` in `select_diverse`, leading to potential out-of-memory panics (DoS) when called with large `top_k` values like `usize::MAX`.
+**Learning:** Public retrieval APIs accepting limits/top_k parameters must bound user-provided values prior to vector allocations.
+**Prevention:** Clamp caller-provided `top_k` / `limit` parameters with existing constants like `crate::storage::MAX_QUERY_LIMIT` before allocation.


### PR DESCRIPTION
**Severity:** MEDIUM
**Finding:** Unbounded `top_k` parameter in `HierarchicalReranker::rerank_with_query` (`memory-core/src/retrieval/gist/reranker.rs`).
**Impact:** An attacker or caller passing `usize::MAX` (or very large `top_k`) causes `select_diverse` to execute `Vec::with_capacity(top_k)`, leading to an immediate memory allocation failure and out-of-memory panic (Denial of Service).
**Fix:** Bounded `top_k` using `crate::storage::MAX_QUERY_LIMIT` (`top_k.min(crate::storage::MAX_QUERY_LIMIT)`). Added unit test `test_rerank_with_query_unbounded_top_k`.
**Verification:** All gates pass (`cargo fmt --check`, unit tests pass).

---
*PR created automatically by Jules for task [13282549477619200583](https://jules.google.com/task/13282549477619200583) started by @d-o-hub*