### PR TITLE
ci(cap): cap remaining release artifact uploads at 7 days

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,7 @@ jobs:
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
+          retention-days: 7
       # sure would be cool if github gave us proper conditionals...
       # so here's a doubly-nested ternary-via-truthiness to try to provide the best possible
       # functionality based on whether this is a pull_request, and whether it's from a fork.
@@ -130,6 +131,7 @@ jobs:
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
+          retention-days: 7
 
   # Build and packages all the platform-specific things
   build-local-artifacts:
@@ -216,6 +218,7 @@ jobs:
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
             ${{ env.BUILD_MANIFEST_NAME }}
+          retention-days: 7
 
   # Build and package all the platform-agnostic(ish) things
   build-global-artifacts:
@@ -264,6 +267,7 @@ jobs:
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
             ${{ env.BUILD_MANIFEST_NAME }}
+          retention-days: 7
   # Determines if we should publish/announce
   host:
     needs:
@@ -315,6 +319,7 @@ jobs:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
           path: dist-manifest.json
+          retention-days: 7
       # Create a GitHub Release while uploading all files to it
       - name: "Download GitHub Artifacts"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
Completes the account-quota guard started in #981: caps the last 5 uncapped artifact uploads (cargo-dist release.yml steps) at 7 days. All 17 artifact uploads across the repo now carry `retention-days: 7`.