### PR TITLE
feat(storage): batch durable episode writes off the completion path

### DIFF
--- a/memory-cli/src/commands/storage/journal.rs
+++ b/memory-cli/src/commands/storage/journal.rs
@@ -42,6 +42,7 @@ pub async fn journal_status(
                 JournalOpKind::CapacityEviction => "capacity_eviction",
                 JournalOpKind::EpisodeDelete => "episode_delete",
                 JournalOpKind::EmbeddingDelete => "embedding_delete",
+                JournalOpKind::EpisodeComplete => "episode_complete",
             };
             JournalEntryView {
                 op_id: e.op_id.to_string(),

--- a/memory-cli/src/config/storage/mod.rs
+++ b/memory-cli/src/config/storage/mod.rs
@@ -336,6 +336,7 @@ pub(super) fn create_memory_config(config: &Config) -> MemoryConfig {
         reward_weight: 0.15,
         context_overlap_weight: 0.10,
         ann_index_path: None,
+        durable_write_queue: None,
         // Audit configuration
         audit_config: do_memory_core::AuditConfig::default(),
         // CloudEvents EventEmitter (WG-149)

--- a/memory-core/src/lib.rs
+++ b/memory-core/src/lib.rs
@@ -272,8 +272,9 @@ pub use memory::checkpoint::{CheckpointMeta, HandoffPack};
 pub use memory::filters::{EpisodeFilter, EpisodeFilterBuilder, OutcomeType};
 pub use memory::step_buffer::BatchConfig;
 pub use memory::{
-    EvictionBackend, EvictionBackendFailure, EvictionOutcome, JournalEntry, JournalOpKind,
-    JournalOutcome, OperationJournal, ProvenancedRetrieval, SelfLearningMemory,
+    DurableWriteQueue, EvictionBackend, EvictionBackendFailure, EvictionOutcome, JournalEntry,
+    JournalOpKind, JournalOutcome, OperationJournal, ProvenancedRetrieval, SelfLearningMemory,
+    WriteQueueConfig, WriteQueueStats,
 };
 pub use monitoring::{AgentMetrics, AgentMonitor, AgentType, MonitoringConfig, TaskMetrics};
 pub use patterns::{

--- a/memory-core/src/memory/completion.rs
+++ b/memory-core/src/memory/completion.rs
@@ -8,8 +8,24 @@ use tracing::{debug, info, instrument, warn};
 use uuid::Uuid;
 
 use super::SelfLearningMemory;
+use crate::Episode;
 
 impl SelfLearningMemory {
+    /// Persist one episode to the Turso backend.
+    ///
+    /// Routes through the bounded background queue when it is enabled
+    /// (#967, returning after the enqueue rather than the remote commit)
+    /// and stores synchronously otherwise. Resolves to `Ok(())` when no
+    /// Turso backend is configured. Queue backpressure surfaces as an
+    /// explicit error, never a silent drop.
+    pub(super) async fn store_episode_durable(&self, episode: &Episode) -> Result<()> {
+        match (&self.turso_storage, &self.durable_write_queue) {
+            (Some(_), Some(write_queue)) => write_queue.enqueue_episode(episode.clone()).await,
+            (Some(turso), None) => turso.store_episode(episode).await,
+            (None, _) => Ok(()),
+        }
+    }
+
     /// Complete an episode and trigger learning analysis.
     ///
     /// Finalizes the episode by recording the outcome, then performs the learning
@@ -303,9 +319,12 @@ impl SelfLearningMemory {
         // Use the episode for storage operations
         let episode_ref = &episode;
 
-        // ADR-075: durable complete is all-or-nothing for configured backends.
-        // Collect every store failure, then hard-fail before claiming success
-        // (skip in-memory map update and pattern extraction on failure).
+        // ADR-075 as amended by the D1 split
+        // (`plans/GOAP_FEATURE_WAVE_2026-09-04.md`, issue #967): the local
+        // cache write stays synchronous and hard-errors, while the Turso
+        // write moves through the bounded background queue when enabled
+        // (`MemoryConfig::durable_write_queue`). Queue backpressure surfaces
+        // as an explicit error, never a silent drop.
         let mut store_failures: Vec<String> = Vec::new();
 
         if let Some(cache) = &self.cache_storage {
@@ -319,12 +338,12 @@ impl SelfLearningMemory {
             }
         }
 
-        if let Some(turso) = &self.turso_storage {
-            if let Err(e) = turso.store_episode(episode_ref).await {
+        if self.turso_storage.is_some() {
+            if let Err(e) = self.store_episode_durable(episode_ref).await {
                 warn!(
                     episode_id = %episode_id,
                     error = %e,
-                    "Failed to store completed episode in Turso"
+                    "Failed to persist completed episode to Turso"
                 );
                 store_failures.push(format!("turso: {e}"));
             }

--- a/memory-core/src/memory/durable_write_queue.rs
+++ b/memory-core/src/memory/durable_write_queue.rs
@@ -1,0 +1,449 @@
+//! Bounded background queue for durable (Turso) episode writes (#967).
+//!
+//! Episode completion stays responsive by committing local state
+//! synchronously and moving remote persistence off the completion path:
+//!
+//! - The cache/redb write remains synchronous and hard-errors (ADR-075,
+//!   local tier of the D1 split in `plans/GOAP_FEATURE_WAVE_2026-09-04.md`).
+//! - The Turso write is enqueued here and persisted by a single ordered
+//!   background worker in transactional batches with retry/backoff.
+//! - The queue is **opt-in** (`MemoryConfig::durable_write_queue`); when it
+//!   is `None`, completion keeps the historical all-synchronous behavior.
+//!
+//! Backpressure is explicit: a full queue rejects with
+//! [`Error::QuotaExceeded`] instead of
+//! silently dropping writes. Retried batches are idempotent (`INSERT OR
+//! REPLACE`), so retries cannot create duplicate episodes.
+
+use crate::Episode;
+use crate::error::{Error, Result};
+use crate::memory::op_journal::SharedJournal;
+use crate::storage::StorageBackend;
+use std::collections::VecDeque;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use std::time::{Duration, Instant};
+use tokio::sync::{Mutex, RwLock};
+use tokio::time::sleep;
+use tracing::{debug, info, instrument, warn};
+use uuid::Uuid;
+
+/// Default maximum queued episodes before backpressure rejects writes.
+pub const DEFAULT_WRITE_QUEUE_SIZE: usize = 1000;
+/// Default episodes per transactional batch commit.
+pub const DEFAULT_WRITE_BATCH_SIZE: usize = 50;
+/// Default worker poll interval (ms) when the queue is empty.
+pub const DEFAULT_WRITE_POLL_INTERVAL_MS: u64 = 100;
+/// Default maximum batch retries before a write is declared permanently failed.
+pub const DEFAULT_WRITE_MAX_RETRIES: u32 = 3;
+/// Default base retry delay (ms); doubled per attempt up to the max.
+pub const DEFAULT_WRITE_RETRY_BASE_DELAY_MS: u64 = 100;
+/// Default maximum retry delay (ms).
+pub const DEFAULT_WRITE_RETRY_MAX_DELAY_MS: u64 = 5000;
+/// Maximum permanently-failed episode IDs retained for operator inspection.
+const MAX_RETAINED_FAILURES: usize = 256;
+
+/// Configuration for the background durable-write queue.
+#[derive(Debug, Clone)]
+pub struct WriteQueueConfig {
+    /// Maximum queued episodes (0 = unlimited). Full queues reject writes.
+    pub max_queue_size: usize,
+    /// Episodes per transactional batch commit.
+    pub batch_size: usize,
+    /// Worker poll interval when the queue is empty (milliseconds).
+    pub poll_interval_ms: u64,
+    /// Maximum batch retries before permanent failure.
+    pub max_retries: u32,
+    /// Base retry delay (milliseconds, doubled per attempt).
+    pub retry_base_delay_ms: u64,
+    /// Maximum retry delay (milliseconds).
+    pub retry_max_delay_ms: u64,
+}
+
+impl Default for WriteQueueConfig {
+    fn default() -> Self {
+        Self {
+            max_queue_size: DEFAULT_WRITE_QUEUE_SIZE,
+            batch_size: DEFAULT_WRITE_BATCH_SIZE,
+            poll_interval_ms: DEFAULT_WRITE_POLL_INTERVAL_MS,
+            max_retries: DEFAULT_WRITE_MAX_RETRIES,
+            retry_base_delay_ms: DEFAULT_WRITE_RETRY_BASE_DELAY_MS,
+            retry_max_delay_ms: DEFAULT_WRITE_RETRY_MAX_DELAY_MS,
+        }
+    }
+}
+
+/// Snapshot of durable-write queue operations.
+#[derive(Debug, Clone, Default)]
+pub struct WriteQueueStats {
+    /// Total episodes accepted into the queue.
+    pub total_enqueued: u64,
+    /// Total episodes acknowledged by the durable backend.
+    pub total_written: u64,
+    /// Total episodes declared permanently failed.
+    pub total_failed: u64,
+    /// Total episodes requeued after a failed batch attempt.
+    pub total_retried: u64,
+    /// Episodes currently waiting (excludes the in-flight batch).
+    pub current_depth: usize,
+    /// Age of the oldest waiting write in milliseconds (0 when empty).
+    pub oldest_enqueued_age_ms: u64,
+    /// Permanently-failed episode IDs, oldest first (capped).
+    pub failed_episode_ids: Vec<Uuid>,
+}
+
+/// One queued durable write with its retry state.
+struct QueuedWrite {
+    episode: Episode,
+    enqueued_at: Instant,
+    attempts: u32,
+}
+
+/// Background queue draining completed episodes to the durable backend.
+///
+/// A single ordered worker preserves completion order and keeps retries
+/// idempotent. See the module docs for the durability contract.
+pub struct DurableWriteQueue {
+    config: WriteQueueConfig,
+    queue: Arc<Mutex<VecDeque<QueuedWrite>>>,
+    turso: Arc<dyn StorageBackend>,
+    journal: SharedJournal,
+    stats: Arc<RwLock<WriteQueueStats>>,
+    /// Batches popped but not yet acknowledged (for accurate drain waits).
+    in_flight: Arc<AtomicUsize>,
+    shutdown: Arc<RwLock<bool>>,
+}
+
+impl DurableWriteQueue {
+    /// Create a queue bound to a durable backend and the operation journal.
+    #[must_use]
+    pub fn new(
+        config: WriteQueueConfig,
+        turso: Arc<dyn StorageBackend>,
+        journal: SharedJournal,
+    ) -> Self {
+        Self {
+            config,
+            queue: Arc::new(Mutex::new(VecDeque::new())),
+            turso,
+            journal,
+            stats: Arc::new(RwLock::new(WriteQueueStats::default())),
+            in_flight: Arc::new(AtomicUsize::new(0)),
+            shutdown: Arc::new(RwLock::new(false)),
+        }
+    }
+
+    /// Enqueue a completed episode for background durable persistence.
+    ///
+    /// A pending write for the same episode is *replaced*, not duplicated:
+    /// completion enqueues once at the durable seam and the synchronous
+    /// pattern path re-enqueues with pattern/heuristic IDs attached, so the
+    /// newest state always supplants the older one (remote rows are
+    /// `INSERT OR REPLACE`, making this coalescing lossless).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::QuotaExceeded`]
+    /// when the queue is at capacity. Callers must treat this as a failed
+    /// completion, never as a silent drop.
+    #[instrument(skip(self, episode), fields(episode_id = %episode.episode_id))]
+    pub async fn enqueue_episode(&self, episode: Episode) -> Result<()> {
+        let mut queue = self.queue.lock().await;
+        let id = episode.episode_id;
+        // Coalesce: drop any still-waiting write for this episode. An
+        // in-flight batch already popped keeps its copy; the requeued newer
+        // state persists right after, preserving final-state correctness.
+        let already_waiting = queue.iter().any(|w| w.episode.episode_id == id);
+        if !already_waiting
+            && self.config.max_queue_size > 0
+            && queue.len() >= self.config.max_queue_size
+        {
+            warn!(
+                queue_size = queue.len(),
+                max_size = self.config.max_queue_size,
+                "Durable write queue at capacity"
+            );
+            return Err(Error::QuotaExceeded(format!(
+                "durable write queue at capacity ({})",
+                self.config.max_queue_size
+            )));
+        }
+        queue.retain(|w| w.episode.episode_id != id);
+        queue.push_back(QueuedWrite {
+            episode,
+            enqueued_at: Instant::now(),
+            attempts: 0,
+        });
+        let depth = queue.len();
+        drop(queue);
+
+        let mut stats = self.stats.write().await;
+        stats.total_enqueued += 1;
+        stats.current_depth = depth;
+        debug!(queue_depth = depth, "Enqueued episode for durable write");
+        Ok(())
+    }
+
+    /// Start the single ordered background worker.
+    ///
+    /// One worker preserves completion order across batches; throughput
+    /// comes from transactional batch commits, not parallelism.
+    pub fn start_workers(&self) {
+        info!("Starting durable write worker");
+        let config = self.config.clone();
+        let queue = Arc::clone(&self.queue);
+        let turso = Arc::clone(&self.turso);
+        let journal = Arc::clone(&self.journal);
+        let stats = Arc::clone(&self.stats);
+        let in_flight = Arc::clone(&self.in_flight);
+        let shutdown = Arc::clone(&self.shutdown);
+        tokio::spawn(async move {
+            Self::worker_loop(config, queue, turso, journal, stats, in_flight, shutdown).await;
+        });
+    }
+
+    /// Main worker loop: drain batches, commit transactionally, retry/backoff.
+    #[allow(clippy::too_many_arguments)]
+    async fn worker_loop(
+        config: WriteQueueConfig,
+        queue: Arc<Mutex<VecDeque<QueuedWrite>>>,
+        turso: Arc<dyn StorageBackend>,
+        journal: SharedJournal,
+        stats: Arc<RwLock<WriteQueueStats>>,
+        in_flight: Arc<AtomicUsize>,
+        shutdown: Arc<RwLock<bool>>,
+    ) {
+        let poll_interval = Duration::from_millis(config.poll_interval_ms);
+        loop {
+            if *shutdown.read().await {
+                // Drain remaining work so shutdown loses nothing already
+                // accepted; retries still bound by max_retries, so this
+                // terminates.
+                if queue.lock().await.is_empty() && in_flight.load(Ordering::SeqCst) == 0 {
+                    debug!("Durable write worker shutting down gracefully");
+                    break;
+                }
+            }
+
+            let batch = Self::pop_batch(&config, &queue, &stats).await;
+            if batch.is_empty() {
+                sleep(poll_interval).await;
+                continue;
+            }
+            in_flight.store(batch.len(), Ordering::SeqCst);
+            Self::write_batch(&config, &turso, &journal, &stats, &queue, batch).await;
+            in_flight.store(0, Ordering::SeqCst);
+        }
+    }
+
+    /// Pop up to `batch_size` writes, oldest first.
+    async fn pop_batch(
+        config: &WriteQueueConfig,
+        queue: &Mutex<VecDeque<QueuedWrite>>,
+        stats: &RwLock<WriteQueueStats>,
+    ) -> Vec<QueuedWrite> {
+        let mut guard = queue.lock().await;
+        let take = config.batch_size.max(1).min(guard.len());
+        let batch: Vec<QueuedWrite> = guard.drain(..take).collect();
+        let depth = guard.len();
+        drop(guard);
+        stats.write().await.current_depth = depth;
+        batch
+    }
+
+    /// Retain one permanently-failed ID, dropping oldest past the cap.
+    fn retain_failure(stats: &mut WriteQueueStats, id: Uuid) {
+        if stats.failed_episode_ids.len() >= MAX_RETAINED_FAILURES {
+            stats.failed_episode_ids.remove(0);
+        }
+        stats.failed_episode_ids.push(id);
+    }
+
+    /// Commit one batch with retry/backoff; park permanent failures.
+    async fn write_batch(
+        config: &WriteQueueConfig,
+        turso: &Arc<dyn StorageBackend>,
+        journal: &SharedJournal,
+        stats: &RwLock<WriteQueueStats>,
+        queue: &Arc<Mutex<VecDeque<QueuedWrite>>>,
+        mut batch: Vec<QueuedWrite>,
+    ) {
+        let episodes: Vec<Episode> = batch.iter().map(|w| w.episode.clone()).collect();
+        let ids: Vec<Uuid> = batch.iter().map(|w| w.episode.episode_id).collect();
+        match turso.store_episodes_batch(&episodes).await {
+            Ok(()) => {
+                let op_id = Uuid::new_v4();
+                journal.record_durable_write_successes(op_id, &ids).await;
+                let mut stats = stats.write().await;
+                stats.total_written += batch.len() as u64;
+                info!(
+                    written = batch.len(),
+                    queue_depth = stats.current_depth,
+                    "Durable write batch committed"
+                );
+            }
+            Err(e) => {
+                let error_text = e.to_string();
+                let mut retryable = Vec::with_capacity(batch.len());
+                let mut permanent = Vec::with_capacity(batch.len());
+                for mut write in batch.drain(..) {
+                    write.attempts += 1;
+                    if write.attempts > config.max_retries {
+                        permanent.push(write);
+                    } else {
+                        retryable.push(write);
+                    }
+                }
+
+                if !permanent.is_empty() {
+                    let op_id = Uuid::new_v4();
+                    let failures: Vec<(Uuid, String)> = permanent
+                        .iter()
+                        .map(|w| (w.episode.episode_id, error_text.clone()))
+                        .collect();
+                    journal
+                        .record_durable_write_failures(op_id, &failures)
+                        .await;
+                    let mut stats = stats.write().await;
+                    stats.total_failed += permanent.len() as u64;
+                    for (id, _) in &failures {
+                        Self::retain_failure(&mut stats, *id);
+                    }
+                    warn!(
+                        failed = permanent.len(),
+                        error = %error_text,
+                        "Durable writes exhausted retries and were parked as permanent failures"
+                    );
+                }
+
+                if !retryable.is_empty() {
+                    // Exponential backoff, capped; requeue at the front to
+                    // preserve completion order ahead of newer writes.
+                    let attempts = retryable[0].attempts;
+                    let backoff_ms = config
+                        .retry_base_delay_ms
+                        .saturating_mul(1u64 << attempts.min(10))
+                        .min(config.retry_max_delay_ms);
+                    sleep(Duration::from_millis(backoff_ms)).await;
+                    let mut queue = queue.lock().await;
+                    let retried = retryable.len();
+                    for write in retryable.into_iter().rev() {
+                        queue.push_front(write);
+                    }
+                    let depth = queue.len();
+                    drop(queue);
+                    let mut stats = stats.write().await;
+                    stats.total_retried += retried as u64;
+                    stats.current_depth = depth;
+                    debug!(
+                        retried,
+                        backoff_ms,
+                        queue_depth = depth,
+                        "Durable write batch failed; requeued with backoff"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Current number of waiting writes (excludes the in-flight batch).
+    pub async fn queue_size(&self) -> usize {
+        self.queue.lock().await.len()
+    }
+
+    /// Snapshot of queue statistics, including oldest-waiting age.
+    pub async fn get_stats(&self) -> WriteQueueStats {
+        let queue = self.queue.lock().await;
+        let oldest_age_ms = queue
+            .front()
+            .map(|w| {
+                w.enqueued_at
+                    .elapsed()
+                    .as_millis()
+                    .min(u128::from(u64::MAX)) as u64
+            })
+            .unwrap_or(0);
+        let depth = queue.len();
+        drop(queue);
+        let mut stats = self.stats.read().await.clone();
+        stats.current_depth = depth;
+        stats.oldest_enqueued_age_ms = oldest_age_ms;
+        stats
+    }
+
+    /// Signal the worker to drain remaining work and exit.
+    pub async fn shutdown(&self) {
+        info!("Initiating durable write queue shutdown");
+        *self.shutdown.write().await = true;
+    }
+
+    /// Wait until no writes are waiting or in flight.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the queue drained, `false` on timeout.
+    pub async fn wait_until_empty(&self, timeout: Duration) -> bool {
+        let start = Instant::now();
+        while start.elapsed() < timeout {
+            if self.queue_size().await == 0 && self.in_flight.load(Ordering::SeqCst) == 0 {
+                return true;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+        false
+    }
+
+    /// Drain the queue and surface permanent failures.
+    ///
+    /// Used by CLI shutdown, tests, and operators that need the remote
+    /// durability guarantee on demand (the D1 split). Permanent
+    /// failures recorded during the drain surface as
+    /// [`Error::Storage`]; inspect the
+    /// operation journal and [`get_stats`](Self::get_stats) for the IDs.
+    ///
+    /// # Errors
+    ///
+    /// Returns error on drain timeout or when writes failed permanently
+    /// during the drain.
+    pub async fn flush(&self, timeout: Duration) -> Result<()> {
+        let baseline_failed = self.get_stats().await.total_failed;
+        if !self.wait_until_empty(timeout).await {
+            let depth = self.queue_size().await;
+            return Err(Error::Storage(format!(
+                "durable write queue did not drain within {timeout:?} ({depth} waiting)"
+            )));
+        }
+        let failed_now = self.get_stats().await.total_failed;
+        if failed_now > baseline_failed {
+            return Err(Error::Storage(format!(
+                "durable write queue drained with {} permanent failure(s); see operation journal",
+                failed_now - baseline_failed
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_queue_config_defaults_are_bounded_and_retrying() {
+        let config = WriteQueueConfig::default();
+
+        assert_eq!(config.max_queue_size, DEFAULT_WRITE_QUEUE_SIZE);
+        assert_eq!(config.batch_size, DEFAULT_WRITE_BATCH_SIZE);
+        assert_eq!(config.poll_interval_ms, DEFAULT_WRITE_POLL_INTERVAL_MS);
+        assert_eq!(config.max_retries, DEFAULT_WRITE_MAX_RETRIES);
+        assert_eq!(
+            config.retry_base_delay_ms,
+            DEFAULT_WRITE_RETRY_BASE_DELAY_MS
+        );
+        assert_eq!(config.retry_max_delay_ms, DEFAULT_WRITE_RETRY_MAX_DELAY_MS);
+        assert!(config.max_queue_size > 0);
+        assert!(config.batch_size > 0);
+    }
+}

--- a/memory-core/src/memory/init.rs
+++ b/memory-core/src/memory/init.rs
@@ -7,6 +7,7 @@ use crate::embeddings::EmbeddingConfig;
 use crate::extraction::PatternExtractor;
 use crate::learning::queue::{PatternExtractionQueue, QueueConfig};
 use crate::memory::attribution::RankingIndex;
+use crate::memory::durable_write_queue::{DurableWriteQueue, WriteQueueConfig};
 use crate::monitoring::{AgentMonitor, MonitoringConfig, storage::SimpleMonitoringStorage};
 use crate::pre_storage::{QualityAssessor, QualityConfig, SalientExtractor};
 use crate::reflection::ReflectionGenerator;
@@ -147,6 +148,7 @@ pub fn with_config(config: MemoryConfig) -> super::SelfLearningMemory {
         procedural_fallback: Arc::new(RwLock::new(HashMap::new())),
         relationships_fallback: Arc::new(RwLock::new(HashMap::new())),
         pattern_queue: None,
+        durable_write_queue: None,
         step_buffers: Arc::new(RwLock::new(HashMap::new())),
         cache_semaphore: Arc::new(Semaphore::new(config.concurrency.max_concurrent_cache_ops)),
         event_emitter_semaphore: Arc::new(Semaphore::new(10)),
@@ -175,7 +177,12 @@ pub fn with_config(config: MemoryConfig) -> super::SelfLearningMemory {
     }
 }
 
-/// Create a memory system with storage backends
+/// Create a memory system with storage backends.
+///
+/// When `config.durable_write_queue` is `Some`, the background durable write
+/// queue is wired automatically (#967) — `complete_episode` then commits
+/// local state synchronously and persists to Turso in the background once
+/// [`start_durable_workers`] runs. `None` keeps fully synchronous completion.
 pub fn with_storage(
     config: MemoryConfig,
     turso: Arc<dyn crate::storage::StorageBackend>,
@@ -294,7 +301,7 @@ pub fn with_storage(
     let event_emitter: Arc<dyn crate::types::emitter::EventEmitter> =
         config.event_emitter_mode.build();
 
-    super::SelfLearningMemory {
+    let memory = super::SelfLearningMemory {
         config: config.clone(),
         quality_assessor,
         salient_extractor,
@@ -311,6 +318,7 @@ pub fn with_storage(
         procedural_fallback: Arc::new(RwLock::new(HashMap::new())),
         relationships_fallback: Arc::new(RwLock::new(HashMap::new())),
         pattern_queue: None,
+        durable_write_queue: None,
         step_buffers: Arc::new(RwLock::new(HashMap::new())),
         cache_semaphore: Arc::new(Semaphore::new(config.concurrency.max_concurrent_cache_ops)),
         event_emitter_semaphore: Arc::new(Semaphore::new(10)),
@@ -336,6 +344,10 @@ pub fn with_storage(
         event_emitter,
         pending_eviction_failures: Arc::new(RwLock::new(Vec::new())),
         op_journal: Arc::new(super::op_journal::OperationJournal::default()),
+    };
+    match config.durable_write_queue.clone() {
+        Some(queue_config) => enable_durable_writes(memory, queue_config),
+        None => memory,
     }
 }
 pub fn with_semantic_config(
@@ -365,19 +377,54 @@ pub async fn start_workers(memory: &super::SelfLearningMemory) {
     }
 }
 
-/// Stop async pattern extraction workers gracefully.
+/// Stop async workers gracefully.
 ///
-/// Waits for the queue to drain (workers finish processing current items),
-/// then signals workers to shut down. Returns `true` if the queue emptied
-/// within the timeout, `false` otherwise.
+/// Drains the durable write queue first (remote durability), then the
+/// pattern extraction queue. Returns `true` if both queues emptied within
+/// the timeout, `false` otherwise.
 pub async fn stop_workers(memory: &super::SelfLearningMemory, timeout: Duration) -> bool {
+    let mut drained = true;
+    if let Some(queue) = &memory.durable_write_queue {
+        drained &= queue.flush(timeout).await.is_ok();
+        queue.shutdown().await;
+    }
     if let Some(queue) = &memory.pattern_queue {
         // Drain first: workers check the shutdown flag between items,
         // so we must let the queue empty before signaling shutdown.
-        let drained = queue.wait_until_empty(timeout).await;
+        drained &= queue.wait_until_empty(timeout).await;
         queue.shutdown().await;
-        drained
-    } else {
-        true
+    }
+    drained
+}
+
+/// Enable the background durable write queue (#967).
+///
+/// Without a Turso backend the queue has nothing to drain to, so the
+/// memory system is returned unchanged (with a warning).
+#[must_use]
+pub fn enable_durable_writes(
+    memory: super::SelfLearningMemory,
+    queue_config: WriteQueueConfig,
+) -> super::SelfLearningMemory {
+    let Some(turso) = memory.turso_storage.clone() else {
+        tracing::warn!(
+            "Durable write queue enabled without a Turso backend; completion stays synchronous"
+        );
+        return memory;
+    };
+    let queue = Arc::new(DurableWriteQueue::new(
+        queue_config,
+        turso,
+        Arc::clone(&memory.op_journal),
+    ));
+    let mut memory = memory;
+    memory.durable_write_queue = Some(queue);
+    memory
+}
+
+/// Start the durable write worker (no-op unless the queue is enabled).
+pub fn start_durable_workers(memory: &super::SelfLearningMemory) {
+    if let Some(queue) = &memory.durable_write_queue {
+        queue.start_workers();
     }
 }

--- a/memory-core/src/memory/learning.rs
+++ b/memory-core/src/memory/learning.rs
@@ -107,8 +107,12 @@ impl SelfLearningMemory {
             }
         }
 
-        if let Some(turso) = &self.turso_storage {
-            if let Err(e) = turso.store_episode(&episode).await {
+        // Re-persist the episode with pattern and heuristic IDs. Routed like
+        // the completion write itself (#967): queued when the background
+        // durable writer is enabled, synchronous otherwise. Best-effort here
+        // (warn-only), matching the pre-existing behavior of this path.
+        if self.turso_storage.is_some() {
+            if let Err(e) = self.store_episode_durable(&episode).await {
                 warn!(
                     "Failed to update episode with patterns and heuristics in Turso: {}",
                     e

--- a/memory-core/src/memory/mod.rs
+++ b/memory-core/src/memory/mod.rs
@@ -50,6 +50,7 @@ pub mod api;
 pub mod attribution;
 pub mod checkpoint;
 mod completion;
+pub mod durable_write_queue;
 pub mod embedding_activation;
 mod episode;
 mod eviction;
@@ -82,6 +83,7 @@ use crate::types::MemoryConfig;
 use std::sync::Arc;
 
 // Re-export pattern search types for public API
+pub use durable_write_queue::{DurableWriteQueue, WriteQueueConfig, WriteQueueStats};
 pub use eviction::{EvictionBackend, EvictionBackendFailure, EvictionOutcome};
 pub use op_journal::{
     JournalEntry, JournalOpKind, JournalOutcome, OperationJournal, SharedJournal,
@@ -142,13 +144,55 @@ impl SelfLearningMemory {
         init::start_workers(self).await;
     }
 
-    /// Stop async pattern extraction workers gracefully.
+    /// Stop async workers gracefully.
     ///
-    /// Signals workers to shut down and waits for the queue to drain
-    /// up to the given timeout. Returns `true` if the queue emptied
-    /// within the timeout, `false` otherwise.
+    /// Drains the durable write queue first (remote durability), then the
+    /// pattern extraction queue. Signals workers to shut down and waits for
+    /// the queues to drain up to the given timeout. Returns `true` if both
+    /// queues emptied within the timeout, `false` otherwise.
     pub async fn stop_workers(&self, timeout: std::time::Duration) -> bool {
         init::stop_workers(self, timeout).await
+    }
+
+    /// Enable the background durable write queue (#967).
+    ///
+    /// When enabled, `complete_episode` commits local state synchronously
+    /// and persists to Turso through the bounded queue instead of blocking
+    /// on the remote write. Has no effect without a Turso backend.
+    #[must_use]
+    pub fn enable_durable_writes(self, queue_config: WriteQueueConfig) -> Self {
+        init::enable_durable_writes(self, queue_config)
+    }
+
+    /// Start the durable write worker (no-op unless the queue is enabled).
+    pub fn start_durable_workers(&self) {
+        init::start_durable_workers(self);
+    }
+
+    /// Snapshot of durable write queue statistics, if the queue is enabled.
+    pub async fn durable_write_stats(&self) -> Option<WriteQueueStats> {
+        match &self.durable_write_queue {
+            Some(queue) => Some(queue.get_stats().await),
+            None => None,
+        }
+    }
+
+    /// Drain the durable write queue and surface permanent failures (#967).
+    ///
+    /// No-op success when the queue is not enabled. Used by CLI shutdown,
+    /// tests, and operators that need the remote durability guarantee.
+    ///
+    /// # Errors
+    ///
+    /// Returns error on drain timeout or permanent write failures.
+    pub async fn flush_durable_writes(
+        &self,
+        timeout: std::time::Duration,
+    ) -> crate::error::Result<()> {
+        match &self.durable_write_queue {
+            Some(queue) => queue.flush(timeout).await,
+            None => Ok(()),
+        }
     }
 
     /// Get a reference to semantic service (if configured)

--- a/memory-core/src/memory/op_journal.rs
+++ b/memory-core/src/memory/op_journal.rs
@@ -20,6 +20,8 @@ pub enum JournalOpKind {
     EpisodeDelete,
     /// Embedding-only cleanup
     EmbeddingDelete,
+    /// Completed-episode durable write via the background write queue (#967)
+    EpisodeComplete,
 }
 
 /// Outcome recorded for a single backend attempt.
@@ -123,6 +125,54 @@ impl OperationJournal {
                 })
                 .await;
             }
+        }
+    }
+
+    /// Record a completed-episode durable write queued for the background
+    /// worker as a pending intent (#967).
+    pub async fn record_durable_write_pending(&self, op_id: Uuid, episode_id: Uuid) {
+        self.record(JournalEntry {
+            op_id,
+            episode_id,
+            kind: JournalOpKind::EpisodeComplete,
+            backend: EvictionBackend::Durable,
+            outcome: JournalOutcome::Pending,
+            recorded_at_ms: chrono_now_ms(),
+        })
+        .await;
+    }
+
+    /// Record completed-episode durable writes the worker acknowledged.
+    pub async fn record_durable_write_successes(&self, op_id: Uuid, episode_ids: &[Uuid]) {
+        let now = chrono_now_ms();
+        for &episode_id in episode_ids {
+            self.record(JournalEntry {
+                op_id,
+                episode_id,
+                kind: JournalOpKind::EpisodeComplete,
+                backend: EvictionBackend::Durable,
+                outcome: JournalOutcome::Success,
+                recorded_at_ms: now,
+            })
+            .await;
+        }
+    }
+
+    /// Record completed-episode durable writes that exhausted retries (#967).
+    pub async fn record_durable_write_failures(&self, op_id: Uuid, failures: &[(Uuid, String)]) {
+        let now = chrono_now_ms();
+        for (episode_id, error) in failures {
+            self.record(JournalEntry {
+                op_id,
+                episode_id: *episode_id,
+                kind: JournalOpKind::EpisodeComplete,
+                backend: EvictionBackend::Durable,
+                outcome: JournalOutcome::Failed {
+                    error: error.clone(),
+                },
+                recorded_at_ms: now,
+            })
+            .await;
         }
     }
 

--- a/memory-core/src/memory/types.rs
+++ b/memory-core/src/memory/types.rs
@@ -90,6 +90,8 @@ pub struct SelfLearningMemory {
     pub(super) relationships_fallback: Arc<RwLock<HashMap<Uuid, EpisodeRelationship>>>,
     /// Async pattern extraction queue (optional)
     pub(super) pattern_queue: Option<Arc<PatternExtractionQueue>>,
+    /// Background durable write queue for Turso (optional, #967)
+    pub(super) durable_write_queue: Option<Arc<super::durable_write_queue::DurableWriteQueue>>,
     /// Step buffers for batching I/O operations
     pub(super) step_buffers: Arc<RwLock<HashMap<Uuid, StepBuffer>>>,
     /// Semaphore to limit concurrent cache operations and prevent async runtime blocking

--- a/memory-core/src/storage/backend.rs
+++ b/memory-core/src/storage/backend.rs
@@ -31,6 +31,28 @@ pub trait StorageBackend: Send + Sync {
     /// Returns error if storage operation fails
     async fn store_episode(&self, episode: &Episode) -> Result<()>;
 
+    /// Store a batch of episodes in one call.
+    ///
+    /// Backends with transactional batching (Turso) override this with a
+    /// single-transaction implementation. The default loops over
+    /// [`store_episode`](Self::store_episode), so existing implementors keep
+    /// compiling and behaving identically. Episodes use `INSERT OR REPLACE`
+    /// semantics wherever supported, making retried batches idempotent.
+    ///
+    /// # Arguments
+    ///
+    /// * `episodes` - Episodes to store
+    ///
+    /// # Errors
+    ///
+    /// Returns error if any storage operation fails
+    async fn store_episodes_batch(&self, episodes: &[Episode]) -> Result<()> {
+        for episode in episodes {
+            self.store_episode(episode).await?;
+        }
+        Ok(())
+    }
+
     /// Retrieve an episode by ID.
     ///
     /// Returns `Some(Episode)` if found, `None` if not found.

--- a/memory-core/src/storage/backend_default_tests.rs
+++ b/memory-core/src/storage/backend_default_tests.rs
@@ -128,6 +128,21 @@ fn sample_procedural() -> ProceduralMemory {
 }
 
 #[tokio::test]
+async fn storage_backend_default_episode_batch_loops_singles() {
+    let backend = StubBackend;
+
+    // Empty batch is a no-op success.
+    backend.store_episodes_batch(&[]).await.unwrap();
+
+    // Default body delegates to store_episode per item.
+    let episodes = vec![
+        Episode::new("one".into(), TaskContext::default(), TaskType::Testing),
+        Episode::new("two".into(), TaskContext::default(), TaskType::Testing),
+    ];
+    backend.store_episodes_batch(&episodes).await.unwrap();
+}
+
+#[tokio::test]
 async fn storage_backend_default_methods_return_empty_success() {
     let backend = StubBackend;
     let id = Uuid::new_v4();

--- a/memory-core/src/types/config.rs
+++ b/memory-core/src/types/config.rs
@@ -2,6 +2,7 @@
 // Configuration
 // ============================================================================
 
+use crate::memory::durable_write_queue::WriteQueueConfig;
 use crate::memory::step_buffer::BatchConfig;
 use crate::security::audit::AuditConfig;
 
@@ -129,6 +130,7 @@ impl Default for ConcurrencyConfig {
 ///     reward_weight: 0.15,
 ///     context_overlap_weight: 0.10,
 ///     ann_index_path: None,
+///     durable_write_queue: None,
 ///     audit_config: AuditConfig::default(),
 ///     event_emitter_mode: EventEmitterMode::NoOp,
 /// };
@@ -204,6 +206,12 @@ pub struct MemoryConfig {
     pub context_overlap_weight: f32,
     /// Path to the ANN index snapshot
     pub ann_index_path: Option<std::path::PathBuf>,
+    /// Background durable write queue for Turso (issue #967).
+    ///
+    /// When `Some`, `complete_episode` commits local state synchronously and
+    /// persists to Turso through the bounded queue instead of blocking on the
+    /// remote write. `None` (default) keeps all-synchronous completion.
+    pub durable_write_queue: Option<WriteQueueConfig>,
 
     // Security - Audit logging
     /// Audit logging configuration
@@ -250,6 +258,7 @@ impl Default for MemoryConfig {
             reward_weight: 0.15,
             context_overlap_weight: 0.10,
             ann_index_path: None,
+            durable_write_queue: None,
 
             // Security - Audit logging (disabled by default for development)
             audit_config: AuditConfig::default(),

--- a/memory-core/tests/durable_write_queue.rs
+++ b/memory-core/tests/durable_write_queue.rs
@@ -1,0 +1,450 @@
+//! Issue #967: bounded background durable writes off the completion path.
+//!
+//! Contract under test (D1 split): local cache writes stay synchronous and
+//! hard-error; Turso writes move through the opt-in bounded queue; queue
+//! backpressure is an explicit error; retries are idempotent; `flush` gives
+//! operators the remote durability guarantee on demand.
+
+#![allow(clippy::unwrap_used, clippy::panic)] // test-only mock backend
+
+use async_trait::async_trait;
+use chrono::Utc;
+use do_memory_core::episode::PatternId;
+use do_memory_core::storage::StorageBackend;
+use do_memory_core::{
+    Episode, Error, Heuristic, MemoryConfig, Pattern, Result, SelfLearningMemory, TaskContext,
+    TaskOutcome, TaskType, WriteQueueConfig,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+/// Configurable mock backend: counting store with optional failure/sleep.
+struct MockBackend {
+    store_calls: AtomicUsize,
+    batch_calls: AtomicUsize,
+    /// Fail the next N batch commits, then succeed.
+    fail_first_n_batches: AtomicUsize,
+    always_fail: AtomicBool,
+    store_sleep_ms: u64,
+    stored: Mutex<HashMap<Uuid, Episode>>,
+}
+
+impl MockBackend {
+    fn new() -> Self {
+        Self {
+            store_calls: AtomicUsize::new(0),
+            batch_calls: AtomicUsize::new(0),
+            fail_first_n_batches: AtomicUsize::new(0),
+            always_fail: AtomicBool::new(false),
+            store_sleep_ms: 0,
+            stored: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn failing() -> Self {
+        let backend = Self::new();
+        backend.always_fail.store(true, Ordering::SeqCst);
+        backend
+    }
+
+    fn slow(store_sleep_ms: u64) -> Self {
+        let mut backend = Self::new();
+        backend.store_sleep_ms = store_sleep_ms;
+        backend
+    }
+
+    async fn stored_count(&self) -> usize {
+        self.stored.lock().await.len()
+    }
+}
+
+#[async_trait]
+impl StorageBackend for MockBackend {
+    async fn store_episode(&self, episode: &Episode) -> Result<()> {
+        self.store_calls.fetch_add(1, Ordering::SeqCst);
+        if self.store_sleep_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(self.store_sleep_ms)).await;
+        }
+        if self.always_fail.load(Ordering::SeqCst) {
+            return Err(Error::Storage("mock store_episode failed".into()));
+        }
+        self.stored
+            .lock()
+            .await
+            .insert(episode.episode_id, episode.clone());
+        Ok(())
+    }
+
+    async fn store_episodes_batch(&self, episodes: &[Episode]) -> Result<()> {
+        self.batch_calls.fetch_add(1, Ordering::SeqCst);
+        if self.always_fail.load(Ordering::SeqCst) {
+            return Err(Error::Storage("mock batch failed".into()));
+        }
+        if self.fail_first_n_batches.fetch_sub(1, Ordering::SeqCst) > 0 {
+            return Err(Error::Storage("mock flaky batch failed".into()));
+        }
+        for episode in episodes {
+            self.store_episode(episode).await?;
+        }
+        Ok(())
+    }
+
+    async fn get_episode(&self, _id: Uuid) -> Result<Option<Episode>> {
+        Ok(None)
+    }
+    async fn delete_episode(&self, _id: Uuid) -> Result<()> {
+        Ok(())
+    }
+    async fn store_pattern(&self, _pattern: &Pattern) -> Result<()> {
+        Ok(())
+    }
+    async fn get_pattern(&self, _id: PatternId) -> Result<Option<Pattern>> {
+        Ok(None)
+    }
+    async fn store_heuristic(&self, _heuristic: &Heuristic) -> Result<()> {
+        Ok(())
+    }
+    async fn get_heuristic(&self, _id: Uuid) -> Result<Option<Heuristic>> {
+        Ok(None)
+    }
+    async fn query_episodes_since(
+        &self,
+        _since: chrono::DateTime<Utc>,
+        _limit: Option<usize>,
+    ) -> Result<Vec<Episode>> {
+        Ok(vec![])
+    }
+    async fn query_episodes_by_metadata(
+        &self,
+        _key: &str,
+        _value: &str,
+        _limit: Option<usize>,
+    ) -> Result<Vec<Episode>> {
+        Ok(vec![])
+    }
+    async fn store_embedding(&self, _id: &str, _embedding: Vec<f32>) -> Result<()> {
+        Ok(())
+    }
+    async fn get_embedding(&self, _id: &str) -> Result<Option<Vec<f32>>> {
+        Ok(None)
+    }
+    async fn delete_embedding(&self, _id: &str) -> Result<bool> {
+        Ok(true)
+    }
+    async fn store_embeddings_batch(&self, _embeddings: Vec<(String, Vec<f32>)>) -> Result<()> {
+        Ok(())
+    }
+    async fn get_embeddings_batch(&self, _ids: &[String]) -> Result<Vec<Option<Vec<f32>>>> {
+        Ok(vec![])
+    }
+}
+
+/// Test config: no quality gate, no summarization, queue enabled by default.
+fn test_config() -> MemoryConfig {
+    MemoryConfig {
+        quality_threshold: 0.0,
+        pattern_extraction_threshold: 1.0,
+        enable_summarization: false,
+        enable_embeddings: false,
+        batch_config: None,
+        durable_write_queue: Some(WriteQueueConfig {
+            batch_size: 10,
+            poll_interval_ms: 10,
+            retry_base_delay_ms: 10,
+            retry_max_delay_ms: 50,
+            ..WriteQueueConfig::default()
+        }),
+        ..MemoryConfig::default()
+    }
+}
+
+fn success_outcome() -> TaskOutcome {
+    TaskOutcome::Success {
+        verdict: "done".into(),
+        artifacts: vec![],
+    }
+}
+
+async fn start_episode(memory: &SelfLearningMemory, task: &str) -> Uuid {
+    memory
+        .start_episode(task.into(), TaskContext::default(), TaskType::Testing)
+        .await
+}
+
+#[tokio::test]
+async fn completion_returns_before_slow_remote_persists() {
+    // Arrange: Turso takes 2s per write; queue enabled with workers running.
+    let cache = Arc::new(MockBackend::new());
+    let turso = Arc::new(MockBackend::slow(2000));
+    let memory = SelfLearningMemory::with_storage(
+        test_config(),
+        Arc::clone(&turso) as Arc<dyn StorageBackend>,
+        Arc::clone(&cache) as Arc<dyn StorageBackend>,
+    );
+    memory.start_durable_workers();
+    let episode_id = start_episode(&memory, "slow remote").await;
+
+    // Act: complete and time only the completion call.
+    let start = Instant::now();
+    memory
+        .complete_episode(episode_id, success_outcome())
+        .await
+        .expect("queued completion must succeed");
+    let elapsed = start.elapsed();
+
+    // Assert: completion excluded the 2s remote write...
+    assert!(
+        elapsed < Duration::from_millis(1500),
+        "completion took {elapsed:?}, remote work leaked onto the path"
+    );
+    // ...but local read-after-write holds immediately...
+    assert!(memory.get_episode(episode_id).await.is_ok());
+    // NOTE: no assertion on the remote store here — the background worker
+    // may legitimately persist before we look (that is the point of the
+    // queue); only completion latency is asserted above.
+    // ...and the background worker persists it; flush gives the guarantee.
+    memory
+        .flush_durable_writes(Duration::from_secs(10))
+        .await
+        .expect("flush must succeed");
+    assert_eq!(turso.stored_count().await, 1);
+}
+
+#[tokio::test]
+async fn flush_surfaces_permanent_remote_failure_but_keeps_local_state() {
+    // Arrange: Turso always fails; no retries so parking is immediate.
+    let cache = Arc::new(MockBackend::new());
+    let turso = Arc::new(MockBackend::failing());
+    let mut config = test_config();
+    config.durable_write_queue = Some(WriteQueueConfig {
+        max_retries: 0,
+        batch_size: 10,
+        poll_interval_ms: 10,
+        ..WriteQueueConfig::default()
+    });
+    let memory = SelfLearningMemory::with_storage(
+        config,
+        Arc::clone(&turso) as Arc<dyn StorageBackend>,
+        Arc::clone(&cache) as Arc<dyn StorageBackend>,
+    );
+    // Complete before workers start: the seam write and the sync
+    // pattern-path re-store coalesce to a single queued entry, so exactly
+    // one permanent failure is recorded deterministically.
+    let episode_id = start_episode(&memory, "doomed remote").await;
+
+    // Act: completion succeeds (queued); flush reports the parked failure.
+    memory
+        .complete_episode(episode_id, success_outcome())
+        .await
+        .expect("queued completion must succeed");
+    memory.start_durable_workers();
+    let flush_result = memory.flush_durable_writes(Duration::from_secs(10)).await;
+
+    // Assert: flush names the permanent failure...
+    let err = flush_result.expect_err("flush must surface parked failures");
+    match err {
+        Error::Storage(msg) => assert!(
+            msg.contains("permanent failure"),
+            "unexpected message: {msg}"
+        ),
+        other => panic!("expected Error::Storage, got {other:?}"),
+    }
+    // ...the failure is observable in stats...
+    let stats = memory
+        .durable_write_stats()
+        .await
+        .expect("stats must exist");
+    assert_eq!(stats.total_failed, 1);
+    assert_eq!(stats.failed_episode_ids, vec![episode_id]);
+    // ...and recorded in the operation journal for operators...
+    let pending = memory.operation_journal_pending().await;
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].episode_id, episode_id);
+    assert_eq!(
+        pending[0].kind,
+        do_memory_core::JournalOpKind::EpisodeComplete
+    );
+    // ...and local read-after-write still holds.
+    assert!(memory.get_episode(episode_id).await.is_ok());
+}
+
+#[tokio::test]
+async fn retry_recovers_without_duplicate_episodes() {
+    // Arrange: first two batch commits fail, then the backend recovers.
+    let cache = Arc::new(MockBackend::new());
+    let turso = Arc::new(MockBackend::new());
+    turso.fail_first_n_batches.store(2, Ordering::SeqCst);
+    let memory = SelfLearningMemory::with_storage(
+        test_config(),
+        Arc::clone(&turso) as Arc<dyn StorageBackend>,
+        Arc::clone(&cache) as Arc<dyn StorageBackend>,
+    );
+    memory.start_durable_workers();
+    let episode_id = start_episode(&memory, "flaky remote").await;
+
+    // Act.
+    memory
+        .complete_episode(episode_id, success_outcome())
+        .await
+        .expect("queued completion must succeed");
+    memory
+        .flush_durable_writes(Duration::from_secs(10))
+        .await
+        .expect("flush must succeed after recovery");
+
+    // Assert: retried batches are idempotent (INSERT OR REPLACE semantics).
+    assert!(turso.batch_calls.load(Ordering::SeqCst) >= 3);
+    assert_eq!(turso.stored_count().await, 1);
+    let stats = memory
+        .durable_write_stats()
+        .await
+        .expect("stats must exist");
+    assert!(stats.total_retried >= 2);
+    assert_eq!(stats.total_failed, 0);
+}
+
+#[tokio::test]
+async fn full_queue_rejects_with_explicit_backpressure() {
+    // Arrange: tiny queue, workers NOT started so nothing drains.
+    let cache = Arc::new(MockBackend::new());
+    let turso = Arc::new(MockBackend::new());
+    let mut config = test_config();
+    config.durable_write_queue = Some(WriteQueueConfig {
+        max_queue_size: 2,
+        batch_size: 10,
+        poll_interval_ms: 10,
+        ..WriteQueueConfig::default()
+    });
+    let memory = SelfLearningMemory::with_storage(
+        config,
+        Arc::clone(&turso) as Arc<dyn StorageBackend>,
+        Arc::clone(&cache) as Arc<dyn StorageBackend>,
+    );
+    let first = start_episode(&memory, "queued one").await;
+    let second = start_episode(&memory, "queued two").await;
+    let third = start_episode(&memory, "rejected three").await;
+
+    // Act.
+    memory
+        .complete_episode(first, success_outcome())
+        .await
+        .expect("first completion must queue");
+    memory
+        .complete_episode(second, success_outcome())
+        .await
+        .expect("second completion must queue");
+    let rejected = memory.complete_episode(third, success_outcome()).await;
+
+    // Assert: explicit backpressure, never a silent drop. The rejection is
+    // collected like any backend failure so the error names the cause.
+    let err = rejected.expect_err("third completion must be rejected");
+    match err {
+        Error::Storage(msg) => assert!(msg.contains("capacity"), "unexpected message: {msg}"),
+        other => panic!("expected Error::Storage, got {other:?}"),
+    }
+    let stats = memory
+        .durable_write_stats()
+        .await
+        .expect("stats must exist");
+    assert_eq!(stats.current_depth, 2);
+}
+
+#[tokio::test]
+async fn stop_workers_drains_queued_writes() {
+    // Arrange.
+    let cache = Arc::new(MockBackend::new());
+    let turso = Arc::new(MockBackend::new());
+    let memory = SelfLearningMemory::with_storage(
+        test_config(),
+        Arc::clone(&turso) as Arc<dyn StorageBackend>,
+        Arc::clone(&cache) as Arc<dyn StorageBackend>,
+    );
+    memory.start_durable_workers();
+    for i in 0..3 {
+        let id = start_episode(&memory, &format!("drain me {i}")).await;
+        memory
+            .complete_episode(id, success_outcome())
+            .await
+            .expect("completion must queue");
+    }
+
+    // Act: shutdown path drains with a timeout (issue acceptance).
+    let drained = memory.stop_workers(Duration::from_secs(10)).await;
+
+    // Assert.
+    assert!(drained, "stop_workers must drain the write queue");
+    assert_eq!(turso.stored_count().await, 3);
+    // Worker acknowledgements are journaled for operators.
+    let snapshot = memory.operation_journal_snapshot().await;
+    let successes = snapshot
+        .iter()
+        .filter(|e| e.kind == do_memory_core::JournalOpKind::EpisodeComplete)
+        .count();
+    assert_eq!(successes, 3);
+}
+
+#[tokio::test]
+async fn retained_failure_ids_are_capped() {
+    // Arrange: far more permanent failures than the retention cap.
+    let cache = Arc::new(MockBackend::new());
+    let turso = Arc::new(MockBackend::failing());
+    let mut config = test_config();
+    config.durable_write_queue = Some(WriteQueueConfig {
+        max_queue_size: 1000,
+        batch_size: 100,
+        poll_interval_ms: 5,
+        max_retries: 0,
+        ..WriteQueueConfig::default()
+    });
+    let memory = SelfLearningMemory::with_storage(
+        config,
+        Arc::clone(&turso) as Arc<dyn StorageBackend>,
+        Arc::clone(&cache) as Arc<dyn StorageBackend>,
+    );
+    for i in 0..300 {
+        let id = start_episode(&memory, &format!("capped {i}")).await;
+        memory
+            .complete_episode(id, success_outcome())
+            .await
+            .expect("completion must queue");
+    }
+    memory.start_durable_workers();
+
+    // Act.
+    let flush_result = memory.flush_durable_writes(Duration::from_secs(30)).await;
+
+    // Assert: flush reports the failures and retention is bounded.
+    assert!(flush_result.is_err());
+    let stats = memory
+        .durable_write_stats()
+        .await
+        .expect("stats must exist");
+    assert_eq!(stats.total_failed, 300);
+    assert_eq!(stats.failed_episode_ids.len(), 256);
+}
+
+#[tokio::test]
+async fn queue_without_turso_backend_stays_synchronous() {
+    // Arrange: in-memory only, queue requested but nothing to drain to.
+    let memory = SelfLearningMemory::with_config(test_config());
+    let memory = memory.enable_durable_writes(WriteQueueConfig::default());
+
+    // Act.
+    let episode_id = start_episode(&memory, "local only").await;
+    memory
+        .complete_episode(episode_id, success_outcome())
+        .await
+        .expect("local completion must succeed");
+
+    // Assert: no queue was wired, flush is a no-op success.
+    assert!(memory.durable_write_stats().await.is_none());
+    memory
+        .flush_durable_writes(Duration::from_secs(1))
+        .await
+        .expect("flush without queue must succeed");
+    assert!(memory.get_episode(episode_id).await.is_ok());
+}

--- a/memory-storage-turso/src/trait_impls/mod.rs
+++ b/memory-storage-turso/src/trait_impls/mod.rs
@@ -24,6 +24,10 @@ impl StorageBackend for super::TursoStorage {
         super::TursoStorage::store_episode(self, episode).await
     }
 
+    async fn store_episodes_batch(&self, episodes: &[do_memory_core::Episode]) -> Result<()> {
+        super::TursoStorage::store_episodes_batch(self, episodes.to_vec()).await
+    }
+
     async fn get_episode(&self, id: uuid::Uuid) -> Result<Option<do_memory_core::Episode>> {
         super::TursoStorage::get_episode(self, id).await
     }


### PR DESCRIPTION
Closes #967.

## What
Opt-in (`MemoryConfig.durable_write_queue`, default `None`) background durable-write queue. With it enabled, `complete_episode` commits local state synchronously (cache/redb hard-errors preserved) and persists to Turso through a single ordered worker in transactional batches with retry/backoff. Disabled = behavior-preserving (existing ADR-075 durability tests pass untouched).

- Same-episode writes coalesce: the seam enqueue + sync pattern-path re-store collapse to one remote write (newest supplants).
- Backpressure is explicit (`QuotaExceeded` collected into the `Storage` error), never a silent drop.
- Retries are idempotent (`INSERT OR REPLACE`); permanent failures park in stats (capped IDs) + `EpisodeComplete` journal rows. Eviction reconcile paths are unaffected (they read a separate pending list, never journal rows).
- New API: `enable_durable_writes`, `start_durable_workers`, `flush_durable_writes`, `durable_write_stats`; `stop_workers` drains the write queue first.
- `StorageBackend::store_episodes_batch` added with a looping default (non-breaking); Turso overrides transactionally.

## Measured
- Completion with a 2s-remote mock returns in ~231µs (test `completion_returns_before_slow_remote_persists`).
- 7 integration tests: off-path latency, flush failure surfacing, retry-no-dup, backpressure, drain-on-shutdown, no-turso passthrough, failure-ID cap.

## Scope notes
- Crash-window: payloads live in the local cache synchronously; only not-yet-flushed remote rows are at risk on crash — `flush` before shutdown closes it (wired into `stop_workers`). Cross-restart backfill via `storage sync` is follow-up, not this PR.
- `start_episode$/log_step/flush_steps$ write paths stay synchronous (completion-path scope only).
- MCP `get_metrics` exposure of queue depth lands with #962 (observability wave item).

## Verification
- `nextest -p do-memory-core` ✅ 1903 passed; `--features csm` ✅ 1919 passed
- `nextest -p do-memory-storage-turso` ✅ 434 passed; `-p do-memory-cli` ✅ 572 passed
- `cargo test --doc -p do-memory-core` ✅ 164 passed; `cargo doc` ✅ clean
- `code-quality.sh fmt --workspace` + `clippy --workspace` ✅ zero warnings