### PR TITLE
fix(bunnyshell): track main branch now that builder PR is merged

### DIFF
--- a/bunnyshell.yaml
+++ b/bunnyshell.yaml
@@ -32,7 +32,7 @@ components:
   - kind: Application
     name: rust-builder
     gitRepo: 'https://github.com/d-o-hub/rust-self-learning-memory.git'
-    gitBranch: infra/bunnyshell-remote-builder
+    gitBranch: main
     gitApplicationPath: /
     dockerCompose:
       build:


### PR DESCRIPTION
## Summary

Points the persistent remote builder at main now that #990 is merged (the feature branch is deleted, so fresh clones would fail until this lands).

## Type of Change

- [x] Bug fix

## Testing

- [x] Tests pass locally (yamllint clean; one-line yaml change, no code touched)
- [ ] Tests pass in CI

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have self-reviewed my changes