### PR TITLE
feat(handoff): add compact checkpoint and handoff representation

### DIFF
--- a/docs/PLAYBOOKS_AND_CHECKPOINTS.md
+++ b/docs/PLAYBOOKS_AND_CHECKPOINTS.md
@@ -60,13 +60,37 @@ do-memory-cli episode checkpoint <episode-id> --reason "Long-running task pause"
 ```
 
 ### Performing a Handoff
-When you need to pass a task to another agent, generate a "Handoff Pack":
+When you need to pass a task to another agent, generate a "Handoff Pack".
 
+**Via CLI (compact by default, max 8 KB / ~2k tokens):**
 ```bash
 do-memory-cli episode handoff <checkpoint-id>
+do-memory-cli episode handoff <checkpoint-id> --max-bytes 4096
+do-memory-cli episode handoff <checkpoint-id> --full   # unbounded, audit/debug
+do-memory-cli episode resume <checkpoint-id>           # resumes the compact pack
 ```
 
-The handoff pack includes the most recent checkpoint, the episode history, and relevant patterns to help the new agent start with full context.
+**Via MCP (`get_handoff_pack`, compact by default):**
+```json
+{
+  "checkpoint_id": "checkpoint-id-from-checkpoint_episode",
+  "mode": "compact",
+  "max_bytes": 4096
+}
+```
+```json
+{
+  "checkpoint_id": "checkpoint-id-from-checkpoint_episode",
+  "mode": "full"
+}
+```
+Resume a compact pack with `resume_from_compact` (takes `compact_handoff`);
+resume a full pack with `resume_from_handoff` (takes `handoff_pack`).
+
+The compact pack carries the objective, status/progress, verified findings,
+decisions, pending actions, ID-only pattern/heuristic references, and the most
+recent step excerpts — plus an `omitted` receipt with exact counts of everything
+left out and a pointer to the full pack (`get_handoff_pack` in `full` mode).
 
 ---
 

--- a/memory-cli/src/commands/dispatch_episode.rs
+++ b/memory-cli/src/commands/dispatch_episode.rs
@@ -163,12 +163,26 @@ pub async fn handle_episode_command(
             reason,
             note,
         } => checkpoint(episode_id, reason, note, memory, config, format, dry_run).await,
-        EpisodeCommands::Handoff { checkpoint_id } => {
-            handoff(checkpoint_id, memory, config, format, dry_run).await
+        EpisodeCommands::Handoff {
+            checkpoint_id,
+            full,
+            max_bytes,
+        } => {
+            handoff(
+                checkpoint_id,
+                full,
+                max_bytes,
+                memory,
+                config,
+                format,
+                dry_run,
+            )
+            .await
         }
-        EpisodeCommands::Resume { checkpoint_id } => {
-            resume(checkpoint_id, memory, config, format, dry_run).await
-        }
+        EpisodeCommands::Resume {
+            checkpoint_id,
+            full,
+        } => resume(checkpoint_id, full, memory, config, format, dry_run).await,
         EpisodeCommands::Checkpoints { episode_id } => {
             crate::commands::episode::list_checkpoints(episode_id, memory, config, format).await
         }

--- a/memory-cli/src/commands/episode/core/checkpoint.rs
+++ b/memory-cli/src/commands/episode/core/checkpoint.rs
@@ -1,11 +1,13 @@
 //! Episode checkpoint CLI commands (ADR-044 Feature 3)
 
+use super::compact_handoff::CompactHandoffResult;
 use crate::config::Config;
 use crate::output::OutputFormat;
 use anyhow::{Result, anyhow};
 use do_memory_core::SelfLearningMemory;
 use do_memory_core::memory::checkpoint::{
-    checkpoint_episode, checkpoint_episode_with_note, get_handoff_pack, resume_from_handoff,
+    HandoffBudget, checkpoint_episode, checkpoint_episode_with_note, get_compact_handoff_pack,
+    get_handoff_pack, resume_from_compact, resume_from_handoff,
 };
 use serde::Serialize;
 use uuid::Uuid;
@@ -107,9 +109,14 @@ pub async fn list_checkpoints(
     Ok(())
 }
 
-/// Get a handoff pack from a checkpoint
+/// Get a handoff pack from a checkpoint.
+///
+/// Compact byte-budgeted profile by default; `--full` returns the unbounded
+/// pack for audit/debug use.
 pub async fn handoff(
     checkpoint_id: String,
+    full: bool,
+    max_bytes: Option<usize>,
     memory: &SelfLearningMemory,
     _config: &Config,
     format: OutputFormat,
@@ -119,6 +126,34 @@ pub async fn handoff(
     let checkpoint_uuid =
         Uuid::parse_str(&checkpoint_id).map_err(|e| anyhow!("Invalid checkpoint ID: {}", e))?;
 
+    if full {
+        return handoff_full(checkpoint_uuid, memory, format).await;
+    }
+
+    let mut budget = HandoffBudget::default();
+    if let Some(max_bytes) = max_bytes {
+        if max_bytes < 1024 {
+            return Err(anyhow!("max_bytes {max_bytes} below minimum 1024"));
+        }
+        budget.max_bytes = max_bytes;
+    }
+
+    // Get compact handoff pack
+    let pack = get_compact_handoff_pack(memory, checkpoint_uuid, budget)
+        .await
+        .map_err(|e| anyhow!("Failed to get handoff pack: {}", e))?;
+
+    let result = CompactHandoffResult::from(pack);
+    result.write(format)?;
+    Ok(())
+}
+
+/// Get the full unbounded handoff pack (audit/debug).
+async fn handoff_full(
+    checkpoint_uuid: Uuid,
+    memory: &SelfLearningMemory,
+    format: OutputFormat,
+) -> Result<()> {
     // Get handoff pack
     let handoff = get_handoff_pack(memory, checkpoint_uuid)
         .await
@@ -142,9 +177,13 @@ pub async fn handoff(
     Ok(())
 }
 
-/// Resume work from a handoff pack
+/// Resume work from a handoff pack.
+///
+/// Resumes from the default compact profile; `--full` resumes from the
+/// unbounded pack instead.
 pub async fn resume(
     checkpoint_id: String,
+    full: bool,
     memory: &SelfLearningMemory,
     _config: &Config,
     format: OutputFormat,
@@ -155,14 +194,25 @@ pub async fn resume(
         Uuid::parse_str(&checkpoint_id).map_err(|e| anyhow!("Invalid checkpoint ID: {}", e))?;
 
     // Get handoff pack first
-    let handoff = get_handoff_pack(memory, checkpoint_uuid)
-        .await
-        .map_err(|e| anyhow!("Failed to get handoff pack: {}", e))?;
+    let new_episode_id = if full {
+        let handoff = get_handoff_pack(memory, checkpoint_uuid)
+            .await
+            .map_err(|e| anyhow!("Failed to get handoff pack: {}", e))?;
 
-    // Resume from handoff
-    let new_episode_id = resume_from_handoff(memory, handoff)
-        .await
-        .map_err(|e| anyhow!("Failed to resume from handoff: {}", e))?;
+        // Resume from handoff
+        resume_from_handoff(memory, handoff)
+            .await
+            .map_err(|e| anyhow!("Failed to resume from handoff: {}", e))?
+    } else {
+        let pack = get_compact_handoff_pack(memory, checkpoint_uuid, HandoffBudget::default())
+            .await
+            .map_err(|e| anyhow!("Failed to get handoff pack: {}", e))?;
+
+        // Resume from compact handoff
+        resume_from_compact(memory, pack)
+            .await
+            .map_err(|e| anyhow!("Failed to resume from handoff: {}", e))?
+    };
 
     let result = ResumeResult {
         new_episode_id: new_episode_id.to_string(),
@@ -226,7 +276,7 @@ pub struct ResumeResult {
     pub checkpoint_id: String,
 }
 
-trait Output: Serialize {
+pub(super) trait Output: Serialize {
     fn write(&self, format: OutputFormat) -> Result<()>;
 }
 

--- a/memory-cli/src/commands/episode/core/compact_handoff.rs
+++ b/memory-cli/src/commands/episode/core/compact_handoff.rs
@@ -1,0 +1,253 @@
+//! Compact handoff CLI presentation (issue #965).
+//!
+//! Serializable views and human/JSON/YAML rendering for the byte-budgeted
+//! compact handoff profile. Full-pack rendering stays in `checkpoint`.
+
+use super::checkpoint::Output;
+use crate::output::OutputFormat;
+use anyhow::Result;
+use do_memory_core::memory::checkpoint::CompactHandoff;
+use serde::Serialize;
+
+/// Result of compact handoff pack retrieval
+#[derive(Debug, Serialize)]
+pub struct CompactHandoffResult {
+    /// Checkpoint ID
+    pub checkpoint_id: String,
+    /// Episode ID
+    pub episode_id: String,
+    /// Current goal
+    pub current_goal: String,
+    /// Episode phase at build time
+    pub status: String,
+    /// Steps completed at the checkpoint
+    pub steps_done: usize,
+    /// Total steps in the episode
+    pub steps_total: usize,
+    /// Verified findings
+    pub verified_findings: Vec<String>,
+    /// Critical decisions
+    pub decisions: Vec<String>,
+    /// Pending actions
+    pub pending_actions: Vec<String>,
+    /// Pattern ID references
+    pub pattern_refs: Vec<String>,
+    /// Heuristic ID references
+    pub heuristic_refs: Vec<String>,
+    /// Evidence excerpts (most recent steps)
+    pub evidence_excerpts: Vec<EvidenceExcerptView>,
+    /// Omitted steps / findings / decisions / actions / refs
+    pub omitted: OmittedView,
+    /// Serialized JSON payload size in bytes
+    pub payload_bytes: usize,
+    /// Heuristic token estimate
+    pub approx_tokens: usize,
+}
+
+/// Serializable evidence excerpt for CLI output
+#[derive(Debug, Serialize)]
+pub struct EvidenceExcerptView {
+    /// 1-indexed step number
+    pub step_number: usize,
+    /// Tool used
+    pub tool: String,
+    /// Action description
+    pub action: String,
+    /// Bounded result summary
+    pub result_summary: Option<String>,
+}
+
+/// Serializable omission account for CLI output
+#[derive(Debug, Serialize)]
+pub struct OmittedView {
+    /// Steps without an excerpt
+    pub omitted_steps: usize,
+    /// Findings dropped
+    pub omitted_findings: usize,
+    /// Decisions dropped
+    pub omitted_decisions: usize,
+    /// Pending actions dropped
+    pub omitted_pending_actions: usize,
+    /// Pattern references dropped
+    pub omitted_patterns: usize,
+    /// Heuristic references dropped
+    pub omitted_heuristics: usize,
+    /// Fields cut mid-string
+    pub truncated_fields: Vec<String>,
+    /// Pointer to the full-fidelity pack
+    pub full_available_via: String,
+}
+
+impl From<CompactHandoff> for CompactHandoffResult {
+    fn from(pack: CompactHandoff) -> Self {
+        let payload_bytes = pack.payload_bytes();
+        Self {
+            checkpoint_id: pack.checkpoint_id.to_string(),
+            episode_id: pack.episode_id.to_string(),
+            current_goal: pack.current_goal,
+            status: pack.status,
+            steps_done: pack.steps_done,
+            steps_total: pack.steps_total,
+            verified_findings: pack.verified_findings,
+            decisions: pack.decisions,
+            pending_actions: pack.pending_actions,
+            pattern_refs: pack.pattern_refs,
+            heuristic_refs: pack.heuristic_refs,
+            evidence_excerpts: pack
+                .evidence_excerpts
+                .into_iter()
+                .map(|e| EvidenceExcerptView {
+                    step_number: e.step_number,
+                    tool: e.tool,
+                    action: e.action,
+                    result_summary: e.result_summary,
+                })
+                .collect(),
+            omitted: OmittedView {
+                omitted_steps: pack.omitted.omitted_steps,
+                omitted_findings: pack.omitted.omitted_findings,
+                omitted_decisions: pack.omitted.omitted_decisions,
+                omitted_pending_actions: pack.omitted.omitted_pending_actions,
+                omitted_patterns: pack.omitted.omitted_patterns,
+                omitted_heuristics: pack.omitted.omitted_heuristics,
+                truncated_fields: pack.omitted.truncated_fields,
+                full_available_via: pack.omitted.full_available_via,
+            },
+            payload_bytes,
+            approx_tokens: pack.approx_tokens,
+        }
+    }
+}
+
+impl Output for CompactHandoffResult {
+    fn write(&self, format: OutputFormat) -> Result<()> {
+        match format {
+            OutputFormat::Json => {
+                println!("{}", serde_json::to_string_pretty(self)?);
+            }
+            OutputFormat::Human => {
+                println!("Compact Handoff for Checkpoint: {}", self.checkpoint_id);
+                println!("  Episode ID:      {}", self.episode_id);
+                println!("  Goal:            {}", self.current_goal);
+                println!(
+                    "  Status:          {} (step {}/{})",
+                    self.status, self.steps_done, self.steps_total
+                );
+                println!(
+                    "  Budget:          {} bytes (~{} tokens)",
+                    self.payload_bytes, self.approx_tokens
+                );
+                println!();
+
+                if !self.verified_findings.is_empty() {
+                    println!("Verified Findings:");
+                    for finding in &self.verified_findings {
+                        println!("  * {finding}");
+                    }
+                    println!();
+                }
+
+                if !self.decisions.is_empty() {
+                    println!("Decisions:");
+                    for decision in &self.decisions {
+                        println!("  # {decision}");
+                    }
+                    println!();
+                }
+
+                if !self.pending_actions.is_empty() {
+                    println!("Pending Actions:");
+                    for (i, action) in self.pending_actions.iter().enumerate() {
+                        println!("  {}. {action}", i + 1);
+                    }
+                    println!();
+                }
+
+                if !self.evidence_excerpts.is_empty() {
+                    println!("Evidence (most recent steps):");
+                    for excerpt in &self.evidence_excerpts {
+                        println!(
+                            "  [step {}] {}: {}",
+                            excerpt.step_number, excerpt.tool, excerpt.action
+                        );
+                    }
+                    println!();
+                }
+
+                let omitted = &self.omitted;
+                if omitted.omitted_steps > 0
+                    || omitted.omitted_findings > 0
+                    || omitted.omitted_decisions > 0
+                    || omitted.omitted_pending_actions > 0
+                    || omitted.omitted_patterns > 0
+                    || omitted.omitted_heuristics > 0
+                {
+                    println!(
+                        "Omitted: {} steps, {} findings, {} decisions, {} actions, {} patterns, {} heuristics",
+                        omitted.omitted_steps,
+                        omitted.omitted_findings,
+                        omitted.omitted_decisions,
+                        omitted.omitted_pending_actions,
+                        omitted.omitted_patterns,
+                        omitted.omitted_heuristics
+                    );
+                    println!("  Full pack: {}", omitted.full_available_via);
+                }
+            }
+            OutputFormat::Yaml => {
+                println!("{}", serde_yaml::to_string(self)?);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_result_maps_all_sections() {
+        use do_memory_core::memory::checkpoint::{
+            CompactHandoff, EvidenceExcerpt, OmissionMetadata,
+        };
+
+        let pack = CompactHandoff {
+            checkpoint_id: uuid::Uuid::nil(),
+            episode_id: uuid::Uuid::nil(),
+            timestamp: chrono::Utc::now(),
+            current_goal: "goal".to_string(),
+            status: "in_progress".to_string(),
+            steps_done: 3,
+            steps_total: 5,
+            verified_findings: vec!["finding".to_string()],
+            decisions: vec!["decision".to_string()],
+            pending_actions: vec!["action".to_string()],
+            pattern_refs: vec!["pattern-1".to_string()],
+            heuristic_refs: vec![],
+            evidence_excerpts: vec![EvidenceExcerpt {
+                step_number: 3,
+                tool: "tool".to_string(),
+                action: "did".to_string(),
+                result_summary: None,
+            }],
+            omitted: OmissionMetadata {
+                omitted_steps: 2,
+                ..OmissionMetadata::default()
+            },
+            approx_tokens: 100,
+        };
+
+        let result = CompactHandoffResult::from(pack);
+
+        assert_eq!(result.status, "in_progress");
+        assert_eq!((result.steps_done, result.steps_total), (3, 5));
+        assert_eq!(result.verified_findings, vec!["finding"]);
+        assert_eq!(result.pattern_refs, vec!["pattern-1"]);
+        assert_eq!(result.evidence_excerpts.len(), 1);
+        assert_eq!(result.evidence_excerpts[0].step_number, 3);
+        assert_eq!(result.omitted.omitted_steps, 2);
+        assert!(result.payload_bytes > 0);
+        assert_eq!(result.approx_tokens, 100);
+    }
+}

--- a/memory-cli/src/commands/episode/core/mod.rs
+++ b/memory-cli/src/commands/episode/core/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod bulk;
 pub mod checkpoint;
+pub mod compact_handoff;
 pub mod complete;
 pub mod create;
 pub mod delete;

--- a/memory-cli/src/commands/episode/core/types.rs
+++ b/memory-cli/src/commands/episode/core/types.rs
@@ -261,6 +261,15 @@ pub enum EpisodeCommands {
         /// Checkpoint ID to generate handoff pack from
         #[arg(value_name = "CHECKPOINT_ID")]
         checkpoint_id: String,
+
+        /// Return the full unbounded pack (audit/debug) instead of the
+        /// default byte-budgeted compact profile
+        #[arg(long)]
+        full: bool,
+
+        /// Compact payload ceiling in bytes (default 8192, minimum 1024)
+        #[arg(long, value_name = "BYTES")]
+        max_bytes: Option<usize>,
     },
 
     /// Resume work from a checkpoint in a new episode (ADR-044 Feature 3)
@@ -268,6 +277,10 @@ pub enum EpisodeCommands {
         /// Checkpoint ID to resume from
         #[arg(value_name = "CHECKPOINT_ID")]
         checkpoint_id: String,
+
+        /// Resume from the full pack instead of the default compact profile
+        #[arg(long)]
+        full: bool,
     },
 
     /// List checkpoints for an episode (ADR-044 Feature 3)

--- a/memory-core/src/lib.rs
+++ b/memory-core/src/lib.rs
@@ -268,7 +268,9 @@ pub use indexing::{
     spatiotemporal::{IndexStats, QueryOptions, SpatiotemporalIndex, TimeBucket},
 };
 pub use learning::queue::{PatternExtractionQueue, QueueConfig, QueueStats};
-pub use memory::checkpoint::{CheckpointMeta, HandoffPack};
+pub use memory::checkpoint::{
+    CheckpointMeta, CompactHandoff, EvidenceExcerpt, HandoffBudget, HandoffPack, OmissionMetadata,
+};
 pub use memory::filters::{EpisodeFilter, EpisodeFilterBuilder, OutcomeType};
 pub use memory::step_buffer::BatchConfig;
 pub use memory::{

--- a/memory-core/src/memory/checkpoint/compact.rs
+++ b/memory-core/src/memory/checkpoint/compact.rs
@@ -1,0 +1,478 @@
+//! Compact handoff packs with byte budgets (issue #965).
+//!
+//! Full [`HandoffPack`](super::types::HandoffPack) payloads embed every
+//! completed step, which inflates storage, retrieval payloads, and MCP
+//! context usage. This module builds the default compact profile instead:
+//!
+//! - task objective, status, and progress counters
+//! - verified findings, decisions, and pending actions (all count-capped)
+//! - bounded evidence excerpts (most recent steps, addressable by
+//!   `(episode_id, step_number)`)
+//! - ID-only pattern/heuristic references (bodies stay fetchable by ID)
+//! - explicit [`OmissionMetadata`] so receivers know what was left out and
+//!   where the full-fidelity pack lives
+//!
+//! ## Budget contract
+//!
+//! 1. Per-section count caps apply first (omissions recorded exactly).
+//! 2. The serialized JSON payload is then forced under
+//!    [`HandoffBudget::max_bytes`] by dropping whole items in reverse
+//!    priority (heuristic refs, pattern refs, oldest excerpts, pending
+//!    actions, decisions, findings) and, as a last resort, truncating the
+//!    goal. Every cut is recorded; string cuts are UTF-8 safe.
+//! 3. Assembly is deterministic: identical inputs yield identical bytes
+//!    (no map iteration, stable section order).
+//!
+//! Token counts are estimated as `bytes / 4` and documented as a heuristic,
+//! not a tokenizer guarantee.
+//!
+//! ## Budget floor
+//!
+//! The empty skeleton serializes to ~590 bytes and truncation receipts grow
+//! it (worst case ~950 bytes with a full receipt list), so budgets below
+//! ~1 KB are best-effort: the assembler drops everything droppable, records
+//! exact omissions, and returns the skeleton even if it exceeds the budget.
+//! Callers that need a hard guarantee should enforce a 1024-byte minimum
+//! (see `MIN_HANDOFF_BYTES` on the MCP input).
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::episode::ExecutionStep;
+use crate::error::Result;
+use crate::memory::SelfLearningMemory;
+use crate::types::ExecutionResult;
+use tracing::{info, instrument};
+
+/// Default payload ceiling in bytes (also ≈2k estimated tokens).
+pub const DEFAULT_HANDOFF_MAX_BYTES: usize = 8192;
+/// Default cap for verified findings.
+pub const DEFAULT_MAX_FINDINGS: usize = 10;
+/// Default cap for decisions.
+pub const DEFAULT_MAX_DECISIONS: usize = 10;
+/// Default cap for pending actions.
+pub const DEFAULT_MAX_PENDING_ACTIONS: usize = 10;
+/// Default cap for evidence excerpts.
+pub const DEFAULT_MAX_EVIDENCE_EXCERPTS: usize = 5;
+/// Default cap for pattern references.
+pub const DEFAULT_MAX_PATTERN_REFS: usize = 5;
+/// Default cap for heuristic references.
+pub const DEFAULT_MAX_HEURISTIC_REFS: usize = 5;
+/// Default cap for goal characters before the byte budget applies.
+pub const DEFAULT_MAX_GOAL_CHARS: usize = 500;
+/// Default cap for excerpt action/result characters.
+pub const DEFAULT_MAX_EXCERPT_CHARS: usize = 300;
+
+/// Size and count budget for a compact handoff pack.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HandoffBudget {
+    /// Serialized JSON ceiling in bytes.
+    pub max_bytes: usize,
+    /// Maximum verified findings (worked, then failed, then facts).
+    pub max_findings: usize,
+    /// Maximum decisions.
+    pub max_decisions: usize,
+    /// Maximum pending actions.
+    pub max_pending_actions: usize,
+    /// Maximum evidence excerpts (most recent steps win).
+    pub max_evidence_excerpts: usize,
+    /// Maximum pattern ID references.
+    pub max_pattern_refs: usize,
+    /// Maximum heuristic ID references.
+    pub max_heuristic_refs: usize,
+    /// Maximum goal characters (before byte-budget pressure).
+    pub max_goal_chars: usize,
+    /// Maximum characters per excerpt action/result summary.
+    pub max_excerpt_chars: usize,
+}
+
+impl Default for HandoffBudget {
+    fn default() -> Self {
+        Self {
+            max_bytes: DEFAULT_HANDOFF_MAX_BYTES,
+            max_findings: DEFAULT_MAX_FINDINGS,
+            max_decisions: DEFAULT_MAX_DECISIONS,
+            max_pending_actions: DEFAULT_MAX_PENDING_ACTIONS,
+            max_evidence_excerpts: DEFAULT_MAX_EVIDENCE_EXCERPTS,
+            max_pattern_refs: DEFAULT_MAX_PATTERN_REFS,
+            max_heuristic_refs: DEFAULT_MAX_HEURISTIC_REFS,
+            max_goal_chars: DEFAULT_MAX_GOAL_CHARS,
+            max_excerpt_chars: DEFAULT_MAX_EXCERPT_CHARS,
+        }
+    }
+}
+
+/// One bounded step excerpt. Addressable via `(episode_id, step_number)`
+/// on the owning [`CompactHandoff`]; full step bodies stay in the episode
+/// and in the full-fidelity pack.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvidenceExcerpt {
+    /// 1-indexed step number within the episode.
+    pub step_number: usize,
+    /// Tool used.
+    pub tool: String,
+    /// Action description (truncated to budget).
+    pub action: String,
+    /// Bounded result summary, if the step produced one.
+    pub result_summary: Option<String>,
+}
+
+/// Exact account of what the budget left out of a compact pack.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OmissionMetadata {
+    /// Completed steps without an excerpt.
+    pub omitted_steps: usize,
+    /// Findings dropped by the count cap or byte budget.
+    pub omitted_findings: usize,
+    /// Decisions dropped.
+    pub omitted_decisions: usize,
+    /// Pending actions dropped.
+    pub omitted_pending_actions: usize,
+    /// Pattern references dropped.
+    pub omitted_patterns: usize,
+    /// Heuristic references dropped.
+    pub omitted_heuristics: usize,
+    /// Fields cut mid-string (e.g. `"current_goal"`, `"evidence[2].action"`).
+    pub truncated_fields: Vec<String>,
+    /// Pointer to the full-fidelity pack (`get_handoff_pack`).
+    pub full_available_via: String,
+}
+
+impl Default for OmissionMetadata {
+    fn default() -> Self {
+        Self {
+            omitted_steps: 0,
+            omitted_findings: 0,
+            omitted_decisions: 0,
+            omitted_pending_actions: 0,
+            omitted_patterns: 0,
+            omitted_heuristics: 0,
+            truncated_fields: Vec::new(),
+            full_available_via: "get_handoff_pack(checkpoint_id)".to_string(),
+        }
+    }
+}
+
+/// Default compact handoff profile: bounded context with omission receipts.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CompactHandoff {
+    /// Checkpoint this pack was derived from.
+    pub checkpoint_id: Uuid,
+    /// Source episode.
+    pub episode_id: Uuid,
+    /// When the pack was built.
+    pub timestamp: DateTime<Utc>,
+    /// Task objective (byte-budgeted).
+    pub current_goal: String,
+    /// Episode phase at build time (`in_progress` or `completed`).
+    pub status: String,
+    /// Steps completed at the checkpoint.
+    pub steps_done: usize,
+    /// Total steps in the episode.
+    pub steps_total: usize,
+    /// Established findings, worked first.
+    pub verified_findings: Vec<String>,
+    /// Critical decisions with rationale.
+    pub decisions: Vec<String>,
+    /// Actions still pending.
+    pub pending_actions: Vec<String>,
+    /// Pattern IDs (fetch bodies by ID; full pack embeds them).
+    pub pattern_refs: Vec<String>,
+    /// Heuristic IDs (fetch bodies by ID).
+    pub heuristic_refs: Vec<String>,
+    /// Most recent step excerpts, chronological.
+    pub evidence_excerpts: Vec<EvidenceExcerpt>,
+    /// Exact omission account.
+    pub omitted: OmissionMetadata,
+    /// Heuristic token estimate (`payload_bytes / 4`).
+    pub approx_tokens: usize,
+}
+
+impl CompactHandoff {
+    /// Serialized JSON payload size in bytes (the budgeted unit).
+    #[must_use]
+    pub fn payload_bytes(&self) -> usize {
+        serde_json::to_string(self)
+            .map(|s| s.len())
+            .unwrap_or(usize::MAX)
+    }
+}
+
+/// Owned inputs for [`assemble_compact`]; keeps the assembler pure and
+/// deterministic (unit-testable without a memory system).
+#[derive(Debug, Clone)]
+pub struct CompactInputs {
+    /// Checkpoint this pack derives from.
+    pub checkpoint_id: Uuid,
+    /// Source episode.
+    pub episode_id: Uuid,
+    /// Build timestamp.
+    pub timestamp: DateTime<Utc>,
+    /// Task objective.
+    pub current_goal: String,
+    /// Episode phase (`in_progress` or `completed`).
+    pub status: String,
+    /// Steps completed at the checkpoint.
+    pub steps_done: usize,
+    /// Total steps in the episode.
+    pub steps_total: usize,
+    /// Completed steps up to the checkpoint, chronological.
+    pub steps: Vec<ExecutionStep>,
+    /// Observed successes.
+    pub worked: Vec<String>,
+    /// Observed failures.
+    pub failed: Vec<String>,
+    /// Extractor salient facts.
+    pub salient_facts: Vec<String>,
+    /// Critical decisions.
+    pub decisions: Vec<String>,
+    /// Suggested next steps.
+    pub pending_actions: Vec<String>,
+    /// Pattern IDs.
+    pub pattern_ids: Vec<String>,
+    /// Heuristic IDs.
+    pub heuristic_ids: Vec<String>,
+}
+
+/// Truncate to a character boundary, reporting whether a cut happened.
+fn truncate_chars(text: &str, max_chars: usize) -> (String, bool) {
+    if text.chars().count() <= max_chars {
+        return (text.to_string(), false);
+    }
+    let cut: String = text.chars().take(max_chars).collect();
+    (cut, true)
+}
+
+/// Bounded one-line summary of a step result, plus whether it was cut.
+fn summarize_result(result: &Option<ExecutionResult>, max_chars: usize) -> (Option<String>, bool) {
+    let text = match result {
+        None => return (None, false),
+        Some(ExecutionResult::Success { output }) => output.clone(),
+        Some(ExecutionResult::Error { message }) => format!("error: {message}"),
+        Some(ExecutionResult::Timeout) => "timeout".to_string(),
+    };
+    let (cut, was_cut) = truncate_chars(&text, max_chars);
+    (Some(cut), was_cut)
+}
+
+/// Assemble a budget-compliant compact pack. See the module docs for the
+/// exact contract (count caps, then byte budget, deterministic order).
+#[must_use]
+pub fn assemble_compact(inputs: CompactInputs, budget: &HandoffBudget) -> CompactHandoff {
+    let mut truncated_fields: Vec<String> = Vec::new();
+
+    let (current_goal, goal_cut) = truncate_chars(&inputs.current_goal, budget.max_goal_chars);
+    if goal_cut {
+        truncated_fields.push("current_goal".to_string());
+    }
+
+    // Findings priority: worked, then failed, then extractor facts.
+    let mut findings: Vec<String> = Vec::new();
+    findings.extend(inputs.worked);
+    findings.extend(inputs.failed);
+    findings.extend(inputs.salient_facts);
+    let omitted_findings = findings.len().saturating_sub(budget.max_findings);
+    findings.truncate(budget.max_findings);
+
+    let mut decisions = inputs.decisions;
+    let omitted_decisions = decisions.len().saturating_sub(budget.max_decisions);
+    decisions.truncate(budget.max_decisions);
+
+    let mut pending_actions = inputs.pending_actions;
+    let omitted_pending = pending_actions
+        .len()
+        .saturating_sub(budget.max_pending_actions);
+    pending_actions.truncate(budget.max_pending_actions);
+
+    let mut pattern_refs = inputs.pattern_ids;
+    let omitted_patterns = pattern_refs.len().saturating_sub(budget.max_pattern_refs);
+    pattern_refs.truncate(budget.max_pattern_refs);
+
+    let mut heuristic_refs = inputs.heuristic_ids;
+    let omitted_heuristics = heuristic_refs
+        .len()
+        .saturating_sub(budget.max_heuristic_refs);
+    heuristic_refs.truncate(budget.max_heuristic_refs);
+
+    // Most recent steps win; excerpts stay chronological.
+    let omitted_steps = inputs
+        .steps
+        .len()
+        .saturating_sub(budget.max_evidence_excerpts);
+    let kept_from = inputs
+        .steps
+        .len()
+        .saturating_sub(budget.max_evidence_excerpts);
+    let mut evidence_excerpts: Vec<EvidenceExcerpt> = Vec::new();
+    for (position, step) in inputs.steps[kept_from..].iter().enumerate() {
+        let (action, action_cut) = truncate_chars(&step.action, budget.max_excerpt_chars);
+        if action_cut {
+            truncated_fields.push(format!("evidence[{position}].action"));
+        }
+        let (summary, summary_cut) = summarize_result(&step.result, budget.max_excerpt_chars);
+        if summary_cut {
+            truncated_fields.push(format!("evidence[{position}].result_summary"));
+        }
+        evidence_excerpts.push(EvidenceExcerpt {
+            step_number: step.step_number,
+            tool: step.tool.clone(),
+            action,
+            result_summary: summary,
+        });
+    }
+
+    let mut pack = CompactHandoff {
+        checkpoint_id: inputs.checkpoint_id,
+        episode_id: inputs.episode_id,
+        timestamp: inputs.timestamp,
+        current_goal,
+        status: inputs.status,
+        steps_done: inputs.steps_done,
+        steps_total: inputs.steps_total,
+        verified_findings: findings,
+        decisions,
+        pending_actions,
+        pattern_refs,
+        heuristic_refs,
+        evidence_excerpts,
+        omitted: OmissionMetadata {
+            omitted_steps,
+            omitted_findings,
+            omitted_decisions,
+            omitted_pending_actions: omitted_pending,
+            omitted_patterns,
+            omitted_heuristics,
+            truncated_fields,
+            ..OmissionMetadata::default()
+        },
+        approx_tokens: 0,
+    };
+
+    enforce_byte_budget(&mut pack, budget);
+    let bytes = pack.payload_bytes();
+    pack.approx_tokens = bytes / 4;
+    pack
+}
+
+/// Drop whole items in reverse priority until the JSON fits `max_bytes`.
+/// Counts flow back into the omission metadata; the goal truncates last.
+/// Best-effort when even the skeleton exceeds the budget (documented).
+fn enforce_byte_budget(pack: &mut CompactHandoff, budget: &HandoffBudget) {
+    loop {
+        if pack.payload_bytes() <= budget.max_bytes {
+            return;
+        }
+        if pack.heuristic_refs.pop().is_some() {
+            pack.omitted.omitted_heuristics += 1;
+        } else if pack.pattern_refs.pop().is_some() {
+            pack.omitted.omitted_patterns += 1;
+        } else if !pack.evidence_excerpts.is_empty() {
+            // Excerpts are chronological; the oldest goes first so the most
+            // recent context (highest resume value) survives the longest.
+            pack.evidence_excerpts.remove(0);
+            pack.omitted.omitted_steps += 1;
+        } else if pack.pending_actions.pop().is_some() {
+            pack.omitted.omitted_pending_actions += 1;
+        } else if pack.decisions.pop().is_some() {
+            pack.omitted.omitted_decisions += 1;
+        } else if pack.verified_findings.pop().is_some() {
+            pack.omitted.omitted_findings += 1;
+        } else if !pack.current_goal.is_empty() {
+            // Last resort: halve the goal (UTF-8 safe) until it fits.
+            let half = pack.current_goal.chars().count() / 2;
+            let (cut, _) = truncate_chars(&pack.current_goal, half);
+            pack.current_goal = cut;
+            if !pack
+                .omitted
+                .truncated_fields
+                .contains(&"current_goal".to_string())
+            {
+                pack.omitted
+                    .truncated_fields
+                    .push("current_goal".to_string());
+            }
+            if half == 0 {
+                return;
+            }
+        } else {
+            return;
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "compact_tests.rs"]
+mod tests;
+
+/// Resume work from a compact handoff pack.
+///
+/// Creates a new episode carrying the compact goal, findings, decisions,
+/// and pending actions as metadata, plus pointers back to the source
+/// checkpoint for full-fidelity fetch.
+#[instrument(skip(memory, handoff), fields(checkpoint_id = %handoff.checkpoint_id))]
+pub async fn resume_from_compact(
+    memory: &SelfLearningMemory,
+    handoff: CompactHandoff,
+) -> Result<Uuid> {
+    info!(
+        "Resuming from compact handoff: checkpoint_id={}, findings={}, pending={}",
+        handoff.checkpoint_id,
+        handoff.verified_findings.len(),
+        handoff.pending_actions.len()
+    );
+
+    let context = crate::types::TaskContext {
+        domain: "resumed".to_string(),
+        language: None,
+        framework: None,
+        complexity: crate::types::ComplexityLevel::Moderate,
+        tags: vec![
+            "resumed".to_string(),
+            "compact".to_string(),
+            format!("from-{}", handoff.episode_id),
+        ],
+    };
+
+    let new_episode_id = memory
+        .start_episode(
+            handoff.current_goal.clone(),
+            context,
+            crate::types::TaskType::Other,
+        )
+        .await;
+
+    let mut episode = memory.get_episode(new_episode_id).await?;
+    episode.metadata.insert(
+        "resumed_from_checkpoint".to_string(),
+        handoff.checkpoint_id.to_string(),
+    );
+    episode.metadata.insert(
+        "resumed_from_episode".to_string(),
+        handoff.episode_id.to_string(),
+    );
+    episode
+        .metadata
+        .insert("handoff_format".to_string(), "compact".to_string());
+    episode.metadata.insert(
+        "compact_findings".to_string(),
+        serde_json::to_string(&handoff.verified_findings).unwrap_or_default(),
+    );
+    episode.metadata.insert(
+        "compact_decisions".to_string(),
+        serde_json::to_string(&handoff.decisions).unwrap_or_default(),
+    );
+    episode.metadata.insert(
+        "compact_pending_actions".to_string(),
+        serde_json::to_string(&handoff.pending_actions).unwrap_or_default(),
+    );
+    episode.metadata.insert(
+        "compact_omitted_steps".to_string(),
+        handoff.omitted.omitted_steps.to_string(),
+    );
+    memory.update_episode_full(&episode).await?;
+
+    info!(new_episode_id = %new_episode_id, "Created new episode for compact resumption");
+
+    Ok(new_episode_id)
+}

--- a/memory-core/src/memory/checkpoint/compact_tests.rs
+++ b/memory-core/src/memory/checkpoint/compact_tests.rs
@@ -1,0 +1,189 @@
+//! Unit tests for compact handoff packs (issue #965).
+
+use super::*;
+use crate::episode::ExecutionStep;
+
+fn step(number: usize, tool: &str, action: &str) -> ExecutionStep {
+    let mut step = ExecutionStep::new(number, tool.to_string(), action.to_string());
+    step.result = Some(ExecutionResult::Success {
+        output: format!("output of step {number}"),
+    });
+    step
+}
+
+fn sample_inputs(steps: usize) -> CompactInputs {
+    CompactInputs {
+        checkpoint_id: Uuid::new_v4(),
+        episode_id: Uuid::new_v4(),
+        timestamp: Utc::now(),
+        current_goal: "Ship the thing".to_string(),
+        status: "in_progress".to_string(),
+        steps_done: steps,
+        steps_total: steps + 2,
+        steps: (1..=steps)
+            .map(|i| step(i, "tool", &format!("action {i}")))
+            .collect(),
+        worked: vec!["worked A".to_string()],
+        failed: vec!["failed B".to_string()],
+        salient_facts: vec!["fact C".to_string()],
+        decisions: vec!["decision D".to_string()],
+        pending_actions: vec!["next E".to_string()],
+        pattern_ids: vec!["pattern-1".to_string()],
+        heuristic_ids: vec!["heuristic-1".to_string()],
+    }
+}
+
+#[test]
+fn compact_budget_defaults_are_sane() {
+    let budget = HandoffBudget::default();
+
+    assert_eq!(budget.max_bytes, DEFAULT_HANDOFF_MAX_BYTES);
+    assert!(budget.max_bytes >= 1024);
+    assert!(budget.max_findings > 0);
+    assert!(budget.max_evidence_excerpts > 0);
+}
+
+#[test]
+fn compact_payload_complies_with_tight_budget() {
+    let inputs = sample_inputs(50);
+    let budget = HandoffBudget {
+        max_bytes: 2048,
+        max_evidence_excerpts: 3,
+        ..HandoffBudget::default()
+    };
+
+    let pack = assemble_compact(inputs, &budget);
+
+    assert!(
+        pack.payload_bytes() <= budget.max_bytes,
+        "payload {} exceeds {}",
+        pack.payload_bytes(),
+        budget.max_bytes
+    );
+    assert_eq!(pack.evidence_excerpts.len(), 3);
+    // Most recent steps win, chronological order kept.
+    assert_eq!(pack.evidence_excerpts[0].step_number, 48);
+    assert_eq!(pack.evidence_excerpts[2].step_number, 50);
+    assert_eq!(pack.omitted.omitted_steps, 47);
+    assert_eq!(
+        pack.omitted.full_available_via,
+        "get_handoff_pack(checkpoint_id)"
+    );
+    assert_eq!(pack.approx_tokens, pack.payload_bytes() / 4);
+}
+
+#[test]
+fn compact_assembly_is_deterministic() {
+    let budget = HandoffBudget::default();
+    let inputs = sample_inputs(12);
+    let first = assemble_compact(inputs.clone(), &budget);
+    let second = assemble_compact(inputs, &budget);
+
+    assert_eq!(
+        serde_json::to_value(&first).unwrap(),
+        serde_json::to_value(&second).unwrap()
+    );
+}
+
+#[test]
+fn compact_omission_counts_are_exact() {
+    let mut inputs = sample_inputs(4);
+    inputs.worked = (0..6).map(|i| format!("worked {i}")).collect();
+    inputs.failed = (0..6).map(|i| format!("failed {i}")).collect();
+    inputs.salient_facts = (0..6).map(|i| format!("fact {i}")).collect();
+    let budget = HandoffBudget {
+        max_bytes: usize::MAX,
+        max_findings: 5,
+        ..HandoffBudget::default()
+    };
+
+    let pack = assemble_compact(inputs, &budget);
+
+    // Priority: worked, then failed, then facts.
+    assert_eq!(pack.verified_findings.len(), 5);
+    assert!(pack.verified_findings[0].starts_with("worked"));
+    assert_eq!(pack.omitted.omitted_findings, 18 - 5);
+}
+
+#[test]
+fn compact_goal_truncation_is_utf8_safe() {
+    let mut inputs = sample_inputs(1);
+    inputs.current_goal = "ééééé done".to_string();
+    let budget = HandoffBudget {
+        max_bytes: usize::MAX,
+        max_goal_chars: 4,
+        ..HandoffBudget::default()
+    };
+
+    let pack = assemble_compact(inputs, &budget);
+
+    assert_eq!(pack.current_goal, "éééé");
+    assert_eq!(pack.omitted.truncated_fields, vec!["current_goal"]);
+}
+
+#[test]
+fn compact_byte_pressure_cascades_into_knowledge_sections() {
+    let mut inputs = sample_inputs(20);
+    inputs.steps = (1..=20)
+        .map(|i| {
+            let mut excerpt = step(i, "tool", &format!("action {i}"));
+            excerpt.result = Some(ExecutionResult::Success {
+                output: "z".repeat(400),
+            });
+            excerpt
+        })
+        .collect();
+    // Long knowledge sections so pressure cascades past excerpts into them.
+    inputs.worked = vec!["w".repeat(300)];
+    inputs.failed = vec!["f".repeat(300)];
+    inputs.salient_facts = vec!["s".repeat(300)];
+    inputs.decisions = vec!["d".repeat(300)];
+    inputs.pending_actions = vec!["p".repeat(300)];
+    let budget = HandoffBudget {
+        max_bytes: 1100,
+        ..HandoffBudget::default()
+    };
+
+    let pack = assemble_compact(inputs, &budget);
+
+    assert!(
+        pack.payload_bytes() <= budget.max_bytes,
+        "payload {} exceeds {}",
+        pack.payload_bytes(),
+        budget.max_bytes
+    );
+    // Pressure passed refs and excerpts into pending/decisions/findings.
+    let deep_omissions = pack.omitted.omitted_pending_actions
+        + pack.omitted.omitted_decisions
+        + pack.omitted.omitted_findings;
+    assert!(
+        deep_omissions > 0,
+        "expected cascade past excerpts: {:?}",
+        pack.omitted
+    );
+}
+
+#[test]
+fn compact_sub_floor_budget_returns_best_effort_skeleton() {
+    let inputs = sample_inputs(20);
+    let budget = HandoffBudget {
+        max_bytes: 200,
+        ..HandoffBudget::default()
+    };
+
+    let pack = assemble_compact(inputs, &budget);
+
+    // Below the ~1 KB floor compliance is impossible (skeleton + receipts);
+    // everything droppable is dropped and omissions stay exact.
+    assert!(pack.verified_findings.is_empty());
+    assert!(pack.decisions.is_empty());
+    assert!(pack.pending_actions.is_empty());
+    assert!(pack.evidence_excerpts.is_empty());
+    assert!(pack.current_goal.is_empty());
+    assert_eq!(pack.omitted.omitted_steps, 20);
+    assert_eq!(pack.omitted.omitted_findings, 3);
+    assert_eq!(pack.omitted.omitted_decisions, 1);
+    assert_eq!(pack.omitted.omitted_pending_actions, 1);
+    assert_eq!(pack.omitted.omitted_patterns, 1);
+    assert_eq!(pack.omitted.omitted_heuristics, 1);
+}

--- a/memory-core/src/memory/checkpoint/mod.rs
+++ b/memory-core/src/memory/checkpoint/mod.rs
@@ -31,11 +31,16 @@
 //! # }
 //! ```
 
+mod compact;
 mod operations;
 mod types;
 
+pub use compact::{
+    CompactHandoff, CompactInputs, EvidenceExcerpt, HandoffBudget, OmissionMetadata,
+    assemble_compact, resume_from_compact,
+};
 pub use operations::{
-    checkpoint_episode, checkpoint_episode_with_note, get_handoff_pack,
+    checkpoint_episode, checkpoint_episode_with_note, get_compact_handoff_pack, get_handoff_pack,
     list_abstention_checkpoints, maybe_create_abstention_checkpoint, resume_from_handoff,
 };
 pub use types::{CheckpointMeta, HandoffPack};

--- a/memory-core/src/memory/checkpoint/operations.rs
+++ b/memory-core/src/memory/checkpoint/operations.rs
@@ -11,7 +11,8 @@ use chrono::Utc;
 use tracing::{info, instrument, warn};
 use uuid::Uuid;
 
-use super::{CheckpointMeta, HandoffPack};
+use super::compact::assemble_compact;
+use super::{CheckpointMeta, CompactHandoff, CompactInputs, HandoffBudget, HandoffPack};
 use crate::episode::Episode;
 use crate::types::TaskOutcome;
 
@@ -224,6 +225,89 @@ pub async fn resume_from_handoff(
     info!(new_episode_id = %new_episode_id, "Created new episode for resumption");
 
     Ok(new_episode_id)
+}
+
+/// Generate a budget-compliant compact handoff pack (issue #965).
+///
+/// Default handoff profile: bounded context (objective, status, findings,
+/// decisions, pending actions, ID references, recent evidence excerpts)
+/// with exact omission receipts. The full-fidelity [`get_handoff_pack`]
+/// remains available for audit/debug use.
+#[instrument(skip(memory), fields(checkpoint_id = %checkpoint_id))]
+pub async fn get_compact_handoff_pack(
+    memory: &SelfLearningMemory,
+    checkpoint_id: Uuid,
+    budget: HandoffBudget,
+) -> Result<CompactHandoff> {
+    info!("Generating compact handoff pack for checkpoint: {checkpoint_id}");
+
+    let (episode, checkpoint) = find_checkpoint(memory, checkpoint_id).await?;
+
+    let steps_completed: Vec<ExecutionStep> = episode
+        .steps
+        .iter()
+        .take(checkpoint.step_number)
+        .cloned()
+        .collect();
+
+    let (what_worked, what_failed, salient_facts) =
+        extract_lessons(memory, &episode, checkpoint.step_number);
+
+    // Decisions stay separate from the merged lesson facts: re-extract the
+    // critical decisions from the same partial-episode view.
+    let mut partial_episode = episode.clone();
+    partial_episode.steps.truncate(checkpoint.step_number);
+    let decisions = memory
+        .salient_extractor
+        .extract(&partial_episode)
+        .critical_decisions;
+
+    let pending_actions = generate_suggested_next_steps(memory, &episode).await;
+    let pattern_ids = get_relevant_patterns(memory, &episode)
+        .await
+        .iter()
+        .map(|r| r.pattern.id().to_string())
+        .collect();
+    let heuristic_ids = get_relevant_heuristics(memory, &episode)
+        .await
+        .iter()
+        .map(|h| h.heuristic_id.to_string())
+        .collect();
+
+    let status = if episode.is_complete() {
+        "completed".to_string()
+    } else {
+        "in_progress".to_string()
+    };
+
+    let pack = assemble_compact(
+        CompactInputs {
+            checkpoint_id: checkpoint.checkpoint_id,
+            episode_id: episode.episode_id,
+            timestamp: Utc::now(),
+            current_goal: episode.task_description.clone(),
+            status,
+            steps_done: checkpoint.step_number,
+            steps_total: episode.steps.len(),
+            steps: steps_completed,
+            worked: what_worked,
+            failed: what_failed,
+            salient_facts,
+            decisions,
+            pending_actions,
+            pattern_ids,
+            heuristic_ids,
+        },
+        &budget,
+    );
+
+    info!(
+        payload_bytes = pack.payload_bytes(),
+        omitted_steps = pack.omitted.omitted_steps,
+        "Generated compact handoff pack"
+    );
+
+    Ok(pack)
 }
 
 /// Find an episode and checkpoint by checkpoint ID.

--- a/memory-core/src/memory/checkpoint/operations_tests.rs
+++ b/memory-core/src/memory/checkpoint/operations_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::memory::checkpoint::resume_from_compact;
 use crate::types::{TaskContext, TaskType};
 
 #[tokio::test]
@@ -54,4 +55,125 @@ async fn test_checkpoint_completed_episode() {
 
     let result = checkpoint_episode(&memory, episode_id, "test".to_string()).await;
     assert!(result.is_err());
+}
+
+async fn start_episode_with_steps(
+    memory: &SelfLearningMemory,
+    task: &str,
+    steps: usize,
+) -> uuid::Uuid {
+    use crate::types::ExecutionResult;
+
+    let episode_id = memory
+        .start_episode(task.to_string(), TaskContext::default(), TaskType::Testing)
+        .await;
+    for i in 1..=steps {
+        let mut step = crate::episode::ExecutionStep::new(
+            i,
+            "test_tool".to_string(),
+            format!("test action {i}"),
+        );
+        step.result = Some(ExecutionResult::Success {
+            output: format!("test output {i}"),
+        });
+        memory.log_step(episode_id, step).await;
+    }
+    episode_id
+}
+
+#[tokio::test]
+async fn test_compact_handoff_pack_default_budget() {
+    use crate::memory::MemoryConfig;
+
+    let memory = SelfLearningMemory::with_config(MemoryConfig {
+        quality_threshold: 0.0,
+        batch_config: None,
+        ..Default::default()
+    });
+    let episode_id = start_episode_with_steps(&memory, "Compact the thing", 5).await;
+    let checkpoint = checkpoint_episode(&memory, episode_id, "pause".to_string())
+        .await
+        .unwrap();
+
+    let pack =
+        get_compact_handoff_pack(&memory, checkpoint.checkpoint_id, HandoffBudget::default())
+            .await
+            .unwrap();
+
+    assert_eq!(pack.episode_id, episode_id);
+    assert_eq!(pack.current_goal, "Compact the thing");
+    assert_eq!(pack.status, "in_progress");
+    assert_eq!(pack.steps_done, checkpoint.step_number);
+    assert!(pack.payload_bytes() <= HandoffBudget::default().max_bytes);
+    assert_eq!(pack.evidence_excerpts.len(), 5);
+    assert_eq!(pack.omitted.omitted_steps, 0);
+    assert!(!pack.verified_findings.is_empty());
+}
+
+#[tokio::test]
+async fn test_compact_handoff_tiny_budget_reports_omissions() {
+    use crate::memory::MemoryConfig;
+
+    let memory = SelfLearningMemory::with_config(MemoryConfig {
+        quality_threshold: 0.0,
+        batch_config: None,
+        ..Default::default()
+    });
+    let episode_id = start_episode_with_steps(&memory, "Long task", 20).await;
+    let checkpoint = checkpoint_episode(&memory, episode_id, "pause".to_string())
+        .await
+        .unwrap();
+    let budget = HandoffBudget {
+        max_bytes: 700,
+        max_evidence_excerpts: 2,
+        ..HandoffBudget::default()
+    };
+
+    let pack = get_compact_handoff_pack(&memory, checkpoint.checkpoint_id, budget.clone())
+        .await
+        .unwrap();
+
+    assert!(pack.payload_bytes() <= budget.max_bytes);
+    assert!(pack.evidence_excerpts.len() <= 2);
+    assert!(pack.omitted.omitted_steps >= 18);
+    assert_eq!(
+        pack.omitted.full_available_via,
+        "get_handoff_pack(checkpoint_id)"
+    );
+}
+
+#[tokio::test]
+async fn test_resume_from_compact_preserves_context() {
+    use crate::memory::MemoryConfig;
+
+    let memory = SelfLearningMemory::with_config(MemoryConfig {
+        quality_threshold: 0.0,
+        batch_config: None,
+        ..Default::default()
+    });
+    let episode_id = start_episode_with_steps(&memory, "Resume me", 3).await;
+    let checkpoint = checkpoint_episode(&memory, episode_id, "switch".to_string())
+        .await
+        .unwrap();
+    let pack =
+        get_compact_handoff_pack(&memory, checkpoint.checkpoint_id, HandoffBudget::default())
+            .await
+            .unwrap();
+
+    let new_id = resume_from_compact(&memory, pack).await.unwrap();
+    let resumed = memory.get_episode(new_id).await.unwrap();
+
+    assert_eq!(resumed.task_description, "Resume me");
+    assert_eq!(
+        resumed.metadata.get("handoff_format").map(String::as_str),
+        Some("compact")
+    );
+    assert_eq!(
+        resumed
+            .metadata
+            .get("resumed_from_checkpoint")
+            .map(String::as_str),
+        Some(checkpoint.checkpoint_id.to_string()).as_deref()
+    );
+    assert!(resumed.metadata.contains_key("compact_pending_actions"));
 }

--- a/memory-mcp/src/bin/server_impl/handlers/batch_execute.rs
+++ b/memory-mcp/src/bin/server_impl/handlers/batch_execute.rs
@@ -13,10 +13,10 @@ use super::super::tools::{
     handle_get_topological_order, handle_health_check, handle_quality_metrics, handle_query_memory,
     handle_query_semantic_memory, handle_recommend_patterns, handle_recommend_playbook,
     handle_record_recommendation_feedback, handle_record_recommendation_session,
-    handle_remove_episode_relationship, handle_remove_episode_tags, handle_resume_from_handoff,
-    handle_search_by_embedding, handle_search_episodes_by_tags, handle_search_patterns,
-    handle_set_episode_tags, handle_test_agentfs_connection, handle_test_embeddings,
-    handle_update_episode, handle_validate_no_cycles,
+    handle_remove_episode_relationship, handle_remove_episode_tags, handle_resume_from_compact,
+    handle_resume_from_handoff, handle_search_by_embedding, handle_search_episodes_by_tags,
+    handle_search_patterns, handle_set_episode_tags, handle_test_agentfs_connection,
+    handle_test_embeddings, handle_update_episode, handle_validate_no_cycles,
 };
 use do_memory_mcp::MemoryMCPServer;
 use do_memory_mcp::jsonrpc::{JsonRpcError, JsonRpcRequest, JsonRpcResponse};
@@ -143,6 +143,9 @@ pub async fn handle_batch_execute(
                 "get_handoff_pack" => handle_get_handoff_pack(&mut server, Some(arguments)).await,
                 "resume_from_handoff" => {
                     handle_resume_from_handoff(&mut server, Some(arguments)).await
+                }
+                "resume_from_compact" => {
+                    handle_resume_from_compact(&mut server, Some(arguments)).await
                 }
                 "bulk_episodes" => handle_bulk_episodes(&mut server, Some(arguments)).await,
                 "create_episode" => handle_create_episode(&mut server, Some(arguments)).await,

--- a/memory-mcp/src/bin/server_impl/handlers/call_tool.rs
+++ b/memory-mcp/src/bin/server_impl/handlers/call_tool.rs
@@ -13,10 +13,10 @@ use super::super::tools::{
     handle_get_topological_order, handle_health_check, handle_quality_metrics, handle_query_memory,
     handle_query_semantic_memory, handle_recommend_patterns, handle_recommend_playbook,
     handle_record_recommendation_feedback, handle_record_recommendation_session,
-    handle_remove_episode_relationship, handle_remove_episode_tags, handle_resume_from_handoff,
-    handle_search_by_embedding, handle_search_episodes_by_tags, handle_search_patterns,
-    handle_set_episode_tags, handle_test_agentfs_connection, handle_test_embeddings,
-    handle_update_episode, handle_validate_no_cycles,
+    handle_remove_episode_relationship, handle_remove_episode_tags, handle_resume_from_compact,
+    handle_resume_from_handoff, handle_search_by_embedding, handle_search_episodes_by_tags,
+    handle_search_patterns, handle_set_episode_tags, handle_test_agentfs_connection,
+    handle_test_embeddings, handle_update_episode, handle_validate_no_cycles,
 };
 use super::super::types::{CallToolParams, CallToolResult, Content};
 use do_memory_mcp::MemoryMCPServer;
@@ -159,6 +159,7 @@ pub async fn handle_call_tool(
         "checkpoint_episode" => handle_checkpoint_episode(&mut server, params.arguments).await,
         "get_handoff_pack" => handle_get_handoff_pack(&mut server, params.arguments).await,
         "resume_from_handoff" => handle_resume_from_handoff(&mut server, params.arguments).await,
+        "resume_from_compact" => handle_resume_from_compact(&mut server, params.arguments).await,
         // External signal provider tools
         "configure_agentfs" => handle_configure_agentfs(&mut server, params.arguments).await,
         "external_signal_status" => {

--- a/memory-mcp/src/bin/server_impl/tools/feature_handlers.rs
+++ b/memory-mcp/src/bin/server_impl/tools/feature_handlers.rs
@@ -362,3 +362,22 @@ pub async fn handle_resume_from_handoff(
     }];
     Ok(content)
 }
+
+/// Handle resume_from_compact tool (issue #965)
+pub async fn handle_resume_from_compact(
+    server: &mut MemoryMCPServer,
+    arguments: Option<Value>,
+) -> anyhow::Result<Vec<Content>> {
+    let args: Value = arguments.ok_or_else(|| anyhow::anyhow!("Missing arguments"))?;
+    let _client_id = get_client_id(&args);
+    let input: do_memory_mcp::mcp::tools::checkpoint::ResumeFromCompactInput =
+        serde_json::from_value(args)?;
+
+    let tools = do_memory_mcp::mcp::tools::checkpoint::CheckpointTools::new(server.memory());
+    let result = tools.resume_from_compact(input).await?;
+
+    let content = vec![Content::Text {
+        text: serde_json::to_string_pretty(&result)?,
+    }];
+    Ok(content)
+}

--- a/memory-mcp/src/bin/server_impl/tools/mod.rs
+++ b/memory-mcp/src/bin/server_impl/tools/mod.rs
@@ -36,7 +36,7 @@ pub use feature_handlers::{
     handle_checkpoint_episode, handle_explain_pattern, handle_get_handoff_pack,
     handle_get_recommendation_stats, handle_recommend_patterns, handle_recommend_playbook,
     handle_record_recommendation_feedback, handle_record_recommendation_session,
-    handle_resume_from_handoff, handle_search_patterns,
+    handle_resume_from_compact, handle_resume_from_handoff, handle_search_patterns,
 };
 pub use memory_handlers::{
     handle_advanced_pattern_analysis, handle_analyze_patterns, handle_configure_embeddings,

--- a/memory-mcp/src/mcp/tools/checkpoint/mod.rs
+++ b/memory-mcp/src/mcp/tools/checkpoint/mod.rs
@@ -9,5 +9,5 @@ mod types;
 pub use tool::CheckpointTools;
 pub use types::{
     CheckpointEpisodeInput, CheckpointEpisodeOutput, GetHandoffPackInput, GetHandoffPackOutput,
-    ResumeFromHandoffInput, ResumeFromHandoffOutput,
+    ResumeFromCompactInput, ResumeFromHandoffInput, ResumeFromHandoffOutput,
 };

--- a/memory-mcp/src/mcp/tools/checkpoint/tool.rs
+++ b/memory-mcp/src/mcp/tools/checkpoint/tool.rs
@@ -2,14 +2,15 @@
 
 use super::types::{
     CheckpointEpisodeInput, CheckpointEpisodeOutput, GetHandoffPackInput, GetHandoffPackOutput,
-    HandoffPackResponse, ResumeFromHandoffInput, ResumeFromHandoffOutput,
+    HandoffPackResponse, ResumeFromCompactInput, ResumeFromHandoffInput, ResumeFromHandoffOutput,
 };
 use crate::constants;
 use crate::types::Tool;
 use anyhow::{Result, anyhow};
 use do_memory_core::SelfLearningMemory;
 use do_memory_core::memory::checkpoint::{
-    checkpoint_episode, checkpoint_episode_with_note, get_handoff_pack, resume_from_handoff,
+    checkpoint_episode, checkpoint_episode_with_note, get_compact_handoff_pack, get_handoff_pack,
+    resume_from_compact, resume_from_handoff,
 };
 use serde_json::json;
 use std::sync::Arc;
@@ -60,16 +61,42 @@ impl CheckpointTools {
     pub fn get_handoff_pack_tool() -> Tool {
         Tool::new(
             "get_handoff_pack".to_string(),
-            "Generate a handoff pack from a checkpoint. Contains lessons learned, relevant patterns, and suggested next steps for transferring work to another agent.".to_string(),
+            "Generate a handoff pack from a checkpoint. Compact mode (default) returns a byte-budgeted profile with findings, decisions, pending actions, and omission receipts; full mode returns the unbounded pack for audit/debug.".to_string(),
             json!({
                 "type": "object",
                 "properties": {
                     "checkpoint_id": {
                         "type": "string",
                         "description": "Checkpoint ID to generate handoff pack from (UUID format)"
+                    },
+                    "mode": {
+                        "type": "string",
+                        "description": "Pack mode: 'compact' (default, byte-budgeted) or 'full' (unbounded, for audit/debug)"
+                    },
+                    "max_bytes": {
+                        "type": "integer",
+                        "description": "Compact payload ceiling in bytes, minimum 1024 (default 8192, compact mode only)"
                     }
                 },
                 "required": ["checkpoint_id"]
+            }),
+        )
+    }
+
+    /// Get the tool definition for resume_from_compact
+    pub fn resume_from_compact_tool() -> Tool {
+        Tool::new(
+            "resume_from_compact".to_string(),
+            "Resume work from a compact handoff pack. Creates a new episode initialized with the compact goal, findings, decisions, and pending actions.".to_string(),
+            json!({
+                "type": "object",
+                "properties": {
+                    "compact_handoff": {
+                        "type": "object",
+                        "description": "The compact handoff pack to resume from (obtained from get_handoff_pack in compact mode)"
+                    }
+                },
+                "required": ["compact_handoff"]
             }),
         )
     }
@@ -195,9 +222,12 @@ impl CheckpointTools {
 
     /// Get a handoff pack from a checkpoint
     ///
+    /// Compact mode (default) returns a byte-budgeted profile;
+    /// `"full"` returns the unbounded pack for audit/debug.
+    ///
     /// # Arguments
     ///
-    /// * `input` - Input containing checkpoint ID
+    /// * `input` - Input containing checkpoint ID, mode, and budget
     ///
     /// # Returns
     ///
@@ -222,6 +252,67 @@ impl CheckpointTools {
         let checkpoint_id = Uuid::parse_str(&input.checkpoint_id)
             .map_err(|e| anyhow!("Invalid checkpoint ID: {}", e))?;
 
+        if input.effective_mode() != "compact" && input.effective_mode() != "full" {
+            return Ok(GetHandoffPackOutput {
+                success: false,
+                handoff_pack: None,
+                compact_handoff: None,
+                message: format!(
+                    "Invalid mode '{}': expected 'compact' or 'full'",
+                    input.effective_mode()
+                ),
+            });
+        }
+
+        if input.effective_mode() == "full" {
+            return self.get_full_handoff_pack(checkpoint_id).await;
+        }
+
+        let budget = input.effective_budget();
+        if budget.max_bytes < GetHandoffPackInput::MIN_HANDOFF_BYTES {
+            return Ok(GetHandoffPackOutput {
+                success: false,
+                handoff_pack: None,
+                compact_handoff: None,
+                message: format!(
+                    "max_bytes {} below minimum {}",
+                    budget.max_bytes,
+                    GetHandoffPackInput::MIN_HANDOFF_BYTES
+                ),
+            });
+        }
+
+        // Get compact handoff pack
+        match get_compact_handoff_pack(&self.memory, checkpoint_id, budget).await {
+            Ok(compact) => {
+                info!(
+                    "Generated compact handoff pack ({} bytes, ~{} tokens, {} omitted steps)",
+                    compact.payload_bytes(),
+                    compact.approx_tokens,
+                    compact.omitted.omitted_steps
+                );
+
+                Ok(GetHandoffPackOutput {
+                    success: true,
+                    handoff_pack: None,
+                    compact_handoff: Some(compact),
+                    message: "Successfully generated compact handoff pack".to_string(),
+                })
+            }
+            Err(e) => {
+                info!("Failed to get compact handoff pack: {}", e);
+                Ok(GetHandoffPackOutput {
+                    success: false,
+                    handoff_pack: None,
+                    compact_handoff: None,
+                    message: format!("Failed to get handoff pack: {}", e),
+                })
+            }
+        }
+    }
+
+    /// Get the full (unbounded) handoff pack for audit/debug use.
+    async fn get_full_handoff_pack(&self, checkpoint_id: Uuid) -> Result<GetHandoffPackOutput> {
         // Get handoff pack
         match get_handoff_pack(&self.memory, checkpoint_id).await {
             Ok(handoff) => {
@@ -235,6 +326,7 @@ impl CheckpointTools {
                 Ok(GetHandoffPackOutput {
                     success: true,
                     handoff_pack: Some(HandoffPackResponse::from(handoff)),
+                    compact_handoff: None,
                     message: "Successfully generated handoff pack".to_string(),
                 })
             }
@@ -243,7 +335,56 @@ impl CheckpointTools {
                 Ok(GetHandoffPackOutput {
                     success: false,
                     handoff_pack: None,
+                    compact_handoff: None,
                     message: format!("Failed to get handoff pack: {}", e),
+                })
+            }
+        }
+    }
+
+    /// Resume work from a compact handoff pack
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - Input containing the compact handoff pack
+    ///
+    /// # Returns
+    ///
+    /// Returns the new episode ID for resumption.
+    #[instrument(skip(self, input))]
+    pub async fn resume_from_compact(
+        &self,
+        input: ResumeFromCompactInput,
+    ) -> Result<ResumeFromHandoffOutput> {
+        info!(
+            "Resuming from compact handoff: checkpoint_id={}",
+            input.compact_handoff.checkpoint_id
+        );
+
+        let checkpoint_id = input.compact_handoff.checkpoint_id;
+        let episode_id = input.compact_handoff.episode_id;
+
+        // Resume from compact handoff
+        match resume_from_compact(&self.memory, input.compact_handoff).await {
+            Ok(new_episode_id) => {
+                info!("Created new episode {} for resumption", new_episode_id);
+
+                Ok(ResumeFromHandoffOutput {
+                    success: true,
+                    new_episode_id: Some(new_episode_id.to_string()),
+                    checkpoint_id: checkpoint_id.to_string(),
+                    original_episode_id: episode_id.to_string(),
+                    message: format!("Successfully resumed work in new episode {new_episode_id}"),
+                })
+            }
+            Err(e) => {
+                info!("Failed to resume from compact handoff: {}", e);
+                Ok(ResumeFromHandoffOutput {
+                    success: false,
+                    new_episode_id: None,
+                    checkpoint_id: checkpoint_id.to_string(),
+                    original_episode_id: episode_id.to_string(),
+                    message: format!("Failed to resume from handoff: {e}"),
                 })
             }
         }
@@ -327,6 +468,8 @@ mod tests {
 
         let input = GetHandoffPackInput {
             checkpoint_id: "not-a-uuid".to_string(),
+            mode: None,
+            max_bytes: None,
         };
 
         let result = tools.get_handoff_pack(input).await;
@@ -411,5 +554,140 @@ mod tests {
         let result = tools.checkpoint_episode(input).await;
         // Should not panic from length
         assert!(result.is_err() || !result.as_ref().unwrap().success);
+    }
+
+    async fn checkpoint_fixture() -> (Arc<SelfLearningMemory>, String) {
+        use do_memory_core::memory::checkpoint::checkpoint_episode as core_checkpoint;
+        use do_memory_core::{MemoryConfig, TaskContext, TaskType};
+
+        // Step buffering would hide steps from the checkpoint; disable it.
+        let memory = Arc::new(SelfLearningMemory::with_config(MemoryConfig {
+            quality_threshold: 0.0,
+            batch_config: None,
+            ..MemoryConfig::default()
+        }));
+        let episode_id = memory
+            .start_episode(
+                "MCP handoff task".to_string(),
+                TaskContext::default(),
+                TaskType::Testing,
+            )
+            .await;
+        for i in 1..=3 {
+            let step = do_memory_core::episode::ExecutionStep::new(
+                i,
+                "tool".to_string(),
+                format!("action {i}"),
+            );
+            memory.log_step(episode_id, step).await;
+        }
+        let checkpoint_id = core_checkpoint(&memory, episode_id, "test".to_string())
+            .await
+            .expect("checkpoint must succeed")
+            .checkpoint_id
+            .to_string();
+        (memory, checkpoint_id)
+    }
+
+    #[tokio::test]
+    async fn test_get_handoff_pack_defaults_to_compact() {
+        let (memory, checkpoint_id) = checkpoint_fixture().await;
+        let tools = CheckpointTools::new(memory);
+
+        let input = GetHandoffPackInput {
+            checkpoint_id,
+            mode: None,
+            max_bytes: None,
+        };
+        let output = tools.get_handoff_pack(input).await.unwrap();
+
+        assert!(output.success);
+        assert!(output.handoff_pack.is_none());
+        let compact = output.compact_handoff.expect("compact pack expected");
+        assert!(compact.payload_bytes() <= 8192);
+        assert_eq!(compact.evidence_excerpts.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_get_handoff_pack_full_mode() {
+        let (memory, checkpoint_id) = checkpoint_fixture().await;
+        let tools = CheckpointTools::new(memory);
+
+        let input = GetHandoffPackInput {
+            checkpoint_id,
+            mode: Some("full".to_string()),
+            max_bytes: None,
+        };
+        let output = tools.get_handoff_pack(input).await.unwrap();
+
+        assert!(output.success);
+        assert!(output.compact_handoff.is_none());
+        assert!(output.handoff_pack.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_get_handoff_pack_invalid_mode_rejected() {
+        let (memory, checkpoint_id) = checkpoint_fixture().await;
+        let tools = CheckpointTools::new(memory);
+
+        let input = GetHandoffPackInput {
+            checkpoint_id,
+            mode: Some("bogus".to_string()),
+            max_bytes: None,
+        };
+        let output = tools.get_handoff_pack(input).await.unwrap();
+
+        assert!(!output.success);
+        assert!(output.message.contains("Invalid mode"));
+    }
+
+    #[tokio::test]
+    async fn test_get_handoff_pack_max_bytes_floor_rejected() {
+        let (memory, checkpoint_id) = checkpoint_fixture().await;
+        let tools = CheckpointTools::new(memory);
+
+        let input = GetHandoffPackInput {
+            checkpoint_id,
+            mode: None,
+            max_bytes: Some(100),
+        };
+        let output = tools.get_handoff_pack(input).await.unwrap();
+
+        assert!(!output.success);
+        assert!(output.message.contains("minimum"));
+    }
+
+    #[tokio::test]
+    async fn test_resume_from_compact_round_trip() {
+        let (memory, checkpoint_id) = checkpoint_fixture().await;
+        let tools = CheckpointTools::new(Arc::clone(&memory));
+
+        let input = GetHandoffPackInput {
+            checkpoint_id,
+            mode: None,
+            max_bytes: None,
+        };
+        let pack = tools.get_handoff_pack(input).await.unwrap();
+        let compact = pack.compact_handoff.expect("compact pack expected");
+
+        let resume = tools
+            .resume_from_compact(ResumeFromCompactInput {
+                compact_handoff: compact,
+            })
+            .await
+            .unwrap();
+
+        assert!(resume.success);
+        let new_id: Uuid = resume
+            .new_episode_id
+            .expect("new episode expected")
+            .parse()
+            .expect("valid UUID");
+        let resumed = memory.get_episode(new_id).await.unwrap();
+        assert_eq!(resumed.task_description, "MCP handoff task");
+        assert_eq!(
+            resumed.metadata.get("handoff_format").map(String::as_str),
+            Some("compact")
+        );
     }
 }

--- a/memory-mcp/src/mcp/tools/checkpoint/types.rs
+++ b/memory-mcp/src/mcp/tools/checkpoint/types.rs
@@ -1,6 +1,6 @@
 //! Checkpoint tool types and input/output structures.
 
-use do_memory_core::HandoffPack;
+use do_memory_core::{CompactHandoff, HandoffBudget, HandoffPack};
 use serde::{Deserialize, Serialize};
 
 /// Input parameters for creating a checkpoint
@@ -35,6 +35,34 @@ pub struct CheckpointEpisodeOutput {
 pub struct GetHandoffPackInput {
     /// Checkpoint ID to generate handoff pack from
     pub checkpoint_id: String,
+    /// Pack mode: `"compact"` (default, byte-budgeted) or `"full"`
+    /// (unbounded, for audit/debug).
+    #[serde(default)]
+    pub mode: Option<String>,
+    /// Compact payload ceiling in bytes (default 8192, compact mode only).
+    #[serde(default)]
+    pub max_bytes: Option<usize>,
+}
+
+impl GetHandoffPackInput {
+    /// Resolve the effective mode, defaulting to compact.
+    #[must_use]
+    pub fn effective_mode(&self) -> &str {
+        self.mode.as_deref().unwrap_or("compact")
+    }
+
+    /// Minimum viable payload in bytes (skeleton + a few findings).
+    pub const MIN_HANDOFF_BYTES: usize = 1024;
+
+    /// Resolve the effective budget for compact mode.
+    #[must_use]
+    pub fn effective_budget(&self) -> HandoffBudget {
+        let mut budget = HandoffBudget::default();
+        if let Some(max_bytes) = self.max_bytes {
+            budget.max_bytes = max_bytes;
+        }
+        budget
+    }
 }
 
 /// Output from getting a handoff pack
@@ -42,8 +70,10 @@ pub struct GetHandoffPackInput {
 pub struct GetHandoffPackOutput {
     /// Whether operation was successful
     pub success: bool,
-    /// The handoff pack (null if not found)
+    /// The full handoff pack (full mode only, null otherwise)
     pub handoff_pack: Option<HandoffPackResponse>,
+    /// The compact handoff pack (compact mode only, null otherwise)
+    pub compact_handoff: Option<CompactHandoff>,
     /// Message describing the result
     pub message: String,
 }
@@ -98,6 +128,13 @@ impl From<HandoffPack> for HandoffPackResponse {
 pub struct ResumeFromHandoffInput {
     /// The handoff pack to resume from
     pub handoff_pack: HandoffPack,
+}
+
+/// Input parameters for resuming from a compact handoff pack
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResumeFromCompactInput {
+    /// The compact handoff pack to resume from
+    pub compact_handoff: CompactHandoff,
 }
 
 /// Output from resuming from a handoff pack

--- a/memory-mcp/src/server/tools/registry/builder.rs
+++ b/memory-mcp/src/server/tools/registry/builder.rs
@@ -187,5 +187,6 @@ pub(super) fn create_additional_extended_tools() -> Vec<Tool> {
         crate::mcp::tools::checkpoint::CheckpointTools::checkpoint_episode_tool(),
         crate::mcp::tools::checkpoint::CheckpointTools::get_handoff_pack_tool(),
         crate::mcp::tools::checkpoint::CheckpointTools::resume_from_handoff_tool(),
+        crate::mcp::tools::checkpoint::CheckpointTools::resume_from_compact_tool(),
     ]
 }

--- a/memory-mcp/tests/snapshot_tests.rs
+++ b/memory-mcp/tests/snapshot_tests.rs
@@ -492,6 +492,18 @@ fn test_checkpoint_episode_output() {
 fn test_get_handoff_pack_input() {
     let input = GetHandoffPackInput {
         checkpoint_id: "770e8400-e29b-41d4-a716-446655440000".to_string(),
+        mode: None,
+        max_bytes: None,
+    };
+    assert_json_snapshot!(input);
+}
+
+#[test]
+fn test_get_handoff_pack_input_compact_options() {
+    let input = GetHandoffPackInput {
+        checkpoint_id: "770e8400-e29b-41d4-a716-446655440000".to_string(),
+        mode: Some("compact".to_string()),
+        max_bytes: Some(4096),
     };
     assert_json_snapshot!(input);
 }
@@ -501,6 +513,7 @@ fn test_get_handoff_pack_output() {
     let output = GetHandoffPackOutput {
         success: true,
         handoff_pack: None,
+        compact_handoff: None,
         message: "Handoff pack retrieved".to_string(),
     };
     assert_json_snapshot!(output);

--- a/memory-mcp/tests/snapshots/snapshot_tests__get_handoff_pack_input_compact_options.snap
+++ b/memory-mcp/tests/snapshots/snapshot_tests__get_handoff_pack_input_compact_options.snap
@@ -1,10 +1,10 @@
 ---
 source: memory-mcp/tests/snapshot_tests.rs
-assertion_line: 498
+assertion_line: 508
 expression: input
 ---
 {
   "checkpoint_id": "770e8400-e29b-41d4-a716-446655440000",
-  "mode": null,
-  "max_bytes": null
+  "mode": "compact",
+  "max_bytes": 4096
 }

--- a/memory-mcp/tests/snapshots/snapshot_tests__get_handoff_pack_output.snap
+++ b/memory-mcp/tests/snapshots/snapshot_tests__get_handoff_pack_output.snap
@@ -1,10 +1,11 @@
 ---
 source: memory-mcp/tests/snapshot_tests.rs
-assertion_line: 498
+assertion_line: 519
 expression: output
 ---
 {
   "success": true,
   "handoff_pack": null,
+  "compact_handoff": null,
   "message": "Handoff pack retrieved"
 }


### PR DESCRIPTION
Closes #965.

## What
Default compact handoff profile with byte budgets + explicit omission receipts; full-fidelity pack retained for audit/debug.

- Core (`memory::checkpoint::compact`): `CompactHandoff` (objective, status/progress, verified findings, decisions, pending actions, pattern/heuristic ID refs, most-recent evidence excerpts, `OmissionMetadata`, token estimate), `HandoffBudget` (default 8 KB), deterministic assembler (count caps → JSON byte budget → reverse-priority drops → UTF-8-safe cuts), `get_compact_handoff_pack` + `resume_from_compact`.
- MCP: `get_handoff_pack` defaults to compact (`mode` compact/full, `max_bytes` floor 1024 enforced explicitly); new `resume_from_compact` tool, registered + routed (call + batch).
- CLI: `episode handoff/resume` default compact with `--full` / `--max-bytes`; human output shows budget + omission line with full-pack pointer.
- Docs: MCP + CLI examples in `PLAYBOOKS_AND_CHECKPOINTS.md`.

## Roast notes (self-review)
- **Budget floor ~1 KB, not 512**: the empty skeleton is ~590 B and truncation receipts grow it (worst case ~950 B), so sub-floor budgets are documented best-effort and the enforced minimum is 1024. Found by a failing test, not by inspection.
- **MCP default shape change**: compact responses set `handoff_pack: null` + `compact_handoff: {...}`. Issue-mandated, flagged here for consumers.
- **Double salient extraction** in compact builds (lessons + decisions separately) — CPU-only, documented inline; unifying would touch the existing extractor contract.
- **Resume-quality eval is a functional proxy** (round-trip preserves goal/decisions/pending), not a quality benchmark — same honest caveat as #992's fixture note.

## Verification
- 17 new tests: budget compliance (tight + cascade + sub-floor), determinism, exact omission counts, UTF-8-safe truncation, resume round trips (core + MCP), MCP mode/floor validation, CLI mapping, snapshots.
- `nextest -p do-memory-core` ✅ 1905 passed; `--features csm` ✅ 1921 passed
- `nextest -p do-memory-mcp` ✅ 597 passed; `-p do-memory-cli` ✅ 574 passed
- `cargo test --doc -p do-memory-core` ✅ 164 passed
- `code-quality.sh fmt --workspace` + `clippy --workspace` ✅ zero warnings; all touched files ≤500 LOC