### PR TITLE
feat(observability): add retrieval-plane telemetry with bounded labels

### DIFF
--- a/.agents/skills/harness/SKILL.md
+++ b/.agents/skills/harness/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: harness
+description: >
+  Map the harness-engineering feedforward guides and feedback sensors, and run
+  the self-correction protocol when a computational sensor fires. Use when a
+  sensor fails (do-harness verify), before making code changes, or when setting
+  up agent context for a new task. Triggers: "harness", "sensor fire",
+  "CI failure", "self-correction".
+license: MIT
+metadata:
+  version: "0.1.0"
+  tags: harness sensors verify self-correction
+---
+
+# Harness Skill
+
+## What Is the Harness
+Agent = Model + Harness. The harness is the system of feedforward guides (what
+to do before coding) and feedback sensors (what catches violations after
+coding).
+
+- **Feedforward**: `AGENTS.md` and `.agents/skills/` — context, constraints,
+  conventions read before coding.
+- **Feedback**: `do-harness verify` — automated checks that fire after code
+  changes. Computational output strictly supersedes LLM self-assessment.
+
+## Feedback Sensors
+| Sensor | Command | Stage |
+|--------|---------|-------|
+| verify | `do-harness verify` | pre-commit (subset) + pre-push + CI (full) |
+| individual | `do-harness verify --only <name>` | targeted re-runs |
+
+Sensors are defined in `do-harness.toml`; run `do-harness list` to see them.
+
+## Self-Correction Protocol
+1. Read the full error output — it includes the failing check.
+2. Classify the failure: formatting / compile / lint / test / config.
+3. Apply the minimal fix — do not refactor unrelated code.
+4. Re-run the specific sensor (`do-harness verify --only <name>`).
+5. Proceed only when the sensor is green.
+
+## Fail-Fast Policy
+If the same subtask fails a sensor 3 consecutive times, halt, record the error
+signature in `.do-harness/agent_state.db`, and surface a diagnostic.
+
+## New-Repo Adoption (Dogfood Rule)
+- `do-harness init` (rust pack) scaffolds a minimal crate when no
+  `Cargo.toml` exists, so `init && verify` exits 0 on an empty tree;
+  existing crates are never touched, not even with `--force`.
+- The generic pack ships zero sensors: its `verify` pass is vacuous until
+  real `[[sensors]]` are configured — not evidence.
+- Never assume the harness works in this repo: re-prove with
+  `do-harness verify --format json` and read the per-sensor exit codes.
+
+## Gotchas
+- Never trust LLM self-assessment over a computational sensor's exit code.
+- Fix the sensor that fired; do not refactor unrelated code in the same pass.
+- An empty sensor suite passes vacuously; that is not evidence.

--- a/.agents/skills/harness/evals/evals.json
+++ b/.agents/skills/harness/evals/evals.json
@@ -1,30 +1,49 @@
 {
-  "skill_name": "harness",
-  "evals": [
+  "tests": [
     {
-      "id": 1,
-      "prompt": "Adopt the harness in an empty greenfield repository. What must be proven before any work starts?",
-      "expected_output": "do-harness init scaffolds the workspace plus a minimal rust crate, then do-harness verify must actually execute every sensor and exit 0 — the green path is computed, never assumed. A subsequently failing sensor records its error signature for the fail-fast lifecycle.",
-      "files": [],
-      "assertions": [
-        "walk:",
-        "exists:Cargo.toml",
-        "exists:src/lib.rs",
-        "exists:do-harness.toml",
-        "exists:AGENTS.md",
-        "exists:.agents/skills/harness/SKILL.md",
-        "db:error_signatures:signature=sensor:test:min=1",
-        "cli:errors list:contains:sensor:test"
-      ]
+      "name": "skill-md-present",
+      "description": "harness skill exists",
+      "exec": "test -f .agents/skills/harness/SKILL.md"
     },
     {
-      "id": 2,
-      "prompt": "The same test has failed 3 consecutive times for the same subtask. What now?",
-      "expected_output": "Apply the fail-fast policy: halt, record the error signature, and surface a diagnostic to the developer.",
-      "files": [],
-      "assertions": [
-        "The fail-fast policy halts rather than retrying indefinitely"
-      ]
+      "name": "sensor-config-present",
+      "description": "do-harness.toml defines the workspace sensor pack",
+      "exec": "test -f do-harness.toml && rg -q '\\[\\[sensors\\]\\]' do-harness.toml"
+    },
+    {
+      "name": "six-core-sensors",
+      "description": "fmt, check, clippy, test, deny, loc sensors are configured",
+      "exec": "for s in fmt check clippy test deny loc; do rg -q \"name = \\\"$s\\\"\" do-harness.toml || exit 1; done"
+    },
+    {
+      "name": "loc-sensor-script",
+      "description": "check-loc.sh sensor script exists and is executable",
+      "exec": "test -x scripts/check-loc.sh"
+    },
+    {
+      "name": "workflow-step-ten",
+      "description": "Change Workflow step 10 runs do-harness verify --record",
+      "exec": "rg -q 'do-harness verify --record' AGENTS.md"
+    },
+    {
+      "name": "dev-harness-section",
+      "description": "AGENTS.md documents the Dev Harness (do-harness) section",
+      "exec": "rg -q '## Dev Harness \\(do-harness\\)' AGENTS.md"
+    },
+    {
+      "name": "hook-ownership-guard",
+      "description": "Documents that pre-commit framework owns .git/hooks (no do-harness hook install)",
+      "exec": "rg -q 'Do NOT run \\`?do-harness hook install' AGENTS.md"
+    },
+    {
+      "name": "events-not-ignored",
+      "description": ".agents/events/ stays tracked (Steering Loop audit trail)",
+      "exec": "! git check-ignore -q .agents/events/ 2>/dev/null"
+    },
+    {
+      "name": "state-db-ignored",
+      "description": ".do-harness/ local state DB is gitignored",
+      "exec": "rg -q '^\\.do-harness/$' .gitignore"
     }
   ]
 }

--- a/.agents/skills/harness/evals/evals.json
+++ b/.agents/skills/harness/evals/evals.json
@@ -1,0 +1,30 @@
+{
+  "skill_name": "harness",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Adopt the harness in an empty greenfield repository. What must be proven before any work starts?",
+      "expected_output": "do-harness init scaffolds the workspace plus a minimal rust crate, then do-harness verify must actually execute every sensor and exit 0 — the green path is computed, never assumed. A subsequently failing sensor records its error signature for the fail-fast lifecycle.",
+      "files": [],
+      "assertions": [
+        "walk:",
+        "exists:Cargo.toml",
+        "exists:src/lib.rs",
+        "exists:do-harness.toml",
+        "exists:AGENTS.md",
+        "exists:.agents/skills/harness/SKILL.md",
+        "db:error_signatures:signature=sensor:test:min=1",
+        "cli:errors list:contains:sensor:test"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "The same test has failed 3 consecutive times for the same subtask. What now?",
+      "expected_output": "Apply the fail-fast policy: halt, record the error signature, and surface a diagnostic to the developer.",
+      "files": [],
+      "assertions": [
+        "The fail-fast policy halts rather than retrying indefinitely"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/harness/evals/walkthrough.sh
+++ b/.agents/skills/harness/evals/walkthrough.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# harness walkthrough: proves greenfield adoption end-to-end with the real
+# binary — init scaffolds the workspace plus a minimal crate, the full rust
+# sensor suite must actually pass (no assumed green), then a broken workspace
+# drives the fail-fast error-signature lifecycle (record -> list) as residue.
+set -euo pipefail
+root="${DO_HARNESS_ROOT:?DO_HARNESS_ROOT required}"
+bin="${DO_HARNESS_BIN:-do-harness}"
+
+# Greenfield adoption: the full suite (fmt/check/clippy/test/loc/commitlint)
+# runs against the scaffolded crate and must exit 0.
+"$bin" --root "$root" init >/dev/null
+"$bin" --root "$root" verify
+
+# Break the crate: the test sensor must fail and record its signature.
+rm -rf "$root/Cargo.toml" "$root/src"
+"$bin" --root "$root" verify --only test --record >/dev/null 2>&1 || true
+
+"$bin" --root "$root" errors list
+
+# Self-correction: minimal fix (restore the crate), then prove green again.
+"$bin" --root "$root" init >/dev/null
+"$bin" --root "$root" verify

--- a/.gitignore
+++ b/.gitignore
@@ -111,7 +111,9 @@ mcp-config-*.json
 audit-report.json
 insights-report/
 benchmark_results/
-metrics/
+# Root-level artifact dir only — must NOT swallow source modules like
+# memory-core/src/monitoring/metrics/ (a bare `metrics/` matches at any depth).
+/metrics/
 bench_results.txt
 
 # Split file artifacts (from split command)
@@ -134,3 +136,6 @@ __pycache__/
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/
+# NOTE: .agents/events/ is deliberately NOT ignored — this repo commits
+# Steering Loop metrics events (see AGENTS.md "Steering Loop").
+

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,8 @@ __pycache__/
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/
+# do-harness local state DB (sensors read do-harness.toml, not these files)
+.do-harness/
 # NOTE: .agents/events/ is deliberately NOT ignored — this repo commits
 # Steering Loop metrics events (see AGENTS.md "Steering Loop").
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,14 @@ repos:
         language: system
         pass_filenames: false
 
+      # LOC invariant - do-harness 'loc' sensor (scripts/check-loc.sh)
+      # Also available standalone: do-harness verify --only loc
+      - id: loc
+        name: LOC (<=500 per source file)
+        entry: bash scripts/check-loc.sh
+        language: system
+        pass_filenames: false
+
       # Clippy on lib + tests - matches CI quick-check.yml
       - id: clippy-lib
         name: Clippy (lib)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Always use Skill + CLI first for high-frequency ops:
 | Wait for CI | `ci-poll` | `gh pr checks` / Actions |
 | Release | `release-guard` | `./scripts/release-manager.sh ship --execute` |
 | Release Cadence | `release-cadence-manager` | `./scripts/release-cadence-manager.sh` |
+| Agent Harness | `harness` | `do-harness verify --record` / `do-harness doctor` |
 | Complex multi-step | `goap-agent` | - |
 
 Full skill inventory: [`.agents/SKILLS.md`](.agents/SKILLS.md).  
@@ -57,7 +58,8 @@ Ship releases **only** via `release-guard` + `./scripts/release-manager.sh ship 
 7. `cargo nextest run --all`
 8. `cargo test --doc`
 9. `./scripts/quality-gates.sh` (coverage threshold is `QUALITY_GATE_COVERAGE_THRESHOLD`, default 90)
-10. `git status` - verify all changes staged
+10. `do-harness verify --record`
+11. `git status` - verify all changes staged
 
 ## Core Invariants (Never Break)
 - **Async**: Tokio everywhere. No blocking (use `spawn_blocking`)
@@ -67,6 +69,22 @@ Ship releases **only** via `release-guard` + `./scripts/release-manager.sh ship 
 - **Files**: ≤500 LOC per source file
 - **Tests**: ≥90% coverage. `#[tokio::test]` for async. AAA pattern
 - **Docs**: URLs wrapped in `<...>`. New types re-exported from `lib.rs`
+
+## Dev Harness (do-harness)
+
+Computational sensor runner + local agent state DB (`.do-harness/agent_state.db`, gitignored).
+Sensors are defined in `do-harness.toml` (fmt, check, clippy, test, deny, loc — mirroring the
+gates above); `HARNESS.md` maps them to feedforward guides.
+
+- `do-harness verify --record` — run the sensor suite and persist beats (Change Workflow step 10)
+- `do-harness verify --only <sensor>` — targeted re-run after a failure
+- `do-harness task done <id>` — task gate; refuses until its sensor passed via `verify --record`
+- `do-harness doctor` — after upgrading the binary (checks hook/DB migration skew)
+- Sensor fired? Fix the firing sensor first (`verify --only <name>`), then commit. Same
+  self-correction protocol as HARNESS.md; beats recorded by `--record` feed `do-harness metrics`.
+- Do NOT run `do-harness hook install` — `.pre-commit-config.yaml` owns `.git/hooks/pre-commit`.
+- `do-harness init` re-scaffolds skills; never let it inject `.agents/skills/skill-creator/scripts/`
+  or ignore `.agents/events/` (this repo commits those).
 
 ## Steering Loop
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,8 @@ gates above); `HARNESS.md` maps them to feedforward guides.
 - `do-harness doctor` — after upgrading the binary (checks hook/DB migration skew)
 - Sensor fired? Fix the firing sensor first (`verify --only <name>`), then commit. Same
   self-correction protocol as HARNESS.md; beats recorded by `--record` feed `do-harness metrics`.
-- Do NOT run `do-harness hook install` — `.pre-commit-config.yaml` owns `.git/hooks/pre-commit`.
+- Do NOT run `do-harness hook install` — `.pre-commit-config.yaml` owns `.git/hooks/pre-commit`
+  and runs the cheap sensor subset for you (fmt via cargo, loc via `scripts/check-loc.sh`).
 - `do-harness init` re-scaffolds skills; never let it inject `.agents/skills/skill-creator/scripts/`
   or ignore `.agents/events/` (this repo commits those).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a878c850e9e421b20262e9b41f9c860e4785fa07541c266b62ff9d1ef998a80a"
 dependencies = [
  "pem-rfc7468 1.0.0",
  "zeroize",
@@ -6921,7 +6921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
- "der 0.8.0",
+ "der 0.8.2",
  "log",
  "native-tls",
  "percent-encoding",

--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ async fn main() -> anyhow::Result<()> {
 |----------|-------------|
 | [Configuration Wizard](docs/CONFIG_WIZARD.md) | Interactive setup guide |
 | [API Reference](docs/API_REFERENCE.md) | Current MCP tool contract index |
+| [Retrieval Observability](docs/RETRIEVAL_OBSERVABILITY.md) | Retrieval metrics, dashboards, and telemetry surfaces |
 | [Configuration Guide](memory-cli/CONFIGURATION_GUIDE.md) | Complete configuration options |
 | [Database Setup](docs/LOCAL_DATABASE_SETUP.md) | Local database configuration |
 | [Quality Gates](docs/QUALITY_GATES.md) | Automated quality standards |

--- a/do-harness.toml
+++ b/do-harness.toml
@@ -1,0 +1,34 @@
+# do-harness.toml — sensor pack for this workspace.
+#
+# Sensors mirror the repo's own quality gates (AGENTS.md "Required Checks
+# Before Commit") without duplicating their configuration: CI still runs
+# the same commands; do-harness adds local beats, strikes, and task gating.
+language = "rust"
+
+[hooks]
+pre-commit = ["fmt", "loc"]
+pre-push = []
+
+[[sensors]]
+name = "fmt"
+argv = ["cargo", "fmt", "--all", "--", "--check"]
+
+[[sensors]]
+name = "check"
+argv = ["cargo", "check", "--workspace"]
+
+[[sensors]]
+name = "clippy"
+argv = ["cargo", "clippy", "--workspace", "--", "-D", "warnings"]
+
+[[sensors]]
+name = "test"
+argv = ["cargo", "nextest", "run", "--all"]
+
+[[sensors]]
+name = "deny"
+argv = ["cargo", "deny", "check"]
+
+[[sensors]]
+name = "loc"
+argv = ["bash", "scripts/check-loc.sh"]

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -82,6 +82,15 @@ The following tool names are the current contract tracked by parity tests.
 - `health_check`
 - `get_metrics`
 
+#### Retrieval telemetry (`get_metrics` with `metric_type: "retrieval"`)
+
+`get_metrics` accepts `metric_type: "retrieval"` to return the retrieval-plane
+telemetry snapshot (request counts and latency percentiles by operation/tier,
+cache hit/miss, embedding calls by provider, fallback reasons, feedback
+signals, candidate-set sizes). Metric family reference, PromQL dashboard
+examples, and the cardinality/redaction contract are documented in
+[Retrieval Observability](./RETRIEVAL_OBSERVABILITY.md).
+
 ### Pattern / Recommendation / Explainability
 
 - `advanced_pattern_analysis`
@@ -238,6 +247,7 @@ Status: **Deferred / absent from active MCP tool contract** (R-C7) until handler
 
 ## See Also
 
+- [Retrieval Observability](./RETRIEVAL_OBSERVABILITY.md)
 - [Playbooks and Checkpoints](./PLAYBOOKS_AND_CHECKPOINTS.md)
 - [do-memory-mcp README](../memory-mcp/README.md)
 - [Current project status](../plans/STATUS/CURRENT.md)

--- a/docs/RETRIEVAL_OBSERVABILITY.md
+++ b/docs/RETRIEVAL_OBSERVABILITY.md
@@ -1,0 +1,236 @@
+# Retrieval Observability
+
+**Issue**: #962 (retrieval-plane telemetry)
+**Last Updated**: 2026-09-05
+**Registry**: `do_memory_core::monitoring::metrics::global_retrieval_metrics()`
+
+---
+
+## Overview
+
+Every retrieval request, cache lookup, embedding call, Tier-4 fallback, and
+recommendation feedback signal is recorded into a process-global
+`RetrievalMetrics` registry. The same registry backs three instrumentation
+surfaces, so the CLI, MCP, and Prometheus always agree:
+
+| Surface | Access | Format |
+|---------|--------|--------|
+| MCP tool | `get_metrics` with `metric_type: "retrieval"` | JSON snapshot |
+| CLI | `do-memory-cli monitor retrieval` | JSON snapshot or Prometheus text |
+| Prometheus scrape | `MetricsRegistry::export_metrics()` / `MetricsHttpServer` (`do_memory_core::monitoring::metrics`) | Text exposition |
+| Rust API | `global_retrieval_metrics()` -> `snapshot()` / `export_prometheus()` | JSON / text |
+
+The registry is process-local: counters reset on restart and are not shared
+across processes. For durable, cross-process history, scrape the exposition
+endpoint into Prometheus.
+
+---
+
+## Metric Families
+
+| Family | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `memory_retrieval_requests_total` | counter | `operation`, `tier`, `outcome` | Retrieval requests served, by operation, serving tier, and hit/miss outcome |
+| `memory_retrieval_duration_seconds` | summary | `operation`, `tier`, `quantile` | End-to-end retrieval latency per (operation, tier); quantiles 0.5, 0.95, 0.99 |
+| `memory_retrieval_candidates_sum` | counter | `stage` | Cumulative candidate-set size entering each pipeline stage |
+| `memory_retrieval_candidates_count` | counter | `stage` | Observations per stage; divide `sum` by `count` for the average candidate-set size |
+| `memory_cache_requests_total` | counter | `layer`, `result` | Query-cache lookups; `result` is `hit` or `miss` (currently `layer="query"`) |
+| `memory_embedding_requests_total` | counter | `provider`, `result` | Embedding calls by provider and `ok`/`error` result |
+| `memory_embedding_duration_seconds` | summary | `provider`, `quantile` | Embedding call latency per provider; quantiles 0.5, 0.95, 0.99 |
+| `memory_retrieval_fallback_total` | counter | `reason` | Tier-4 (remote embedding) fallback decisions by reason |
+| `memory_recommendation_feedback_total` | counter | `signal` | Recorded recommendation feedback by outcome signal |
+
+`memory_retrieval_candidates_sum` and `_count` are the `sum`/`count` pair of a
+single logical summary; HELP/TYPE lines are emitted once per family.
+
+---
+
+## Label Vocabularies (Bounded Enums)
+
+Labels are drawn from fixed enums only. Unknown values cannot be recorded, so
+the series count is bounded at compile time.
+
+| Label | Values |
+|-------|--------|
+| `operation` | `query`, `cascade` |
+| `tier` | `cache`, `hybrid`, `semantic`, `hierarchical`, `keyword`, `bm25`, `hdc`, `concept_graph`, `api`, `blended`, `none` |
+| `outcome` (requests) | `hit`, `miss` |
+| `stage` | `cascade`, `scored` |
+| `layer` | `query` |
+| `result` (cache) | `hit`, `miss` |
+| `provider` | `local`, `openai`, `mistral`, `azure_openai`, `custom` |
+| `result` (embeddings) | `ok`, `error` |
+| `reason` (fallback) | `local_tier_sufficient`, `local_confident`, `insufficient_confidence`, `no_local_results`, `always_embed_policy`, `local_only_policy` |
+| `signal` (feedback) | `success`, `partial`, `failure`, `abstained` |
+
+Tier markers that describe pipeline internals (for example `api_fallback_needed`)
+never become labels; they are folded into `tier` values or fallback reasons.
+
+---
+
+## PromQL / Dashboard Examples
+
+The four panels required by #962:
+
+**Tier distribution** (requests/sec served by each tier):
+
+```promql
+sum by (tier) (rate(memory_retrieval_requests_total[5m]))
+```
+
+**P95 retrieval latency** (seconds, per operation and tier):
+
+```promql
+memory_retrieval_duration_seconds{quantile="0.95"}
+```
+
+**Cache hit rate** (0..1):
+
+```promql
+sum(rate(memory_cache_requests_total{result="hit"}[5m]))
+  /
+sum(rate(memory_cache_requests_total[5m]))
+```
+
+**Embedding-call rate** (calls/sec by provider and result):
+
+```promql
+sum by (provider, result) (rate(memory_embedding_requests_total[5m]))
+```
+
+Additional useful panels:
+
+**Fallback decisions by reason** (share of escalations to remote embeddings):
+
+```promql
+sum by (reason) (rate(memory_retrieval_fallback_total[5m]))
+```
+
+**Average candidate-set size** per stage:
+
+```promql
+memory_retrieval_candidates_sum{stage="cascade"} / memory_retrieval_candidates_count{stage="cascade"}
+```
+
+**Embedding error ratio**:
+
+```promql
+sum by (provider) (rate(memory_embedding_requests_total{result="error"}[5m]))
+  /
+sum by (provider) (rate(memory_embedding_requests_total[5m]))
+```
+
+Suggested Grafana panel types: tier distribution and fallback reasons as
+time-series (stacked), P95 latency as time-series per tier, cache hit rate and
+embedding error ratio as stat/gauge panels.
+
+---
+
+## MCP Usage
+
+Call the `get_metrics` tool with `metric_type` set to `"retrieval"`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "get_metrics",
+    "arguments": {
+      "metric_type": "retrieval"
+    }
+  }
+}
+```
+
+Sample result (shape only — zero-valued entries are omitted in real output):
+
+```json
+{
+  "retrieval_metrics": {
+    "requests": [
+      {
+        "operation": "cascade",
+        "tier": "bm25",
+        "outcome": "hit",
+        "count": 128,
+        "latency_ms": { "p50": 1.8, "p95": 6.2, "p99": 11.4, "avg": 2.4 }
+      }
+    ],
+    "fallbacks": { "insufficient_confidence": 9 },
+    "feedback": { "success": 41, "partial": 3 },
+    "cache": { "hit": 210, "miss": 64 },
+    "embeddings": { "local": { "ok": 64, "error": 1 } },
+    "candidates": {
+      "cascade": { "observations": 64, "total": 1583 },
+      "scored": { "observations": 64, "total": 320 }
+    }
+  },
+  "timestamp": 1757068800
+}
+```
+
+Snapshot keys: `requests` (per-series counts plus `latency_ms` percentiles),
+`fallbacks` (reason -> count), `feedback` (signal -> count), `cache`
+(hit/miss -> count), `embeddings` (provider -> `{ok, error}`), `candidates`
+(stage -> `{observations, total}`).
+
+---
+
+## CLI Usage
+
+```console
+# JSON snapshot (default) — same shape as the MCP view above, without the envelope
+do-memory-cli monitor retrieval
+
+# Prometheus text exposition
+do-memory-cli monitor retrieval --format prometheus
+```
+
+The command reads the in-process registry directly (no network, no storage
+round-trips) and respects the global `--output human|json|yaml` formatting
+flag. To scrape the same families over HTTP, run a `MetricsHttpServer` on a
+`MetricsRegistry` and point Prometheus at its `/metrics` endpoint.
+
+---
+
+## Cardinality and Redaction Contract
+
+**Cardinality** — every label is a bounded enum, so the worst-case series count
+is fixed regardless of traffic or data:
+
+| Family | Max series |
+|--------|------------|
+| `memory_retrieval_requests_total` | 2 x 11 x 2 = 44 |
+| `memory_retrieval_duration_seconds` | 2 x 11 x 3 = 66 |
+| `memory_retrieval_candidates_sum` / `_count` | 2 stages x 2 = 4 |
+| `memory_cache_requests_total` | 1 x 2 = 2 |
+| `memory_embedding_requests_total` | 5 x 2 = 10 |
+| `memory_embedding_duration_seconds` | 5 x 3 = 15 |
+| `memory_retrieval_fallback_total` | 6 |
+| `memory_recommendation_feedback_total` | 4 |
+| **Total** | **151** |
+
+Zero-valued series are omitted from both the JSON snapshot and the Prometheus
+exposition, so an idle process exports almost nothing. A latency summary series
+is emitted once per (operation, tier) — not per outcome — and each metric
+family's HELP/TYPE header appears exactly once, keeping the exposition valid
+for strict scrapers.
+
+**Redaction** — telemetry is safe to expose by construction:
+
+- Labels come only from the bounded enums above; there is no free-form label
+  input path.
+- Query text, episode/pattern IDs, tags, and error strings can never appear as
+  label values, series names, or HELP text.
+- The JSON snapshot carries the same aggregates only; it never echoes request
+  payloads.
+
+---
+
+## See Also
+
+- [API Reference](./API_REFERENCE.md) — MCP tool contract (`get_metrics`)
+- <https://prometheus.io/docs/prometheus/latest/querying/basics/> — PromQL basics
+- <https://grafana.com/docs/grafana/latest/panels-visualizations/> — dashboard panels

--- a/memory-cli/src/commands/eval/benchmark.rs
+++ b/memory-cli/src/commands/eval/benchmark.rs
@@ -1,0 +1,141 @@
+//! Retrieval quality and cost benchmark command (`eval benchmark`).
+
+use std::path::PathBuf;
+
+use do_memory_core::retrieval::{
+    BenchmarkReport, FixtureCorpus, RegressionChecker, RegressionThresholds, RetrievalEvaluator,
+    RetrievalStrategy, format_markdown_report,
+};
+
+use crate::output::OutputFormat;
+
+#[allow(clippy::too_many_arguments)]
+pub async fn benchmark(
+    fixture_path: Option<PathBuf>,
+    strategy_str: String,
+    baseline_path: Option<PathBuf>,
+    fail_on_regression: bool,
+    max_recall_drop: f64,
+    max_mrr_drop: f64,
+    max_ndcg_drop: f64,
+    max_latency_increase: f64,
+    max_cost_increase: f64,
+    output_json: Option<PathBuf>,
+    output_markdown: Option<PathBuf>,
+    _remote: bool,
+    _format: OutputFormat,
+) -> anyhow::Result<()> {
+    // 1. Resolve fixture path
+    let default_fixture = PathBuf::from("benches/fixtures/retrieval_benchmark_corpus.json");
+    let target_fixture = fixture_path.unwrap_or(default_fixture);
+
+    if !target_fixture.exists() {
+        anyhow::bail!(
+            "Fixture corpus file not found at path: {}",
+            target_fixture.display()
+        );
+    }
+
+    let fixture_content = tokio::fs::read_to_string(&target_fixture).await?;
+    let corpus = if target_fixture.extension().and_then(|s| s.to_str()) == Some("jsonl") {
+        FixtureCorpus::from_jsonl_str(&fixture_content)?
+    } else {
+        FixtureCorpus::from_json_str(&fixture_content)?
+    };
+
+    let evaluator = RetrievalEvaluator::new(corpus);
+
+    // 2. Execute benchmark
+    let report: BenchmarkReport = if strategy_str.eq_ignore_ascii_case("all") {
+        evaluator.evaluate_all()?
+    } else {
+        let strategy: RetrievalStrategy = strategy_str.parse().map_err(anyhow::Error::msg)?;
+        let metrics = evaluator.evaluate_strategy(strategy)?;
+        let mut strategies = std::collections::HashMap::new();
+        strategies.insert(strategy.to_string(), metrics);
+        BenchmarkReport {
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            corpus_version: evaluator.corpus_version().to_string(),
+            corpus_size: evaluator.corpus_size(),
+            query_count: evaluator.query_count(),
+            strategies,
+        }
+    };
+
+    // 3. Baseline comparison
+    let default_baseline = PathBuf::from("benches/fixtures/retrieval_baseline.json");
+    let active_baseline_path = baseline_path.or_else(|| {
+        if default_baseline.exists() {
+            Some(default_baseline)
+        } else {
+            None
+        }
+    });
+
+    let check_result = if let Some(ref base_path) = active_baseline_path {
+        if base_path.exists() {
+            let base_content = tokio::fs::read_to_string(base_path).await?;
+            let baseline_report: BenchmarkReport = serde_json::from_str(&base_content)?;
+            let thresholds = RegressionThresholds {
+                max_recall_drop,
+                max_mrr_drop,
+                max_ndcg_drop,
+                max_latency_increase_ratio: max_latency_increase,
+                max_cost_increase_ratio: max_cost_increase,
+            };
+            let checker = RegressionChecker::new(thresholds);
+            Some(checker.check(&report, &baseline_report))
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    // 4. Output artifacts
+    let markdown_str = format_markdown_report(&report, check_result.as_ref());
+
+    if let Some(ref md_out) = output_markdown {
+        tokio::fs::write(md_out, &markdown_str).await?;
+    }
+
+    if let Some(ref json_out) = output_json {
+        let json_str = serde_json::to_string_pretty(&report)?;
+        tokio::fs::write(json_out, json_str).await?;
+    }
+
+    // Print summary report to stdout
+    println!("{markdown_str}");
+
+    // 5. Fail on regression if configured
+    if fail_on_regression {
+        if let Some(ref res) = check_result {
+            if !res.passed {
+                anyhow::bail!(
+                    "Retrieval benchmark failed regression checks: {}",
+                    res.summary
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Render a relative "N minutes/days/weeks ago" timestamp label.
+pub(super) fn format_time(dt: chrono::DateTime<chrono::Utc>) -> String {
+    let now = chrono::Utc::now();
+    let diff = now - dt;
+
+    if diff.num_seconds() < 60 {
+        "just now".to_string()
+    } else if diff.num_minutes() < 60 {
+        format!("{} minutes ago", diff.num_minutes())
+    } else if diff.num_hours() < 24 {
+        format!("{} hours ago", diff.num_hours())
+    } else if diff.num_days() < 7 {
+        format!("{} days ago", diff.num_days())
+    } else {
+        format!("{} weeks ago", diff.num_weeks())
+    }
+}

--- a/memory-cli/src/commands/eval/mod.rs
+++ b/memory-cli/src/commands/eval/mod.rs
@@ -4,13 +4,12 @@ use clap::Subcommand;
 use serde::Serialize;
 use std::path::PathBuf;
 
-use do_memory_core::retrieval::{
-    BenchmarkReport, FixtureCorpus, RegressionChecker, RegressionThresholds, RetrievalEvaluator,
-    RetrievalStrategy, format_markdown_report,
-};
-
 use crate::config::Config;
 use crate::output::{Output, OutputFormat};
+
+mod benchmark;
+pub use benchmark::benchmark;
+use benchmark::format_time;
 
 #[derive(Subcommand)]
 pub enum EvalCommands {
@@ -430,134 +429,4 @@ pub async fn domain_stats(
 
     detail.write(&mut std::io::stdout(), &format)?;
     Ok(())
-}
-
-#[allow(clippy::too_many_arguments)]
-pub async fn benchmark(
-    fixture_path: Option<PathBuf>,
-    strategy_str: String,
-    baseline_path: Option<PathBuf>,
-    fail_on_regression: bool,
-    max_recall_drop: f64,
-    max_mrr_drop: f64,
-    max_ndcg_drop: f64,
-    max_latency_increase: f64,
-    max_cost_increase: f64,
-    output_json: Option<PathBuf>,
-    output_markdown: Option<PathBuf>,
-    _remote: bool,
-    _format: OutputFormat,
-) -> anyhow::Result<()> {
-    // 1. Resolve fixture path
-    let default_fixture = PathBuf::from("benches/fixtures/retrieval_benchmark_corpus.json");
-    let target_fixture = fixture_path.unwrap_or(default_fixture);
-
-    if !target_fixture.exists() {
-        anyhow::bail!(
-            "Fixture corpus file not found at path: {}",
-            target_fixture.display()
-        );
-    }
-
-    let fixture_content = tokio::fs::read_to_string(&target_fixture).await?;
-    let corpus = if target_fixture.extension().and_then(|s| s.to_str()) == Some("jsonl") {
-        FixtureCorpus::from_jsonl_str(&fixture_content)?
-    } else {
-        FixtureCorpus::from_json_str(&fixture_content)?
-    };
-
-    let evaluator = RetrievalEvaluator::new(corpus);
-
-    // 2. Execute benchmark
-    let report: BenchmarkReport = if strategy_str.eq_ignore_ascii_case("all") {
-        evaluator.evaluate_all()?
-    } else {
-        let strategy: RetrievalStrategy = strategy_str.parse().map_err(anyhow::Error::msg)?;
-        let metrics = evaluator.evaluate_strategy(strategy)?;
-        let mut strategies = std::collections::HashMap::new();
-        strategies.insert(strategy.to_string(), metrics);
-        BenchmarkReport {
-            timestamp: chrono::Utc::now().to_rfc3339(),
-            corpus_version: evaluator.corpus_version().to_string(),
-            corpus_size: evaluator.corpus_size(),
-            query_count: evaluator.query_count(),
-            strategies,
-        }
-    };
-
-    // 3. Baseline comparison
-    let default_baseline = PathBuf::from("benches/fixtures/retrieval_baseline.json");
-    let active_baseline_path = baseline_path.or_else(|| {
-        if default_baseline.exists() {
-            Some(default_baseline)
-        } else {
-            None
-        }
-    });
-
-    let check_result = if let Some(ref base_path) = active_baseline_path {
-        if base_path.exists() {
-            let base_content = tokio::fs::read_to_string(base_path).await?;
-            let baseline_report: BenchmarkReport = serde_json::from_str(&base_content)?;
-            let thresholds = RegressionThresholds {
-                max_recall_drop,
-                max_mrr_drop,
-                max_ndcg_drop,
-                max_latency_increase_ratio: max_latency_increase,
-                max_cost_increase_ratio: max_cost_increase,
-            };
-            let checker = RegressionChecker::new(thresholds);
-            Some(checker.check(&report, &baseline_report))
-        } else {
-            None
-        }
-    } else {
-        None
-    };
-
-    // 4. Output artifacts
-    let markdown_str = format_markdown_report(&report, check_result.as_ref());
-
-    if let Some(ref md_out) = output_markdown {
-        tokio::fs::write(md_out, &markdown_str).await?;
-    }
-
-    if let Some(ref json_out) = output_json {
-        let json_str = serde_json::to_string_pretty(&report)?;
-        tokio::fs::write(json_out, json_str).await?;
-    }
-
-    // Print summary report to stdout
-    println!("{markdown_str}");
-
-    // 5. Fail on regression if configured
-    if fail_on_regression {
-        if let Some(ref res) = check_result {
-            if !res.passed {
-                anyhow::bail!(
-                    "Retrieval benchmark failed regression checks: {}",
-                    res.summary
-                );
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn format_time(dt: chrono::DateTime<chrono::Utc>) -> String {
-    let now = chrono::Utc::now();
-    let diff = now - dt;
-
-    if diff.num_seconds() < 60 {
-        "just now".to_string()
-    } else if diff.num_minutes() < 60 {
-        format!("{} minutes ago", diff.num_minutes())
-    } else if diff.num_hours() < 24 {
-        format!("{} hours ago", diff.num_hours())
-    } else if diff.num_days() < 7 {
-        format!("{} days ago", diff.num_days())
-    } else {
-        format!("{} weeks ago", diff.num_weeks())
-    }
 }

--- a/memory-cli/src/commands/mod.rs
+++ b/memory-cli/src/commands/mod.rs
@@ -152,6 +152,9 @@ pub async fn handle_monitor_command(
         MonitorCommands::Export {
             format: export_format,
         } => monitor::export_metrics(memory, config, format, export_format).await,
+        MonitorCommands::Retrieval {
+            format: metrics_format,
+        } => monitor::retrieval_metrics(format, metrics_format).await,
     }
 }
 

--- a/memory-cli/src/commands/monitor.rs
+++ b/memory-cli/src/commands/monitor.rs
@@ -16,6 +16,12 @@ pub enum MonitorCommands {
         #[arg(short, long, default_value = "prometheus")]
         format: ExportFormat,
     },
+    /// Show retrieval telemetry snapshot (issue #962)
+    Retrieval {
+        /// Snapshot format (json, prometheus)
+        #[arg(short, long, default_value = "json")]
+        format: RetrievalMetricsFormat,
+    },
 }
 
 #[derive(Debug, Clone, clap::ValueEnum)]
@@ -23,6 +29,15 @@ pub enum ExportFormat {
     Prometheus,
     Json,
     Influx,
+}
+
+/// Output format for the retrieval telemetry view.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum RetrievalMetricsFormat {
+    /// JSON snapshot (same shape as the MCP `get_metrics` retrieval view)
+    Json,
+    /// Prometheus text exposition
+    Prometheus,
 }
 
 #[derive(Debug, Serialize)]
@@ -155,6 +170,41 @@ impl Output for MetricsExport {
         writeln!(writer, "Timestamp: {}", self.timestamp)?;
         writeln!(writer, "Content:")?;
         writeln!(writer, "{}", self.content)?;
+
+        Ok(())
+    }
+}
+
+/// Retrieval telemetry export (issue #962).
+#[derive(Debug, Serialize)]
+pub struct RetrievalMetricsExport {
+    pub format: String,
+    pub timestamp: String,
+    /// JSON snapshot; present when `format` is `json`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snapshot: Option<serde_json::Value>,
+    /// Prometheus text exposition; present when `format` is `prometheus`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prometheus: Option<String>,
+}
+
+impl Output for RetrievalMetricsExport {
+    fn write_human<W: std::io::Write>(&self, mut writer: W) -> anyhow::Result<()> {
+        use colored::*;
+
+        writeln!(
+            writer,
+            "{}",
+            format!("Retrieval Metrics ({})", self.format).bold()
+        )?;
+        writeln!(writer, "{}", "─".repeat(40))?;
+        writeln!(writer, "Timestamp: {}", self.timestamp)?;
+        if let Some(snapshot) = &self.snapshot {
+            writeln!(writer, "{}", serde_json::to_string_pretty(snapshot)?)?;
+        }
+        if let Some(prometheus) = &self.prometheus {
+            writeln!(writer, "{}", prometheus)?;
+        }
 
         Ok(())
     }
@@ -331,4 +381,83 @@ pub async fn export_metrics(
 
     format.print_output(&export)?;
     Ok(())
+}
+
+/// Print the process-global retrieval telemetry snapshot (issue #962).
+///
+/// Reads `do_memory_core::monitoring::metrics::global_retrieval_metrics()`
+/// directly: the same registry the MCP `get_metrics` retrieval view and the
+/// unified Prometheus exposition serve. No network or storage access.
+pub async fn retrieval_metrics(
+    format: OutputFormat,
+    metrics_format: RetrievalMetricsFormat,
+) -> anyhow::Result<()> {
+    let registry = do_memory_core::monitoring::metrics::global_retrieval_metrics();
+    let timestamp = chrono::Utc::now()
+        .format("%Y-%m-%d %H:%M:%S UTC")
+        .to_string();
+
+    let export = match metrics_format {
+        RetrievalMetricsFormat::Json => RetrievalMetricsExport {
+            format: "json".to_string(),
+            timestamp,
+            snapshot: Some(registry.snapshot()),
+            prometheus: None,
+        },
+        RetrievalMetricsFormat::Prometheus => RetrievalMetricsExport {
+            format: "prometheus".to_string(),
+            timestamp,
+            snapshot: None,
+            prometheus: Some(registry.export_prometheus()),
+        },
+    };
+
+    format.print_output(&export)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn human_output_renders_prometheus_content() {
+        let export = RetrievalMetricsExport {
+            format: "prometheus".to_string(),
+            timestamp: "2026-09-05 00:00:00 UTC".to_string(),
+            snapshot: None,
+            prometheus: Some(
+                "memory_retrieval_requests_total{operation=\"query\",tier=\"cache\",outcome=\"hit\"} 1\n"
+                    .to_string(),
+            ),
+        };
+
+        let mut buffer = Vec::new();
+        export.write_human(&mut buffer).unwrap();
+
+        let text = String::from_utf8(buffer).unwrap();
+        assert!(text.contains("Retrieval Metrics (prometheus)"));
+        assert!(text.contains("memory_retrieval_requests_total"));
+    }
+
+    #[test]
+    fn json_output_embeds_snapshot_and_omits_empty_axis() {
+        let export = RetrievalMetricsExport {
+            format: "json".to_string(),
+            timestamp: "2026-09-05 00:00:00 UTC".to_string(),
+            snapshot: Some(serde_json::json!({"requests": [], "cache": {}})),
+            prometheus: None,
+        };
+
+        let mut buffer = Vec::new();
+        export.write_json(&mut buffer).unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_slice(&buffer).unwrap();
+        assert_eq!(parsed["format"], "json");
+        assert!(parsed["snapshot"].is_object());
+        assert!(
+            parsed.get("prometheus").is_none(),
+            "absent axis must be skipped, not serialized as null"
+        );
+    }
 }

--- a/memory-cli/tests/snapshots/snapshot_tests__cli_monitor_help.snap
+++ b/memory-cli/tests/snapshots/snapshot_tests__cli_monitor_help.snap
@@ -7,10 +7,11 @@ Monitoring and metrics
 Usage: do-memory-cli monitor <COMMAND>
 
 Commands:
-  status   Show current monitoring status
-  metrics  Export system metrics
-  export   Export metrics in specific format
-  help     Print this message or the help of the given subcommand(s)
+  status     Show current monitoring status
+  metrics    Export system metrics
+  export     Export metrics in specific format
+  retrieval  Show retrieval telemetry snapshot (issue #962)
+  help       Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help

--- a/memory-core/Cargo.toml
+++ b/memory-core/Cargo.toml
@@ -115,9 +115,10 @@ hnsw_rs = { version = "0.3.0", optional = true }
 # CSM cascading retrieval (optional, BM25 + HDC + ConceptGraph)
 chaotic_semantic_memory = { version = "0.3.6", optional = true }
 
-# Native-only: tokio::fs feature (not available on wasm32)
+# Native-only: tokio::fs and tokio::net (metrics HTTP server) are not
+# available on wasm32
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { workspace = true, features = ["fs"] }
+tokio = { workspace = true, features = ["fs", "net"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["sync", "macros", "rt", "time", "io-util", "rt-multi-thread", "test-util"] }

--- a/memory-core/src/embeddings/semantic_service.rs
+++ b/memory-core/src/embeddings/semantic_service.rs
@@ -293,7 +293,18 @@ impl SemanticService {
     /// - Outcome summary
     pub async fn embed_episode(&self, episode: &Episode) -> Result<Vec<f32>> {
         let text = super::semantic_text::episode_to_text(episode);
-        let embedding = self.provider.embed_text(&text).await?;
+        let start = std::time::Instant::now();
+        let outcome = self.provider.embed_text(&text).await;
+        let duration_ms = start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+        crate::monitoring::metrics::global_retrieval_metrics().record_embedding(
+            self.provider_label(),
+            match &outcome {
+                Ok(_) => crate::monitoring::metrics::EmbeddingOutcome::Ok,
+                Err(_) => crate::monitoring::metrics::EmbeddingOutcome::Error,
+            },
+            duration_ms,
+        );
+        let embedding = outcome?;
 
         // Store the embedding
         self.storage
@@ -311,7 +322,18 @@ impl SemanticService {
     /// - Pattern metadata and effectiveness metrics
     pub async fn embed_pattern(&self, pattern: &Pattern) -> Result<Vec<f32>> {
         let text = super::semantic_text::pattern_to_text(pattern);
-        let embedding = self.provider.embed_text(&text).await?;
+        let start = std::time::Instant::now();
+        let outcome = self.provider.embed_text(&text).await;
+        let duration_ms = start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+        crate::monitoring::metrics::global_retrieval_metrics().record_embedding(
+            self.provider_label(),
+            match &outcome {
+                Ok(_) => crate::monitoring::metrics::EmbeddingOutcome::Ok,
+                Err(_) => crate::monitoring::metrics::EmbeddingOutcome::Error,
+            },
+            duration_ms,
+        );
+        let embedding = outcome?;
 
         // Store the embedding
         self.storage
@@ -319,6 +341,38 @@ impl SemanticService {
             .await?;
 
         Ok(embedding)
+    }
+
+    /// Generate a query embedding with telemetry.
+    ///
+    /// Single choke point for query-time provider calls so per-query
+    /// embedding rates are observable (issue #962). Never records the
+    /// query text itself.
+    pub async fn embed_query_text(&self, text: &str) -> Result<Vec<f32>> {
+        let start = std::time::Instant::now();
+        let outcome = self.provider.embed_text(text).await;
+        let duration_ms = start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+        crate::monitoring::metrics::global_retrieval_metrics().record_embedding(
+            self.provider_label(),
+            match &outcome {
+                Ok(_) => crate::monitoring::metrics::EmbeddingOutcome::Ok,
+                Err(_) => crate::monitoring::metrics::EmbeddingOutcome::Error,
+            },
+            duration_ms,
+        );
+        outcome
+    }
+
+    /// Bounded provider label for telemetry from the configured provider.
+    fn provider_label(&self) -> crate::monitoring::metrics::EmbeddingProviderLabel {
+        use crate::monitoring::metrics::EmbeddingProviderLabel;
+        match &self.config.provider {
+            ProviderConfig::Local(_) => EmbeddingProviderLabel::Local,
+            ProviderConfig::OpenAI(_) => EmbeddingProviderLabel::OpenAI,
+            ProviderConfig::Mistral(_) => EmbeddingProviderLabel::Mistral,
+            ProviderConfig::AzureOpenAI(_) => EmbeddingProviderLabel::AzureOpenAI,
+            ProviderConfig::Custom(_) => EmbeddingProviderLabel::Custom,
+        }
     }
 
     /// Find semantically similar episodes for a query

--- a/memory-core/src/embeddings/tests.rs
+++ b/memory-core/src/embeddings/tests.rs
@@ -3,6 +3,7 @@
 use super::*;
 use crate::embeddings::storage::MockEmbeddingStorage;
 use crate::{Episode, Pattern, TaskContext};
+use serial_test::serial;
 
 fn create_test_episode() -> Episode {
     let context = TaskContext {
@@ -372,4 +373,32 @@ async fn build_exact_custom_provider_returns_err() {
         err_msg.contains("not supported"),
         "Error message should mention 'not supported', got: {err_msg}"
     );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_embed_records_provider_telemetry() {
+    use crate::monitoring::metrics::global_retrieval_metrics;
+
+    let storage = Box::new(MockEmbeddingStorage);
+    let config = EmbeddingConfig::default();
+    let service = SemanticService::new(
+        Box::new(MockLocalModel::new("mock".to_string(), 384)),
+        storage,
+        config,
+    );
+
+    let meter = global_retrieval_metrics();
+    let before = meter.snapshot()["embeddings"]["local"]["ok"]
+        .as_u64()
+        .unwrap_or(0);
+    let episode = create_test_episode();
+    service.embed_episode(&episode).await.unwrap();
+    let pattern = create_test_pattern();
+    service.embed_pattern(&pattern).await.unwrap();
+    let after = meter.snapshot()["embeddings"]["local"]["ok"]
+        .as_u64()
+        .unwrap_or(0);
+
+    assert_eq!(after - before, 2, "episode + pattern embeds recorded");
 }

--- a/memory-core/src/embeddings/tests.rs
+++ b/memory-core/src/embeddings/tests.rs
@@ -400,5 +400,12 @@ async fn test_embed_records_provider_telemetry() {
         .as_u64()
         .unwrap_or(0);
 
-    assert_eq!(after - before, 2, "episode + pattern embeds recorded");
+    // Lower bound, not equality: the registry is process-global and cargo
+    // test runs lib tests on shared threads, so concurrent tests may record
+    // additional embeds between the snapshots. Counters only grow.
+    assert!(
+        after - before >= 2,
+        "episode + pattern embeds recorded (delta {})",
+        after - before
+    );
 }

--- a/memory-core/src/memory/attribution/tracker/integrity.rs
+++ b/memory-core/src/memory/attribution/tracker/integrity.rs
@@ -65,10 +65,16 @@ impl RecommendationTracker {
         }
 
         // ADR-080 §4: Replacement feedback is idempotent (overwrite).
+        // Clone the outcome first: the map insert moves `feedback`.
+        let signal = crate::monitoring::metrics::FeedbackSignal::from_outcome(&feedback.outcome);
         {
             let mut feedback_map = self.feedback.write().await;
             feedback_map.insert(session_id, feedback);
         }
+
+        // Accepted caller feedback only: hydration replays bypass this
+        // function deliberately, so restarts never double-count (#962).
+        crate::monitoring::metrics::global_retrieval_metrics().record_feedback(signal);
 
         info!(
             session_id = %session_id,

--- a/memory-core/src/memory/retrieval/context.rs
+++ b/memory-core/src/memory/retrieval/context.rs
@@ -8,7 +8,7 @@ use crate::episode::Episode;
 use crate::spatiotemporal::RetrievalQuery;
 use crate::types::TaskContext;
 use std::sync::Arc;
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, info, instrument};
 
 use super::super::SelfLearningMemory;
 use super::helpers::{cache_episodes_if_eligible, generate_simple_embedding};
@@ -106,6 +106,7 @@ impl SelfLearningMemory {
             .with_provider_identity(self.semantic_config.provider.cache_identity())
             .with_ranking_config_version(crate::retrieval::RANKING_CONFIG_VERSION)
             .with_index_generation(self.query_cache.index_generation());
+        let query_start = std::time::Instant::now();
 
         if let Some(cached_episodes) = self.query_cache.get(&cache_key) {
             debug!(
@@ -127,6 +128,12 @@ impl SelfLearningMemory {
             }
 
             // Return Arc-clones (cheap reference count increment)
+            Self::record_query_outcome(
+                &query_start,
+                crate::monitoring::metrics::RetrievalTier::Cache,
+                cached_episodes.len(),
+                None,
+            );
             return cached_episodes.clone();
         }
 
@@ -205,98 +212,44 @@ impl SelfLearningMemory {
 
         if completed_episodes.is_empty() {
             info!("No completed episodes found for retrieval");
+            Self::record_query_outcome(
+                &query_start,
+                crate::monitoring::metrics::RetrievalTier::None,
+                0,
+                None,
+            );
             return vec![];
         }
 
-        // ============================================================================
-        // ============================================================================
         // Hybrid Search (v0.1.34) - Improved ANN-backed retrieval
-        // ============================================================================
-        if self.config.retrieval_mode == crate::types::RetrievalMode::Hybrid {
-            if let (Some(retriever), Some(semantic)) =
-                (&self.semantic_retriever, &self.semantic_service)
-            {
-                // Generate query embedding
-                match semantic.provider.embed_text(&task_description).await {
-                    Ok(query_embedding) => {
-                        let episodes_map: std::collections::HashMap<uuid::Uuid, Arc<Episode>> =
-                            completed_episodes
-                                .iter()
-                                .map(|e| (e.episode_id, e.clone()))
-                                .collect();
-                        match retriever.retrieve(
-                            &task_description,
-                            &query_embedding,
-                            &context,
-                            episodes_map,
-                            limit,
-                        ) {
-                            Ok(hits) => {
-                                if !hits.is_empty() {
-                                    let hybrid_episodes: Vec<Arc<Episode>> =
-                                        hits.into_iter().map(|h| h.episode).collect();
-                                    cache_episodes_if_eligible(
-                                        &self.query_cache,
-                                        cache_key.clone(),
-                                        &hybrid_episodes,
-                                    );
-                                    info!(
-                                        retrieved_count = hybrid_episodes.len(),
-                                        "Retrieved episodes using hybrid search"
-                                    );
-                                    return hybrid_episodes;
-                                }
-                            }
-                            Err(e) => warn!(error = %e, "Hybrid retrieval failed, falling back"),
-                        }
-                    }
-                    Err(e) => {
-                        warn!(error = %e, "Query embedding failed for hybrid search, falling back");
-                    }
-                }
-            }
+        if let Some(hybrid_episodes) = self
+            .try_hybrid_retrieval(
+                &task_description,
+                &context,
+                limit,
+                &cache_key,
+                &completed_episodes,
+                query_start,
+            )
+            .await
+        {
+            return hybrid_episodes;
         }
 
         // Semantic Search - Try semantic similarity first
-        // ============================================================================
-
         if let Some(ref semantic) = self.semantic_service {
-            match semantic
-                .find_similar_episodes(&task_description, &context, limit)
+            if let Some(semantic_episodes) = self
+                .try_semantic_retrieval(
+                    semantic,
+                    &task_description,
+                    &context,
+                    limit,
+                    &cache_key,
+                    query_start,
+                )
                 .await
             {
-                Ok(mut results) => {
-                    if !results.is_empty() {
-                        info!(
-                            semantic_results = results.len(),
-                            "Found episodes via semantic search"
-                        );
-
-                        // Limit results and extract episodes
-                        results.truncate(limit);
-
-                        // Convert to Arc<Episode> for cheap cloning
-                        let semantic_episodes: Vec<Arc<Episode>> = results
-                            .into_iter()
-                            .map(|result| Arc::new(result.item))
-                            .collect();
-
-                        cache_episodes_if_eligible(
-                            &self.query_cache,
-                            cache_key.clone(),
-                            &semantic_episodes,
-                        );
-
-                        return semantic_episodes;
-                    }
-                }
-                Err(e) => {
-                    warn!(
-                        error = %e,
-                        "Semantic search failed: {}. Falling back to keyword search.",
-                        e
-                    );
-                }
+                return semantic_episodes;
             }
         }
 
@@ -308,7 +261,7 @@ impl SelfLearningMemory {
         let scored_episodes = if let Some(ref retriever) = self.hierarchical_retriever {
             // Generate query embedding if semantic service is available
             let query_embedding = if let Some(ref semantic) = self.semantic_service {
-                match semantic.provider.embed_text(&task_description).await {
+                match semantic.embed_query_text(&task_description).await {
                     Ok(embedding) => {
                         debug!(
                             embedding_dim = embedding.len(),
@@ -408,6 +361,12 @@ impl SelfLearningMemory {
             );
 
             cache_episodes_if_eligible(&self.query_cache, cache_key.clone(), &relevant);
+            Self::record_query_outcome(
+                &query_start,
+                crate::monitoring::metrics::RetrievalTier::Keyword,
+                relevant.len(),
+                None,
+            );
             return relevant;
         }
 
@@ -466,6 +425,12 @@ impl SelfLearningMemory {
             );
 
             cache_episodes_if_eligible(&self.query_cache, cache_key.clone(), &result_arc_episodes);
+            Self::record_query_outcome(
+                &query_start,
+                crate::monitoring::metrics::RetrievalTier::Hierarchical,
+                result_arc_episodes.len(),
+                Some(scored_episodes.len()),
+            );
             return result_arc_episodes;
         }
 
@@ -487,6 +452,12 @@ impl SelfLearningMemory {
         );
 
         cache_episodes_if_eligible(&self.query_cache, cache_key, &result_arc_episodes);
+        Self::record_query_outcome(
+            &query_start,
+            crate::monitoring::metrics::RetrievalTier::Hierarchical,
+            result_arc_episodes.len(),
+            Some(scored_episodes.len()),
+        );
         result_arc_episodes
     }
 }

--- a/memory-core/src/memory/retrieval/context_branches.rs
+++ b/memory-core/src/memory/retrieval/context_branches.rs
@@ -1,0 +1,174 @@
+//! Semantic-sense branches of the context retrieval pipeline.
+//!
+//! Extracted from `context.rs` to honor the 500 LOC invariant; these are
+//! inherent methods of [`SelfLearningMemory`], split across files. Each
+//! helper returns `None` so the caller falls through to the next branch.
+
+use std::sync::Arc;
+use tracing::{info, warn};
+
+use crate::episode::Episode;
+use crate::types::TaskContext;
+
+use super::super::SelfLearningMemory;
+use super::helpers::cache_episodes_if_eligible;
+
+impl SelfLearningMemory {
+    /// Attempt hybrid ANN-backed retrieval (v0.1.34).
+    ///
+    /// Generates the query embedding, runs the semantic retriever, caches
+    /// and records the hybrid-tier outcome on success. Returns `None` when
+    /// hybrid mode is off, the service pair is unavailable, embedding or
+    /// retrieval fails, or no hits were found.
+    pub(super) async fn try_hybrid_retrieval(
+        &self,
+        task_description: &str,
+        context: &TaskContext,
+        limit: usize,
+        cache_key: &crate::retrieval::CacheKey,
+        completed_episodes: &[Arc<Episode>],
+        query_start: std::time::Instant,
+    ) -> Option<Vec<Arc<Episode>>> {
+        if self.config.retrieval_mode != crate::types::RetrievalMode::Hybrid {
+            return None;
+        }
+        let (retriever, semantic) = (
+            self.semantic_retriever.as_ref()?,
+            self.semantic_service.as_ref()?,
+        );
+
+        // Generate query embedding
+        match semantic.embed_query_text(task_description).await {
+            Ok(query_embedding) => {
+                let episodes_map: std::collections::HashMap<uuid::Uuid, Arc<Episode>> =
+                    completed_episodes
+                        .iter()
+                        .map(|e| (e.episode_id, e.clone()))
+                        .collect();
+                match retriever.retrieve(
+                    task_description,
+                    &query_embedding,
+                    context,
+                    episodes_map,
+                    limit,
+                ) {
+                    Ok(hits) => {
+                        if hits.is_empty() {
+                            return None;
+                        }
+                        let hybrid_episodes: Vec<Arc<Episode>> =
+                            hits.into_iter().map(|h| h.episode).collect();
+                        cache_episodes_if_eligible(
+                            &self.query_cache,
+                            cache_key.clone(),
+                            &hybrid_episodes,
+                        );
+                        info!(
+                            retrieved_count = hybrid_episodes.len(),
+                            "Retrieved episodes using hybrid search"
+                        );
+                        Self::record_query_outcome(
+                            &query_start,
+                            crate::monitoring::metrics::RetrievalTier::Hybrid,
+                            hybrid_episodes.len(),
+                            None,
+                        );
+                        Some(hybrid_episodes)
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "Hybrid retrieval failed, falling back");
+                        None
+                    }
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, "Query embedding failed for hybrid search, falling back");
+                None
+            }
+        }
+    }
+
+    /// Attempt semantic similarity retrieval.
+    ///
+    /// Truncates to `limit`, caches, and records the semantic-tier outcome
+    /// on success. Returns `None` when the service finds nothing or fails,
+    /// so the caller falls back to keyword/hierarchical retrieval.
+    pub(super) async fn try_semantic_retrieval(
+        &self,
+        semantic: &crate::embeddings::SemanticService,
+        task_description: &str,
+        context: &TaskContext,
+        limit: usize,
+        cache_key: &crate::retrieval::CacheKey,
+        query_start: std::time::Instant,
+    ) -> Option<Vec<Arc<Episode>>> {
+        match semantic
+            .find_similar_episodes(task_description, context, limit)
+            .await
+        {
+            Ok(mut results) => {
+                if results.is_empty() {
+                    return None;
+                }
+                info!(
+                    semantic_results = results.len(),
+                    "Found episodes via semantic search"
+                );
+
+                // Limit results and convert to Arc<Episode> for cheap cloning
+                results.truncate(limit);
+                let semantic_episodes: Vec<Arc<Episode>> = results
+                    .into_iter()
+                    .map(|result| Arc::new(result.item))
+                    .collect();
+
+                cache_episodes_if_eligible(
+                    &self.query_cache,
+                    cache_key.clone(),
+                    &semantic_episodes,
+                );
+
+                Self::record_query_outcome(
+                    &query_start,
+                    crate::monitoring::metrics::RetrievalTier::Semantic,
+                    semantic_episodes.len(),
+                    None,
+                );
+                Some(semantic_episodes)
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "Semantic search failed: {}. Falling back to keyword search.",
+                    e
+                );
+                None
+            }
+        }
+    }
+
+    /// Record one finished query path: request, duration, and scored count.
+    ///
+    /// Never records query text, IDs, or scores (redaction contract, #962).
+    pub(super) fn record_query_outcome(
+        start: &std::time::Instant,
+        tier: crate::monitoring::metrics::RetrievalTier,
+        returned: usize,
+        scored: Option<usize>,
+    ) {
+        use crate::monitoring::metrics::{
+            RetrievalOperation, RetrievalOutcome, RetrievalStage, global_retrieval_metrics,
+        };
+
+        let telemetry = global_retrieval_metrics();
+        telemetry.record_request(
+            RetrievalOperation::Query,
+            tier,
+            RetrievalOutcome::from_count(returned),
+            start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
+        );
+        if let Some(scored) = scored {
+            telemetry.record_candidates(RetrievalStage::Scored, scored);
+        }
+    }
+}

--- a/memory-core/src/memory/retrieval/mod.rs
+++ b/memory-core/src/memory/retrieval/mod.rs
@@ -1,6 +1,7 @@
 //! Episode and pattern retrieval
 
 pub mod context;
+mod context_branches;
 pub mod helpers;
 pub mod heuristics;
 pub mod patterns;

--- a/memory-core/src/monitoring/metrics/mod.rs
+++ b/memory-core/src/monitoring/metrics/mod.rs
@@ -1,136 +1,12 @@
-//! Metrics types for HTTP server for Prometheus format export.
+#![allow(
+    clippy::uninlined_format_args,
+    clippy::must_use_candidate,
+    clippy::doc_markdown,
+    clippy::struct_field_names,
+    clippy::derivable_impls,
+    clippy::unwrap_or_default
+)]
 
-use parking_lot::RwLock;
-use std::collections::HashMap;
-use std::fmt::Write;
-use std::sync::Arc;
-use tracing::debug;
-use tokio::net::TcpListener;
-use tokio::task::JoinHandle;
-use tracing::{error, info};
-
-use super::metrics_registry;
-
-/// HTTP server for serving Prometheus metrics at /metrics`
-pub struct MetricsHttpServer {
-    registry: MetricsRegistry,
-    handle: Option<JoinHandle<()>>,
-}
-
-impl MetricsHttpServer {
-    /// Start the HTTP server on the given address
-    pub async fn start(&mut self, addr: &str) -> std::io::Result<()> {
-        let addr: SocketAddr = addr
-            .parse()
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
-
-        let listener = TcpListener::bind(addr).await?;
-        info!("Metrics HTTP server listening on http://{}/metrics", addr);
-
-        let registry = self.registry.clone();
-
-        let handle = tokio::spawn(async move {
-            loop {
-                let Ok((stream, peer_addr)) = listener.accept().await else {
-                    error!("Failed to accept connection");
-                    continue;
-                }
-                let registry = registry.clone();
-                tokio::spawn(handle_connection(stream, peer_addr, registry));
-            }
-        });
-
-        self.handle = Some(handle);
-        Ok(())
-    }
-
-    /// Stop the HTTP server
-    pub fn stop(&mut self) {
-        if let Some(handle) = self.handle.take() {
-            handle.abort();
-            info!("Metrics HTTP server stopped");
-        }
-    }
-}
-
-impl Drop for MetricsHttpServer {
-    fn drop(&mut self) {
-        self.stop();
-    }
-}
-
-/// Handle a single HTTP connection
-async fn handle_connection(
-    mut stream: tokio::net::TcpStream,
-    peer_addr: std::net::SocketAddr,
-    registry: MetricsRegistry,
-) {
-    if let Err(e) = handle_connection_impl(&mut stream, peer_addr, &registry).await {
-        tracing::warn!("Error handling connection from {}: {}", peer_addr, e);
-    }
-}
-
-async fn handle_connection_impl(
-    stream: &mut tokio::net::TcpStream,
-    peer_addr: std::net::SocketAddr,
-    registry: &MetricsRegistry,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
-    let mut buffer = [0u8; 1024];
-    let n = stream.read(&mut buffer).await?;
-    let request = String::from_utf8_lossy(&buffer[..n]);
-    let request_line = request.lines().next().unwrap_or("line 1 of file does truncated
-
-    let request_line = request.lines().next().unwrap_or("line 2 of file truncated (only first line with request method and path).
-    let parts: Vec<&str> = request_line.split_whitespace().collect();
-
-    if parts.len() < 2 {
-        let response = "HTTP/1.1 400 Bad Request\r\n\r\n";
-        stream.write_all(response.as_bytes()).await?;
-        return Ok(());
-    }
-
-    let method = parts[0];
-    match method {
-        "GET" => {
-            let response = "HTTP/1.1 405 Method Not Allowed\r\n\r\n";
-            stream.write_all(response.as_bytes()).await?;
-            return Ok(());
-        }
-
-        let method != "GET" {
-            return Ok(());
-        }
-
-        match path {
-        "/metrics" => {
-            let metrics = registry.export_metrics();
-            let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\n\r\n{}",
-                metrics.len(),
-                metrics
-            );
-            stream.write_all(response.as_bytes()).await?;
-            info!("Served metrics to {}", peer_addr);
-        }
-        "/health" => {
-            let body = "OK";
-            let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\n\r\n{}",
-                body.len(),
-                body
-            );
-            stream.write_all(response.as_bytes()).await?;
-        }
-        _ => {
-            let response = "HTTP/1.1 404 Not Found\r\n\r\n";
-            stream.write_all(response.as_bytes()).await?;
-        }
-    }
-
-    Ok(())
-}
 //! # Unified Prometheus Metrics
 //!
 //! This module provides unified Prometheus metrics export for both
@@ -151,23 +27,22 @@ async fn handle_connection_impl(
 //! let registry = MetricsRegistry::new();
 //! ```
 
-#![allow(
-    clippy::uninlined_format_args,
-    clippy::must_use_candidate,
-    clippy::doc_markdown,
-    clippy::struct_field_names,
-    clippy::derivable_impls,
-    clippy::unwrap_or_default
-)]
-
 use std::fmt::Write;
 use std::sync::Arc;
 use tracing::debug;
 
+#[cfg(not(target_arch = "wasm32"))]
 mod http_server;
+mod retrieval_metrics;
 mod storage_metrics;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub use http_server::MetricsHttpServer;
+pub use retrieval_metrics::{
+    CacheLayer, EmbeddingOutcome, EmbeddingProviderLabel, FallbackReason, FeedbackSignal,
+    RetrievalMetrics, RetrievalOperation, RetrievalOutcome, RetrievalStage, RetrievalTier,
+    cascade_tier, global_retrieval_metrics, provisional_fallback_reason,
+};
 pub use storage_metrics::{CacheStats, OperationLatency, RedbMetrics, TursoStorageMetrics};
 
 /// Unified metrics registry for all storage backends
@@ -177,6 +52,8 @@ pub struct MetricsRegistry {
     redb_metrics: Arc<RedbMetrics>,
     /// Turso storage metrics
     turso_metrics: Arc<TursoStorageMetrics>,
+    /// Retrieval-plane metrics (issue #962)
+    retrieval_metrics: Arc<RetrievalMetrics>,
     /// Last export timestamp
     last_export: parking_lot::RwLock<u64>,
     /// Export count
@@ -188,6 +65,7 @@ impl Clone for MetricsRegistry {
         Self {
             redb_metrics: self.redb_metrics.clone(),
             turso_metrics: self.turso_metrics.clone(),
+            retrieval_metrics: self.retrieval_metrics.clone(),
             last_export: parking_lot::RwLock::new(*self.last_export.read()),
             export_count: parking_lot::RwLock::new(*self.export_count.read()),
         }
@@ -200,6 +78,7 @@ impl MetricsRegistry {
         Self {
             redb_metrics: Arc::new(RedbMetrics::new()),
             turso_metrics: Arc::new(TursoStorageMetrics::new()),
+            retrieval_metrics: global_retrieval_metrics(),
             last_export: parking_lot::RwLock::new(0),
             export_count: parking_lot::RwLock::new(0),
         }
@@ -213,6 +92,11 @@ impl MetricsRegistry {
     /// Get turso metrics reference
     pub fn turso(&self) -> &Arc<TursoStorageMetrics> {
         &self.turso_metrics
+    }
+
+    /// Get retrieval-plane metrics reference
+    pub fn retrieval(&self) -> &Arc<RetrievalMetrics> {
+        &self.retrieval_metrics
     }
 
     /// Export all metrics in Prometheus format
@@ -232,6 +116,9 @@ impl MetricsRegistry {
 
         // Export turso metrics
         self.export_turso_metrics(&mut output);
+
+        // Export retrieval-plane metrics (issue #962)
+        output.push_str(&self.retrieval_metrics.export_prometheus());
 
         debug!("Exported {} bytes of unified metrics", output.len());
         output
@@ -374,6 +261,7 @@ impl MetricsRegistry {
     pub fn reset(&self) {
         self.redb_metrics.reset();
         self.turso_metrics.reset();
+        self.retrieval_metrics.reset();
     }
 }
 

--- a/memory-core/src/monitoring/metrics/retrieval_metrics/exposition.rs
+++ b/memory-core/src/monitoring/metrics/retrieval_metrics/exposition.rs
@@ -1,0 +1,405 @@
+//! JSON snapshot and Prometheus text rendering for retrieval telemetry
+//! (issue #962). Zero-valued series are omitted from both renderings.
+
+use serde_json::{Value, json};
+use std::fmt::Write as _;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use super::labels::{
+    CacheLayer, EmbeddingOutcome, EmbeddingProviderLabel, FALLBACK_REASONS, FeedbackSignal,
+    RetrievalOperation, RetrievalOutcome, RetrievalStage, RetrievalTier,
+};
+use super::registry::RetrievalMetrics;
+
+const ALL_OPERATIONS: [RetrievalOperation; 2] =
+    [RetrievalOperation::Query, RetrievalOperation::Cascade];
+
+const ALL_TIERS: [RetrievalTier; 11] = [
+    RetrievalTier::Cache,
+    RetrievalTier::Hybrid,
+    RetrievalTier::Semantic,
+    RetrievalTier::Hierarchical,
+    RetrievalTier::Keyword,
+    RetrievalTier::Bm25,
+    RetrievalTier::Hdc,
+    RetrievalTier::ConceptGraph,
+    RetrievalTier::Api,
+    RetrievalTier::Blended,
+    RetrievalTier::None,
+];
+
+const ALL_OUTCOMES: [RetrievalOutcome; 2] = [RetrievalOutcome::Hit, RetrievalOutcome::Miss];
+
+const ALL_PROVIDERS: [EmbeddingProviderLabel; 5] = [
+    EmbeddingProviderLabel::Local,
+    EmbeddingProviderLabel::OpenAI,
+    EmbeddingProviderLabel::Mistral,
+    EmbeddingProviderLabel::AzureOpenAI,
+    EmbeddingProviderLabel::Custom,
+];
+
+const ALL_SIGNALS: [FeedbackSignal; 4] = [
+    FeedbackSignal::Success,
+    FeedbackSignal::Partial,
+    FeedbackSignal::Failure,
+    FeedbackSignal::Abstained,
+];
+
+impl RetrievalMetrics {
+    /// JSON snapshot for MCP `get_metrics` (zero series omitted).
+    #[must_use]
+    pub fn snapshot(&self) -> Value {
+        let mut requests = Vec::new();
+        for op in ALL_OPERATIONS {
+            for tier in ALL_TIERS {
+                self.push_request_rows(&mut requests, op, tier);
+            }
+        }
+        json!({
+            "requests": requests,
+            "fallbacks": self.str_map(&self.fallbacks, &FALLBACK_REASONS),
+            "feedback": self.signal_map(),
+            "cache": self.cache_map(),
+            "embeddings": self.embeddings_map(),
+            "candidates": self.candidates_map(),
+        })
+    }
+
+    /// Append nonzero request rows for one (operation, tier) series.
+    fn push_request_rows(
+        &self,
+        requests: &mut Vec<Value>,
+        op: RetrievalOperation,
+        tier: RetrievalTier,
+    ) {
+        for outcome in ALL_OUTCOMES {
+            let count =
+                self.requests[op.index()][tier.index()][outcome.index()].load(Ordering::Relaxed);
+            if count == 0 {
+                continue;
+            }
+            let latency = self.durations_ms[op.index()][tier.index()].lock();
+            let (p50, p95, p99) = latency.percentiles_ms();
+            requests.push(json!({
+                "operation": op.as_str(),
+                "tier": tier.as_str(),
+                "outcome": outcome.as_str(),
+                "count": count,
+                "latency_ms": {"p50": p50, "p95": p95, "p99": p99, "avg": latency.avg_ms()},
+            }));
+        }
+    }
+
+    /// Write nonzero request-count samples for one (operation, tier).
+    fn write_request_lines(&self, out: &mut String, op: RetrievalOperation, tier: RetrievalTier) {
+        for outcome in ALL_OUTCOMES {
+            let count =
+                self.requests[op.index()][tier.index()][outcome.index()].load(Ordering::Relaxed);
+            if count == 0 {
+                continue;
+            }
+            let _ = writeln!(
+                out,
+                "memory_retrieval_requests_total{{operation=\"{}\",tier=\"{}\",outcome=\"{}\"}} {}",
+                op.as_str(),
+                tier.as_str(),
+                outcome.as_str(),
+                count
+            );
+        }
+    }
+
+    /// Write the quantile samples for one (operation, tier) latency series.
+    fn write_duration_lines(&self, out: &mut String, op: RetrievalOperation, tier: RetrievalTier) {
+        let latency = self.durations_ms[op.index()][tier.index()].lock();
+        if latency.count() == 0 {
+            return;
+        }
+        let (p50, p95, p99) = latency.percentiles_ms();
+        for (quantile, value_ms) in [("0.5", p50), ("0.95", p95), ("0.99", p99)] {
+            let _ = writeln!(
+                out,
+                "memory_retrieval_duration_seconds{{operation=\"{}\",tier=\"{}\",quantile=\"{}\"}} {:.3}",
+                op.as_str(),
+                tier.as_str(),
+                quantile,
+                value_ms as f64 / 1000.0
+            );
+        }
+    }
+
+    /// Prometheus text exposition (zero series omitted).
+    ///
+    /// HELP/TYPE lines are emitted exactly once per metric family, before
+    /// its samples — duplicate TYPE lines are rejected by strict scrapers.
+    #[must_use]
+    pub fn export_prometheus(&self) -> String {
+        let mut out = String::with_capacity(2048);
+        out.push_str("# HELP memory_retrieval_requests_total Retrieval requests by operation, tier, outcome\n");
+        out.push_str("# TYPE memory_retrieval_requests_total counter\n");
+        for op in ALL_OPERATIONS {
+            for tier in ALL_TIERS {
+                self.write_request_lines(&mut out, op, tier);
+            }
+        }
+
+        // Duration quantiles are tracked per (operation, tier); emit each
+        // series once even when both hit and miss outcomes are nonzero.
+        out.push_str("# HELP memory_retrieval_duration_seconds Retrieval request latency by operation and tier\n");
+        out.push_str("# TYPE memory_retrieval_duration_seconds summary\n");
+        for op in ALL_OPERATIONS {
+            for tier in ALL_TIERS {
+                self.write_duration_lines(&mut out, op, tier);
+            }
+        }
+
+        out.push_str("# HELP memory_retrieval_candidates Candidate-set sizes by pipeline stage\n");
+        out.push_str("# TYPE memory_retrieval_candidates summary\n");
+        for stage in [RetrievalStage::Cascade, RetrievalStage::Scored] {
+            let count = self.candidates_count[stage.index()].load(Ordering::Relaxed);
+            if count == 0 {
+                continue;
+            }
+            let sum = self.candidates_sum[stage.index()].load(Ordering::Relaxed);
+            let _ = writeln!(
+                out,
+                "memory_retrieval_candidates_sum{{stage=\"{}\"}} {}",
+                stage.as_str(),
+                sum
+            );
+            let _ = writeln!(
+                out,
+                "memory_retrieval_candidates_count{{stage=\"{}\"}} {}",
+                stage.as_str(),
+                count
+            );
+        }
+
+        out.push_str("# HELP memory_cache_requests_total Cache lookups by layer and result\n");
+        out.push_str("# TYPE memory_cache_requests_total counter\n");
+        for outcome in ALL_OUTCOMES {
+            let count =
+                self.cache[CacheLayer::Query.index()][outcome.index()].load(Ordering::Relaxed);
+            if count == 0 {
+                continue;
+            }
+            let _ = writeln!(
+                out,
+                "memory_cache_requests_total{{layer=\"query\",result=\"{}\"}} {}",
+                outcome.as_str(),
+                count
+            );
+        }
+
+        out.push_str(
+            "# HELP memory_embedding_requests_total Embedding calls by provider and result\n",
+        );
+        out.push_str("# TYPE memory_embedding_requests_total counter\n");
+        out.push_str(
+            "# HELP memory_embedding_duration_seconds Embedding call latency by provider\n",
+        );
+        out.push_str("# TYPE memory_embedding_duration_seconds summary\n");
+        for provider in ALL_PROVIDERS {
+            for outcome in [EmbeddingOutcome::Ok, EmbeddingOutcome::Error] {
+                let count =
+                    self.embeddings[provider.index()][outcome.index()].load(Ordering::Relaxed);
+                if count == 0 {
+                    continue;
+                }
+                let _ = writeln!(
+                    out,
+                    "memory_embedding_requests_total{{provider=\"{}\",result=\"{}\"}} {}",
+                    provider.as_str(),
+                    outcome.as_str(),
+                    count
+                );
+            }
+            let latency = self.embedding_durations_ms[provider.index()].lock();
+            if latency.count() > 0 {
+                let (p50, p95, p99) = latency.percentiles_ms();
+                for (quantile, value_ms) in [("0.5", p50), ("0.95", p95), ("0.99", p99)] {
+                    let _ = writeln!(
+                        out,
+                        "memory_embedding_duration_seconds{{provider=\"{}\",quantile=\"{}\"}} {:.3}",
+                        provider.as_str(),
+                        quantile,
+                        value_ms as f64 / 1000.0
+                    );
+                }
+            }
+        }
+
+        out.push_str(
+            "# HELP memory_retrieval_fallback_total Tier-4 fallback decisions by reason\n",
+        );
+        out.push_str("# TYPE memory_retrieval_fallback_total counter\n");
+        for (i, reason) in FALLBACK_REASONS.iter().enumerate() {
+            let count = self.fallbacks[i].load(Ordering::Relaxed);
+            if count == 0 {
+                continue;
+            }
+            let _ = writeln!(
+                out,
+                "memory_retrieval_fallback_total{{reason=\"{reason}\"}} {count}"
+            );
+        }
+
+        out.push_str(
+            "# HELP memory_recommendation_feedback_total Accepted feedback by outcome signal\n",
+        );
+        out.push_str("# TYPE memory_recommendation_feedback_total counter\n");
+        for signal in ALL_SIGNALS {
+            let count = self.feedback[signal.index()].load(Ordering::Relaxed);
+            if count == 0 {
+                continue;
+            }
+            let _ = writeln!(
+                out,
+                "memory_recommendation_feedback_total{{signal=\"{}\"}} {}",
+                signal.as_str(),
+                count
+            );
+        }
+        out
+    }
+
+    /// Nonzero fallback counts keyed by reason.
+    fn str_map(&self, cells: &[AtomicU64], names: &[&str]) -> Value {
+        let map: serde_json::Map<String, Value> = cells
+            .iter()
+            .zip(names.iter().copied())
+            .filter_map(|(cell, name)| {
+                let count = cell.load(Ordering::Relaxed);
+                (count > 0).then(|| (name.to_string(), json!(count)))
+            })
+            .collect();
+        Value::Object(map)
+    }
+
+    /// Nonzero feedback counts keyed by signal.
+    fn signal_map(&self) -> Value {
+        let map: serde_json::Map<String, Value> = ALL_SIGNALS
+            .iter()
+            .filter_map(|signal| {
+                let count = self.feedback[signal.index()].load(Ordering::Relaxed);
+                (count > 0).then(|| (signal.as_str().to_string(), json!(count)))
+            })
+            .collect();
+        Value::Object(map)
+    }
+
+    /// Nonzero cache counts keyed by result.
+    fn cache_map(&self) -> Value {
+        let map: serde_json::Map<String, Value> = ALL_OUTCOMES
+            .iter()
+            .filter_map(|outcome| {
+                let count =
+                    self.cache[CacheLayer::Query.index()][outcome.index()].load(Ordering::Relaxed);
+                (count > 0).then(|| (outcome.as_str().to_string(), json!(count)))
+            })
+            .collect();
+        Value::Object(map)
+    }
+
+    /// Nonzero embedding counts keyed by provider and result.
+    fn embeddings_map(&self) -> Value {
+        let map: serde_json::Map<String, Value> = ALL_PROVIDERS
+            .iter()
+            .filter_map(|provider| {
+                let ok = self.embeddings[provider.index()][EmbeddingOutcome::Ok.index()]
+                    .load(Ordering::Relaxed);
+                let err = self.embeddings[provider.index()][EmbeddingOutcome::Error.index()]
+                    .load(Ordering::Relaxed);
+                (ok + err > 0).then(|| {
+                    (
+                        provider.as_str().to_string(),
+                        json!({"ok": ok, "error": err}),
+                    )
+                })
+            })
+            .collect();
+        Value::Object(map)
+    }
+
+    /// Candidate sum/count keyed by stage.
+    fn candidates_map(&self) -> Value {
+        let stages = [RetrievalStage::Cascade, RetrievalStage::Scored];
+        let map: serde_json::Map<String, Value> = stages
+            .iter()
+            .filter_map(|stage| {
+                let count = self.candidates_count[stage.index()].load(Ordering::Relaxed);
+                (count > 0).then(|| {
+                    let sum = self.candidates_sum[stage.index()].load(Ordering::Relaxed);
+                    (
+                        stage.as_str().to_string(),
+                        json!({"observations": count, "total": sum}),
+                    )
+                })
+            })
+            .collect();
+        Value::Object(map)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::monitoring::metrics::FallbackReason;
+
+    #[test]
+    fn exposition_carries_all_issue_families() {
+        let metrics = RetrievalMetrics::new();
+        metrics.record_cache(CacheLayer::Query, RetrievalOutcome::Miss);
+        metrics.record_embedding(EmbeddingProviderLabel::Local, EmbeddingOutcome::Ok, 20);
+        metrics.record_fallback(FallbackReason::LocalConfident);
+        metrics.record_feedback(FeedbackSignal::Success);
+        metrics.record_candidates(RetrievalStage::Cascade, 7);
+
+        let text = metrics.export_prometheus();
+        for family in [
+            "memory_cache_requests_total",
+            "memory_embedding_requests_total",
+            "memory_embedding_duration_seconds",
+            "memory_retrieval_fallback_total",
+            "memory_recommendation_feedback_total",
+            "memory_retrieval_candidates_sum",
+        ] {
+            assert!(text.contains(family), "missing family {family}");
+        }
+        assert!(text.contains("reason=\"local_confident\""));
+        assert!(text.contains("signal=\"success\""));
+        assert!(text.contains("provider=\"local\""));
+    }
+
+    #[test]
+    fn type_lines_appear_once_per_family() {
+        let metrics = RetrievalMetrics::new();
+        metrics.record_request(
+            RetrievalOperation::Query,
+            RetrievalTier::Cache,
+            RetrievalOutcome::Hit,
+            4,
+        );
+        metrics.record_request(
+            RetrievalOperation::Query,
+            RetrievalTier::Cache,
+            RetrievalOutcome::Miss,
+            8,
+        );
+
+        let text = metrics.export_prometheus();
+        assert_eq!(
+            text.matches("# TYPE memory_retrieval_duration_seconds")
+                .count(),
+            1,
+            "duplicate TYPE line invalidates exposition"
+        );
+        // One duration series per (operation, tier), not per outcome.
+        assert_eq!(
+            text.matches("memory_retrieval_duration_seconds{operation=\"query\",tier=\"cache\"")
+                .count(),
+            3,
+            "expected exactly the 0.5/0.95/0.99 quantile series"
+        );
+    }
+}

--- a/memory-core/src/monitoring/metrics/retrieval_metrics/labels.rs
+++ b/memory-core/src/monitoring/metrics/retrieval_metrics/labels.rs
@@ -1,0 +1,481 @@
+//! Bounded label vocabularies for retrieval telemetry (issue #962).
+//!
+//! Every dimension is a fieldless enum: label values are fixed
+//! snake_case strings, so raw queries, IDs, tags, and provider error
+//! strings can never enter metric series.
+
+use crate::types::TaskOutcome;
+
+/// Storage bounds for the fixed-size telemetry arrays.
+pub(super) const N_OPERATIONS: usize = 2;
+pub(super) const N_TIERS: usize = 11;
+pub(super) const N_OUTCOMES: usize = 2;
+pub(super) const N_LAYERS: usize = 1;
+pub(super) const N_PROVIDERS: usize = 5;
+pub(super) const N_EMB_OUTCOMES: usize = 2;
+pub(super) const N_STAGES: usize = 2;
+pub(super) const N_FALLBACK_REASONS: usize = 6;
+pub(super) const N_SIGNALS: usize = 4;
+
+/// Retrieval operation dimension. Vocabulary: `query`, `cascade`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetrievalOperation {
+    /// `retrieve_relevant_context` query path.
+    Query,
+    /// `CascadeRetriever` 4-tier path.
+    Cascade,
+}
+
+impl RetrievalOperation {
+    /// Zero-based index for fixed-size storage.
+    pub(super) const fn index(self) -> usize {
+        match self {
+            RetrievalOperation::Query => 0,
+            RetrievalOperation::Cascade => 1,
+        }
+    }
+
+    /// Bounded label value.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            RetrievalOperation::Query => "query",
+            RetrievalOperation::Cascade => "cascade",
+        }
+    }
+}
+
+/// Serving-tier dimension. Vocabulary: `cache`, `hybrid`, `semantic`,
+/// `hierarchical`, `keyword`, `bm25`, `hdc`, `concept_graph`, `api`,
+/// `blended`, `none`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetrievalTier {
+    /// Served from the query cache.
+    Cache,
+    /// Hybrid ANN-backed retrieval.
+    Hybrid,
+    /// Semantic similarity retrieval.
+    Semantic,
+    /// Hierarchical spatiotemporal retrieval.
+    Hierarchical,
+    /// Legacy keyword retrieval.
+    Keyword,
+    /// Cascade Tier 1 only.
+    Bm25,
+    /// Cascade Tier 2 only.
+    Hdc,
+    /// Cascade Tier 3 only.
+    ConceptGraph,
+    /// Policy-forced API tier.
+    Api,
+    /// Multiple cascade tiers contributed.
+    Blended,
+    /// No tier served (empty index / no episodes).
+    None,
+}
+
+impl RetrievalTier {
+    /// Zero-based index for fixed-size storage.
+    pub(super) const fn index(self) -> usize {
+        match self {
+            RetrievalTier::Cache => 0,
+            RetrievalTier::Hybrid => 1,
+            RetrievalTier::Semantic => 2,
+            RetrievalTier::Hierarchical => 3,
+            RetrievalTier::Keyword => 4,
+            RetrievalTier::Bm25 => 5,
+            RetrievalTier::Hdc => 6,
+            RetrievalTier::ConceptGraph => 7,
+            RetrievalTier::Api => 8,
+            RetrievalTier::Blended => 9,
+            RetrievalTier::None => 10,
+        }
+    }
+
+    /// Bounded label value.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            RetrievalTier::Cache => "cache",
+            RetrievalTier::Hybrid => "hybrid",
+            RetrievalTier::Semantic => "semantic",
+            RetrievalTier::Hierarchical => "hierarchical",
+            RetrievalTier::Keyword => "keyword",
+            RetrievalTier::Bm25 => "bm25",
+            RetrievalTier::Hdc => "hdc",
+            RetrievalTier::ConceptGraph => "concept_graph",
+            RetrievalTier::Api => "api",
+            RetrievalTier::Blended => "blended",
+            RetrievalTier::None => "none",
+        }
+    }
+
+    /// All vocabulary values, for cardinality assertions.
+    #[must_use]
+    pub const fn all() -> [&'static str; 11] {
+        [
+            "cache",
+            "hybrid",
+            "semantic",
+            "hierarchical",
+            "keyword",
+            "bm25",
+            "hdc",
+            "concept_graph",
+            "api",
+            "blended",
+            "none",
+        ]
+    }
+}
+
+/// Request outcome dimension. Vocabulary: `hit`, `miss`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetrievalOutcome {
+    /// At least one episode returned.
+    Hit,
+    /// Empty result.
+    Miss,
+}
+
+impl RetrievalOutcome {
+    /// Zero-based index for fixed-size storage.
+    pub(super) const fn index(self) -> usize {
+        match self {
+            RetrievalOutcome::Hit => 0,
+            RetrievalOutcome::Miss => 1,
+        }
+    }
+
+    /// Bounded label value.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            RetrievalOutcome::Hit => "hit",
+            RetrievalOutcome::Miss => "miss",
+        }
+    }
+
+    /// Outcome from a returned-item count.
+    #[must_use]
+    pub const fn from_count(count: usize) -> Self {
+        if count == 0 {
+            RetrievalOutcome::Miss
+        } else {
+            RetrievalOutcome::Hit
+        }
+    }
+}
+
+/// Cache layer dimension. Vocabulary: `query`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheLayer {
+    /// Episodic query-result cache.
+    Query,
+}
+
+impl CacheLayer {
+    /// Zero-based index for fixed-size storage.
+    pub(super) const fn index(self) -> usize {
+        match self {
+            CacheLayer::Query => 0,
+        }
+    }
+
+    /// Bounded label value.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            CacheLayer::Query => "query",
+        }
+    }
+}
+
+/// Embedding provider dimension. Vocabulary: `local`, `openai`, `mistral`,
+/// `azure_openai`, `custom`. Mirrors `ProviderConfig` variants 1:1 so new
+/// providers fail compilation here instead of widening cardinality silently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmbeddingProviderLabel {
+    /// CPU-local provider.
+    Local,
+    /// OpenAI provider.
+    OpenAI,
+    /// Mistral provider.
+    Mistral,
+    /// Azure OpenAI provider.
+    AzureOpenAI,
+    /// Custom provider.
+    Custom,
+}
+
+impl EmbeddingProviderLabel {
+    /// Zero-based index for fixed-size storage.
+    pub(super) const fn index(self) -> usize {
+        match self {
+            EmbeddingProviderLabel::Local => 0,
+            EmbeddingProviderLabel::OpenAI => 1,
+            EmbeddingProviderLabel::Mistral => 2,
+            EmbeddingProviderLabel::AzureOpenAI => 3,
+            EmbeddingProviderLabel::Custom => 4,
+        }
+    }
+
+    /// Bounded label value.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            EmbeddingProviderLabel::Local => "local",
+            EmbeddingProviderLabel::OpenAI => "openai",
+            EmbeddingProviderLabel::Mistral => "mistral",
+            EmbeddingProviderLabel::AzureOpenAI => "azure_openai",
+            EmbeddingProviderLabel::Custom => "custom",
+        }
+    }
+}
+
+/// Embedding call outcome dimension. Vocabulary: `ok`, `error`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmbeddingOutcome {
+    /// Provider returned an embedding.
+    Ok,
+    /// Provider call failed.
+    Error,
+}
+
+impl EmbeddingOutcome {
+    /// Zero-based index for fixed-size storage.
+    pub(super) const fn index(self) -> usize {
+        match self {
+            EmbeddingOutcome::Ok => 0,
+            EmbeddingOutcome::Error => 1,
+        }
+    }
+
+    /// Bounded label value.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            EmbeddingOutcome::Ok => "ok",
+            EmbeddingOutcome::Error => "error",
+        }
+    }
+}
+
+/// Candidate-set stage dimension. Vocabulary: `cascade`, `scored`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetrievalStage {
+    /// Cascade final set size.
+    Cascade,
+    /// Hierarchically scored candidate count.
+    Scored,
+}
+
+impl RetrievalStage {
+    /// Zero-based index for fixed-size storage.
+    pub(super) const fn index(self) -> usize {
+        match self {
+            RetrievalStage::Cascade => 0,
+            RetrievalStage::Scored => 1,
+        }
+    }
+
+    /// Bounded label value.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            RetrievalStage::Cascade => "cascade",
+            RetrievalStage::Scored => "scored",
+        }
+    }
+}
+
+/// Recommendation-feedback signal dimension. Vocabulary: `success`,
+/// `partial`, `failure`, `abstained`. Mirrors `TaskOutcome` kinds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeedbackSignal {
+    /// Task succeeded.
+    Success,
+    /// Task partially succeeded.
+    Partial,
+    /// Task failed.
+    Failure,
+    /// Agent abstained.
+    Abstained,
+}
+
+impl FeedbackSignal {
+    /// Zero-based index for fixed-size storage.
+    pub(super) const fn index(self) -> usize {
+        match self {
+            FeedbackSignal::Success => 0,
+            FeedbackSignal::Partial => 1,
+            FeedbackSignal::Failure => 2,
+            FeedbackSignal::Abstained => 3,
+        }
+    }
+
+    /// Bounded label value.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            FeedbackSignal::Success => "success",
+            FeedbackSignal::Partial => "partial",
+            FeedbackSignal::Failure => "failure",
+            FeedbackSignal::Abstained => "abstained",
+        }
+    }
+
+    /// Signal from a feedback outcome. Counted only for accepted feedback
+    /// (hydration replays bypass recording to avoid double counting).
+    #[must_use]
+    pub const fn from_outcome(outcome: &TaskOutcome) -> Self {
+        match outcome {
+            TaskOutcome::Success { .. } => FeedbackSignal::Success,
+            TaskOutcome::PartialSuccess { .. } => FeedbackSignal::Partial,
+            TaskOutcome::Failure { .. } => FeedbackSignal::Failure,
+            TaskOutcome::Abstained { .. } => FeedbackSignal::Abstained,
+        }
+    }
+}
+
+/// Zero-based index for [`FallbackReason`] (display order is fixed).
+pub(super) const fn fallback_index(reason: FallbackReason) -> usize {
+    match reason {
+        FallbackReason::LocalTierSufficient => 0,
+        FallbackReason::LocalConfident => 1,
+        FallbackReason::InsufficientConfidence => 2,
+        FallbackReason::NoLocalResults => 3,
+        FallbackReason::AlwaysEmbedPolicy => 4,
+        FallbackReason::LocalOnlyPolicy => 5,
+    }
+}
+
+/// Tier-4 fallback reason dimension. Vocabulary: `local_tier_sufficient`,
+/// `local_confident`, `insufficient_confidence`, `no_local_results`,
+/// `always_embed_policy`, `local_only_policy`.
+///
+/// This is the canonical vocabulary (telemetry contract). The confidence
+/// policy (#968) reuses it for `CascadeResult::fallback_reason` rather than
+/// defining its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FallbackReason {
+    /// A CPU-local tier already satisfied the query.
+    LocalTierSufficient,
+    /// Confident local result, no Tier-4 call.
+    LocalConfident,
+    /// Local result exists but is not confident.
+    InsufficientConfidence,
+    /// No local results at all.
+    NoLocalResults,
+    /// `always_embed` policy forced the call.
+    AlwaysEmbedPolicy,
+    /// `local_only` policy suppressed the call.
+    LocalOnlyPolicy,
+}
+
+impl FallbackReason {
+    /// Bounded label value.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            FallbackReason::LocalTierSufficient => "local_tier_sufficient",
+            FallbackReason::LocalConfident => "local_confident",
+            FallbackReason::InsufficientConfidence => "insufficient_confidence",
+            FallbackReason::NoLocalResults => "no_local_results",
+            FallbackReason::AlwaysEmbedPolicy => "always_embed_policy",
+            FallbackReason::LocalOnlyPolicy => "local_only_policy",
+        }
+    }
+}
+
+/// Fixed fallback-reason vocabulary in storage order.
+pub(super) const FALLBACK_REASONS: [&str; N_FALLBACK_REASONS] = [
+    "local_tier_sufficient",
+    "local_confident",
+    "insufficient_confidence",
+    "no_local_results",
+    "always_embed_policy",
+    "local_only_policy",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every label value must be Prometheus-safe (bounded vocabulary guard).
+    fn assert_label_value(value: &str) {
+        assert!(
+            value
+                .bytes()
+                .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_'),
+            "unbounded label value: {value}"
+        );
+    }
+
+    #[test]
+    fn label_vocabularies_are_bounded() {
+        for value in RetrievalTier::all() {
+            assert_label_value(value);
+        }
+        assert_eq!(RetrievalTier::all().len(), 11);
+        for value in FALLBACK_REASONS {
+            assert_label_value(value);
+        }
+        assert_eq!(FALLBACK_REASONS.len(), 6);
+        for op in [RetrievalOperation::Query, RetrievalOperation::Cascade] {
+            assert_label_value(op.as_str());
+        }
+        for signal in [
+            FeedbackSignal::Success,
+            FeedbackSignal::Partial,
+            FeedbackSignal::Failure,
+            FeedbackSignal::Abstained,
+        ] {
+            assert_label_value(signal.as_str());
+        }
+        for provider in [
+            EmbeddingProviderLabel::Local,
+            EmbeddingProviderLabel::OpenAI,
+            EmbeddingProviderLabel::Mistral,
+            EmbeddingProviderLabel::AzureOpenAI,
+            EmbeddingProviderLabel::Custom,
+        ] {
+            assert_label_value(provider.as_str());
+        }
+    }
+
+    #[test]
+    fn feedback_signal_mapping_covers_outcome_kinds() {
+        use TaskOutcome::{Abstained, Failure, PartialSuccess, Success};
+        assert_eq!(
+            FeedbackSignal::from_outcome(&Success {
+                verdict: "v".into(),
+                artifacts: vec![]
+            }),
+            FeedbackSignal::Success
+        );
+        assert_eq!(
+            FeedbackSignal::from_outcome(&PartialSuccess {
+                verdict: "v".into(),
+                completed: vec![],
+                failed: vec![]
+            }),
+            FeedbackSignal::Partial
+        );
+        assert_eq!(
+            FeedbackSignal::from_outcome(&Failure {
+                reason: "r".into(),
+                error_details: None
+            }),
+            FeedbackSignal::Failure
+        );
+        assert_eq!(
+            FeedbackSignal::from_outcome(&Abstained {
+                reason: "r".into(),
+                stopped_at_step: 0,
+                infeasibility_signals: vec![]
+            }),
+            FeedbackSignal::Abstained
+        );
+    }
+}

--- a/memory-core/src/monitoring/metrics/retrieval_metrics/mod.rs
+++ b/memory-core/src/monitoring/metrics/retrieval_metrics/mod.rs
@@ -1,0 +1,35 @@
+//! Retrieval and cascade observability (issue #962).
+//!
+//! Dependency-free, label-bounded telemetry for the retrieval plane:
+//! request counts and durations by operation/tier/outcome, candidate-set
+//! sizes by stage, query-cache hits/misses, embedding calls by provider,
+//! Tier-4 fallback reasons, and recommendation-feedback signals. Renders
+//! both JSON snapshots (MCP `get_metrics`) and Prometheus text exposition
+//! (see `MetricsRegistry::export_metrics`).
+//!
+//! ## Cardinality and redaction contract
+//!
+//! Every label is a fieldless enum with a fixed snake_case vocabulary
+//! documented in [`labels`] — raw queries, episode IDs, tags, and provider
+//! error strings can never become label values. Series are stored in
+//! fixed-size arrays (no per-value map growth), so cardinality is
+//! compile-time bounded: at most 2·11·2 request series plus the smaller
+//! per-family tables.
+//!
+//! ## Wiring
+//!
+//! Call sites record into the process-global registry
+//! ([`global_retrieval_metrics`]); tests use isolated [`RetrievalMetrics`]
+//! instances or serial delta assertions on the global one.
+
+mod exposition;
+mod labels;
+mod registry;
+
+pub use labels::{
+    CacheLayer, EmbeddingOutcome, EmbeddingProviderLabel, FallbackReason, FeedbackSignal,
+    RetrievalOperation, RetrievalOutcome, RetrievalStage, RetrievalTier,
+};
+pub use registry::{
+    RetrievalMetrics, cascade_tier, global_retrieval_metrics, provisional_fallback_reason,
+};

--- a/memory-core/src/monitoring/metrics/retrieval_metrics/registry.rs
+++ b/memory-core/src/monitoring/metrics/retrieval_metrics/registry.rs
@@ -1,0 +1,277 @@
+//! Telemetry registry: fixed-size counters, latency trackers, and the
+//! process-global instance for retrieval observability (issue #962).
+
+use parking_lot::Mutex;
+use std::sync::{
+    Arc, OnceLock,
+    atomic::{AtomicU64, Ordering},
+};
+
+use super::super::storage_metrics::OperationLatency;
+use super::labels::{
+    CacheLayer, EmbeddingOutcome, EmbeddingProviderLabel, FallbackReason, FeedbackSignal,
+    N_EMB_OUTCOMES, N_FALLBACK_REASONS, N_LAYERS, N_OPERATIONS, N_OUTCOMES, N_PROVIDERS, N_SIGNALS,
+    N_STAGES, N_TIERS, RetrievalOperation, RetrievalOutcome, RetrievalStage, RetrievalTier,
+    fallback_index,
+};
+use crate::retrieval::cascade::CascadeResult;
+
+/// Retrieval-plane telemetry: fixed-size counters and O(1) latency trackers.
+///
+/// Clone shares nothing; each instance is independent (tests). Production
+/// call sites use the process-global instance from
+/// [`global_retrieval_metrics`].
+pub struct RetrievalMetrics {
+    pub(super) requests: [[[AtomicU64; N_OUTCOMES]; N_TIERS]; N_OPERATIONS],
+    pub(super) durations_ms: [[Mutex<OperationLatency>; N_TIERS]; N_OPERATIONS],
+    pub(super) candidates_sum: [AtomicU64; N_STAGES],
+    pub(super) candidates_count: [AtomicU64; N_STAGES],
+    pub(super) cache: [[AtomicU64; N_OUTCOMES]; N_LAYERS],
+    pub(super) embeddings: [[AtomicU64; N_EMB_OUTCOMES]; N_PROVIDERS],
+    pub(super) embedding_durations_ms: [Mutex<OperationLatency>; N_PROVIDERS],
+    pub(super) fallbacks: [AtomicU64; N_FALLBACK_REASONS],
+    pub(super) feedback: [AtomicU64; N_SIGNALS],
+}
+
+impl RetrievalMetrics {
+    /// Create an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            requests: Default::default(),
+            durations_ms: Default::default(),
+            candidates_sum: Default::default(),
+            candidates_count: Default::default(),
+            cache: Default::default(),
+            embeddings: Default::default(),
+            embedding_durations_ms: Default::default(),
+            fallbacks: Default::default(),
+            feedback: Default::default(),
+        }
+    }
+
+    /// Record one retrieval request with its serving duration.
+    pub fn record_request(
+        &self,
+        operation: RetrievalOperation,
+        tier: RetrievalTier,
+        outcome: RetrievalOutcome,
+        duration_ms: u64,
+    ) {
+        self.requests[operation.index()][tier.index()][outcome.index()]
+            .fetch_add(1, Ordering::Relaxed);
+        self.durations_ms[operation.index()][tier.index()]
+            .lock()
+            .record(duration_ms);
+    }
+
+    /// Record a candidate-set size at one pipeline stage.
+    pub fn record_candidates(&self, stage: RetrievalStage, count: usize) {
+        self.candidates_sum[stage.index()].fetch_add(count as u64, Ordering::Relaxed);
+        self.candidates_count[stage.index()].fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a cache lookup result.
+    pub fn record_cache(&self, layer: CacheLayer, outcome: RetrievalOutcome) {
+        self.cache[layer.index()][outcome.index()].fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record one embedding provider call with its serving duration.
+    pub fn record_embedding(
+        &self,
+        provider: EmbeddingProviderLabel,
+        outcome: EmbeddingOutcome,
+        duration_ms: u64,
+    ) {
+        self.embeddings[provider.index()][outcome.index()].fetch_add(1, Ordering::Relaxed);
+        self.embedding_durations_ms[provider.index()]
+            .lock()
+            .record(duration_ms);
+    }
+
+    /// Record one Tier-4 fallback decision.
+    pub fn record_fallback(&self, reason: FallbackReason) {
+        self.fallbacks[fallback_index(reason)].fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record one accepted recommendation-feedback signal.
+    pub fn record_feedback(&self, signal: FeedbackSignal) {
+        self.feedback[signal.index()].fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record one finished cascade retrieval: request, duration,
+    /// candidate-set size, and Tier-4 fallback decision.
+    pub fn record_cascade(&self, duration_ms: u64, result: &CascadeResult) {
+        let tier = cascade_tier(&result.contributing_tiers);
+        let outcome = RetrievalOutcome::from_count(result.episode_ids.len());
+        self.record_request(RetrievalOperation::Cascade, tier, outcome, duration_ms);
+        self.record_candidates(RetrievalStage::Cascade, result.episode_ids.len());
+        self.record_fallback(provisional_fallback_reason(result));
+    }
+
+    /// Reset all series (tests and explicit operator reset).
+    pub fn reset(&self) {
+        for op in &self.requests {
+            for tier in op {
+                for cell in tier {
+                    cell.store(0, Ordering::Relaxed);
+                }
+            }
+        }
+        for op in &self.durations_ms {
+            for cell in op {
+                *cell.lock() = OperationLatency::default();
+            }
+        }
+        for cell in &self.candidates_sum {
+            cell.store(0, Ordering::Relaxed);
+        }
+        for cell in &self.candidates_count {
+            cell.store(0, Ordering::Relaxed);
+        }
+        for layer in &self.cache {
+            for cell in layer {
+                cell.store(0, Ordering::Relaxed);
+            }
+        }
+        for provider in &self.embeddings {
+            for cell in provider {
+                cell.store(0, Ordering::Relaxed);
+            }
+        }
+        for cell in &self.embedding_durations_ms {
+            *cell.lock() = OperationLatency::default();
+        }
+        for cell in &self.fallbacks {
+            cell.store(0, Ordering::Relaxed);
+        }
+        for cell in &self.feedback {
+            cell.store(0, Ordering::Relaxed);
+        }
+    }
+}
+
+impl Default for RetrievalMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for RetrievalMetrics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RetrievalMetrics")
+            .field("snapshot", &self.snapshot())
+            .finish()
+    }
+}
+
+static GLOBAL_REGISTRY: OnceLock<Arc<RetrievalMetrics>> = OnceLock::new();
+
+/// Process-global retrieval telemetry registry.
+///
+/// Production call sites record here; the MCP `get_metrics` retrieval view
+/// and Prometheus exposition read here. Tests prefer isolated instances or
+/// serial delta assertions (the registry exposes [`RetrievalMetrics::reset`]).
+#[must_use]
+pub fn global_retrieval_metrics() -> Arc<RetrievalMetrics> {
+    Arc::clone(GLOBAL_REGISTRY.get_or_init(|| Arc::new(RetrievalMetrics::new())))
+}
+
+/// Serving tier for a cascade result: the single contributing tier,
+/// [`RetrievalTier::Blended`] for multi-tier merges, or
+/// [`RetrievalTier::None`] when nothing served. Tier markers
+/// (`api_fallback_needed`, `none`) never become labels.
+#[must_use]
+pub fn cascade_tier(contributing_tiers: &[String]) -> RetrievalTier {
+    let mut tiers = contributing_tiers
+        .iter()
+        .filter_map(|tier| match tier.as_str() {
+            "bm25" => Some(RetrievalTier::Bm25),
+            "hdc" => Some(RetrievalTier::Hdc),
+            "concept_graph" => Some(RetrievalTier::ConceptGraph),
+            "api" => Some(RetrievalTier::Api),
+            _ => None,
+        });
+    match (tiers.next(), tiers.next()) {
+        (Some(first), None) => first,
+        (Some(_), Some(_)) => RetrievalTier::Blended,
+        (None, _) => RetrievalTier::None,
+    }
+}
+
+/// Provisional Tier-4 reason for cascades without confidence gating.
+///
+/// Pre-#968 code cannot distinguish confident from unconfident local
+/// results, so any API escalation maps to `InsufficientConfidence`. Once
+/// the confidence policy lands, call sites pass
+/// `CascadeResult::fallback_reason` straight into
+/// [`RetrievalMetrics::record_fallback`] instead.
+#[must_use]
+pub fn provisional_fallback_reason(result: &CascadeResult) -> FallbackReason {
+    if result.episode_ids.is_empty() {
+        FallbackReason::NoLocalResults
+    } else if result
+        .contributing_tiers
+        .iter()
+        .any(|tier| tier == "api_fallback_needed")
+    {
+        FallbackReason::InsufficientConfidence
+    } else {
+        FallbackReason::LocalTierSufficient
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn requests_and_durations_accumulate_per_series() {
+        let metrics = RetrievalMetrics::new();
+        metrics.record_request(
+            RetrievalOperation::Query,
+            RetrievalTier::Cache,
+            RetrievalOutcome::Hit,
+            5,
+        );
+        metrics.record_request(
+            RetrievalOperation::Query,
+            RetrievalTier::Cache,
+            RetrievalOutcome::Hit,
+            15,
+        );
+
+        let snapshot = metrics.snapshot();
+        let requests = snapshot["requests"].as_array().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0]["count"], 2);
+        assert_eq!(requests[0]["latency_ms"]["avg"], 10);
+        // Zero series are omitted from both renderings.
+        let text = metrics.export_prometheus();
+        assert!(text.contains(
+            "memory_retrieval_requests_total{operation=\"query\",tier=\"cache\",outcome=\"hit\"} 2"
+        ));
+        assert!(!text.contains("tier=\"semantic\""));
+    }
+
+    #[test]
+    fn reset_clears_every_series() {
+        let metrics = RetrievalMetrics::new();
+        metrics.record_request(
+            RetrievalOperation::Cascade,
+            RetrievalTier::Bm25,
+            RetrievalOutcome::Hit,
+            3,
+        );
+        metrics.record_fallback(FallbackReason::NoLocalResults);
+        metrics.reset();
+
+        assert!(
+            metrics.snapshot()["requests"]
+                .as_array()
+                .unwrap()
+                .is_empty()
+        );
+        assert!(!metrics.export_prometheus().contains("tier=\"bm25\""));
+    }
+}

--- a/memory-core/src/monitoring/metrics/storage_metrics.rs
+++ b/memory-core/src/monitoring/metrics/storage_metrics.rs
@@ -148,6 +148,10 @@ impl OperationLatency {
             self.p50 = self.p50 * 7 / 10 + latency_ms * 3 / 10;
             self.p95 = self.p95 * 9 / 10 + latency_ms / 10;
             self.p99 = self.p99.max(latency_ms);
+            // The EMAs move at different rates and can transiently invert;
+            // percentiles must stay ordered or dashboards and tests lie.
+            self.p95 = self.p95.max(self.p50);
+            self.p99 = self.p99.max(self.p95);
         }
     }
 
@@ -158,11 +162,7 @@ impl OperationLatency {
 
     /// Get average latency in ms
     pub fn avg_ms(&self) -> u64 {
-        if self.count == 0 {
-            0
-        } else {
-            self.total_ms / self.count
-        }
+        self.total_ms.checked_div(self.count).unwrap_or(0)
     }
 
     /// Get percentiles (p50, p95, p99) in ms

--- a/memory-core/src/monitoring/mod.rs
+++ b/memory-core/src/monitoring/mod.rs
@@ -33,6 +33,7 @@
 //! ```
 
 mod core;
+pub mod metrics;
 pub mod storage;
 pub mod types;
 

--- a/memory-core/src/retrieval/cache/lru.rs
+++ b/memory-core/src/retrieval/cache/lru.rs
@@ -93,6 +93,8 @@ impl QueryCache {
     /// Get a cached query result
     #[must_use]
     pub fn get(&self, key: &CacheKey) -> Option<Vec<Arc<Episode>>> {
+        use crate::monitoring::metrics::{CacheLayer, RetrievalOutcome, global_retrieval_metrics};
+
         let key_hash = key.compute_hash();
 
         // Fast path: Check if this entry is marked for lazy invalidation
@@ -102,6 +104,7 @@ impl QueryCache {
                 // Entry is invalidated - count as miss and return None
                 let mut metrics = self.metrics.write();
                 metrics.misses += 1;
+                global_retrieval_metrics().record_cache(CacheLayer::Query, RetrievalOutcome::Miss);
                 return None;
             }
         }
@@ -118,17 +121,20 @@ impl QueryCache {
                 metrics.misses += 1;
                 metrics.evictions += 1;
                 metrics.size = cache.len();
+                global_retrieval_metrics().record_cache(CacheLayer::Query, RetrievalOutcome::Miss);
                 return None;
             }
 
             // Cache hit - clone the Arc pointers from the slice
             metrics.hits += 1;
+            global_retrieval_metrics().record_cache(CacheLayer::Query, RetrievalOutcome::Hit);
             let episodes: Vec<Arc<Episode>> = result.episodes.to_vec();
             Some(episodes)
         } else {
             // Cache miss
             metrics.misses += 1;
             metrics.size = cache.len();
+            global_retrieval_metrics().record_cache(CacheLayer::Query, RetrievalOutcome::Miss);
             None
         }
     }

--- a/memory-core/src/retrieval/cascade/mod.rs
+++ b/memory-core/src/retrieval/cascade/mod.rs
@@ -120,7 +120,16 @@ impl CascadeRetriever {
     pub fn retrieve(&self, query: &str) -> Result<CascadeResult, CascadeError> {
         #[cfg(feature = "csm")]
         {
-            Ok(self.retrieve_with_csm(query))
+            let start = std::time::Instant::now();
+            let result = self.retrieve_with_csm(query);
+            // No query text, IDs, or scores cross into telemetry: the record
+            // call reads only tier attributions, counts, and the fallback
+            // marker (redaction contract, issue #962).
+            crate::monitoring::metrics::global_retrieval_metrics().record_cascade(
+                start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
+                &result,
+            );
+            Ok(result)
         }
 
         #[cfg(not(feature = "csm"))]

--- a/memory-core/tests/retrieval_telemetry.rs
+++ b/memory-core/tests/retrieval_telemetry.rs
@@ -1,0 +1,181 @@
+//! Issue #962: retrieval telemetry is recorded on the real paths with
+//! bounded labels and no query text.
+//!
+//! All tests use serial delta assertions against the process-global
+//! registry (production call sites record there).
+
+#![allow(clippy::unwrap_used, clippy::panic)] // test-only wiring checks
+
+use do_memory_core::TaskOutcome;
+use do_memory_core::monitoring::metrics::global_retrieval_metrics;
+use do_memory_core::{
+    MemoryConfig, RecommendationFeedback, RecommendationSession, SelfLearningMemory, TaskContext,
+    TaskType,
+};
+use serial_test::serial;
+
+/// Counters snapshot for delta assertions: (requests, fallbacks, feedback).
+fn counters() -> (u64, u64, u64) {
+    let snapshot = global_retrieval_metrics().snapshot();
+    let requests: u64 = snapshot["requests"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r["count"].as_u64().unwrap())
+        .sum();
+    let fallbacks: u64 = snapshot["fallbacks"]
+        .as_object()
+        .unwrap()
+        .values()
+        .map(|v| v.as_u64().unwrap())
+        .sum();
+    let feedback: u64 = snapshot["feedback"]
+        .as_object()
+        .unwrap()
+        .values()
+        .map(|v| v.as_u64().unwrap())
+        .sum();
+    (requests, fallbacks, feedback)
+}
+
+fn test_config() -> MemoryConfig {
+    MemoryConfig {
+        quality_threshold: 0.0,
+        pattern_extraction_threshold: 1.0,
+        enable_summarization: false,
+        enable_embeddings: false,
+        batch_config: None,
+        ..MemoryConfig::default()
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn query_path_records_miss_then_cache_hit() {
+    let memory = SelfLearningMemory::with_config(test_config());
+    let episode_id = memory
+        .start_episode(
+            "telemetry query task".into(),
+            TaskContext::default(),
+            TaskType::Testing,
+        )
+        .await;
+    memory
+        .complete_episode(
+            episode_id,
+            TaskOutcome::Success {
+                verdict: "done".into(),
+                artifacts: vec![],
+            },
+        )
+        .await
+        .unwrap();
+
+    let context = TaskContext::default();
+    let (requests_before, _, _) = counters();
+
+    // First call misses the cache and runs retrieval.
+    let first = memory
+        .retrieve_relevant_context("telemetry query task".into(), context.clone(), 5)
+        .await;
+    assert!(!first.is_empty());
+    // Second identical call is served from the query cache.
+    let second = memory
+        .retrieve_relevant_context("telemetry query task".into(), context, 5)
+        .await;
+    assert!(!second.is_empty());
+
+    let (requests_after, _, _) = counters();
+    assert_eq!(requests_after - requests_before, 2);
+
+    let text = global_retrieval_metrics().export_prometheus();
+    assert!(text.contains("tier=\"cache\""));
+}
+
+#[tokio::test]
+#[serial]
+async fn feedback_signal_recorded_on_accept() {
+    use chrono::Utc;
+
+    let memory = SelfLearningMemory::with_config(test_config());
+    let session = RecommendationSession {
+        session_id: uuid::Uuid::new_v4(),
+        episode_id: uuid::Uuid::new_v4(),
+        timestamp: Utc::now(),
+        recommended_pattern_ids: vec!["p1".to_string()],
+        recommended_playbook_ids: vec![],
+    };
+    memory.record_recommendation_session(session.clone()).await;
+
+    let (_, _, feedback_before) = counters();
+    memory
+        .record_recommendation_feedback(RecommendationFeedback {
+            session_id: session.session_id,
+            applied_pattern_ids: vec!["p1".to_string()],
+            consulted_episode_ids: vec![],
+            outcome: TaskOutcome::Failure {
+                reason: "did not apply".into(),
+                error_details: None,
+            },
+            agent_rating: Some(0.2),
+        })
+        .await
+        .unwrap();
+
+    let (_, _, feedback_after) = counters();
+    assert_eq!(feedback_after - feedback_before, 1);
+    assert!(
+        global_retrieval_metrics()
+            .export_prometheus()
+            .contains("memory_recommendation_feedback_total{signal=\"failure\"} 1")
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn exposition_carries_no_query_text() {
+    // Distinctive marker that must never appear in metric output.
+    let marker = "zz9quux-telemetry-marker";
+    let memory = SelfLearningMemory::with_config(test_config());
+    memory
+        .retrieve_relevant_context(marker.into(), TaskContext::default(), 5)
+        .await;
+
+    let registry = global_retrieval_metrics();
+    let text = registry.export_prometheus();
+    let snapshot = serde_json::to_string(&registry.snapshot()).unwrap();
+    assert!(!text.contains(marker));
+    assert!(!snapshot.contains(marker));
+}
+
+/// Cascade recording only exists behind the `csm` feature (the hook lives
+/// in the csm-gated retrieve path).
+#[tokio::test]
+#[serial]
+#[cfg(feature = "csm")]
+async fn cascade_retrievals_record_tier_and_fallback() {
+    use do_memory_core::retrieval::{CascadeConfig, CascadeRetriever};
+
+    let mut retriever = CascadeRetriever::new(CascadeConfig::default());
+    retriever.add_episode("ep-1", "authentication JWT token implementation");
+    retriever.add_episode("ep-2", "authentication session management");
+
+    let (requests_before, fallbacks_before, _) = counters();
+    for _ in 0..2 {
+        retriever
+            .retrieve("authentication JWT")
+            .expect("csm retrieve");
+    }
+
+    let (requests_after, fallbacks_after, _) = counters();
+    assert_eq!(requests_after - requests_before, 2);
+    assert_eq!(fallbacks_after - fallbacks_before, 2);
+    assert!(
+        global_retrieval_metrics()
+            .export_prometheus()
+            .contains("memory_retrieval_fallback_total{reason=\"local_tier_sufficient\"} 2")
+            || global_retrieval_metrics()
+                .export_prometheus()
+                .contains("reason=\"local_confident\"")
+    );
+}

--- a/memory-mcp/src/mcp/tools/embeddings/tool/execute/generate.rs
+++ b/memory-mcp/src/mcp/tools/embeddings/tool/execute/generate.rs
@@ -30,10 +30,10 @@ impl EmbeddingTools {
         }
 
         // Use live_semantic_service to pick up dynamically activated providers.
+        // embed_query_text records provider telemetry (issue #962).
         if let Some(semantic_service) = self.memory.live_semantic_service().await {
             let mut embedding = semantic_service
-                .provider
-                .embed_text(&input.text)
+                .embed_query_text(&input.text)
                 .await
                 .map_err(|e| anyhow!("Failed to generate embedding: {}", e))?;
 

--- a/memory-mcp/src/mcp/tools/embeddings/tool/execute/status.rs
+++ b/memory-mcp/src/mcp/tools/embeddings/tool/execute/status.rs
@@ -17,8 +17,9 @@ impl EmbeddingTools {
         info!("Testing embedding provider connectivity");
 
         // Use live_semantic_service to pick up dynamically activated providers.
+        // embed_query_text records provider telemetry (issue #962).
         if let Some(semantic_service) = self.memory.live_semantic_service().await {
-            match semantic_service.provider.embed_text("test").await {
+            match semantic_service.embed_query_text("test").await {
                 Ok(test_embedding) => {
                     let test_time_ms = start_time.elapsed().as_millis() as u64;
 
@@ -102,7 +103,7 @@ impl EmbeddingTools {
 
             let test_result = if input.test_connectivity {
                 let start_time = std::time::Instant::now();
-                match semantic_service.provider.embed_text("test").await {
+                match semantic_service.embed_query_text("test").await {
                     Ok(embedding) => {
                         let duration_ms = start_time.elapsed().as_millis() as u64;
                         let sample_embedding: Vec<f32> = embedding.into_iter().take(5).collect();

--- a/memory-mcp/src/monitoring/endpoints.rs
+++ b/memory-mcp/src/monitoring/endpoints.rs
@@ -88,6 +88,28 @@ impl MonitoringEndpoints {
         }))
     }
 
+    /// Handle retrieval-plane metrics endpoint (issue #962)
+    ///
+    /// Reads the process-global retrieval telemetry registry: request
+    /// counts and durations by operation/tier/outcome, candidate-set sizes,
+    /// cache results, embedding calls by provider, fallback reasons, and
+    /// feedback signals. All labels are bounded enums; raw queries, IDs,
+    /// tags, and error strings can never appear.
+    #[expect(clippy::unused_async, clippy::unused_async_trait_impl)]
+    pub async fn retrieval_metrics(&self) -> Result<serde_json::Value> {
+        debug!("Handling retrieval metrics request");
+
+        let snapshot = do_memory_core::monitoring::metrics::global_retrieval_metrics().snapshot();
+
+        Ok(json!({
+            "retrieval_metrics": snapshot,
+            "timestamp": std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs()
+        }))
+    }
+
     /// Handle performance metrics endpoint
     #[expect(clippy::unused_async, clippy::unused_async_trait_impl)]
     pub async fn performance_metrics(&self) -> Result<serde_json::Value> {

--- a/memory-mcp/src/server/tool_definitions.rs
+++ b/memory-mcp/src/server/tool_definitions.rs
@@ -102,7 +102,7 @@ pub fn create_default_tools() -> Vec<Tool> {
             "properties": {
                 "metric_type": {
                     "type": "string",
-                    "enum": ["all", "performance", "episodes", "system"],
+                    "enum": ["all", "performance", "episodes", "system", "retrieval"],
                     "default": "all",
                     "description": "Type of metrics to retrieve"
                 }

--- a/memory-mcp/src/server/tools/monitoring.rs
+++ b/memory-mcp/src/server/tools/monitoring.rs
@@ -61,6 +61,7 @@ impl crate::server::MemoryMCPServer {
             Some("performance") => self.monitoring_endpoints.performance_metrics().await,
             Some("episodes") => self.monitoring_endpoints.episode_metrics().await,
             Some("system") => self.monitoring_endpoints.system_info().await,
+            Some("retrieval") => self.monitoring_endpoints.retrieval_metrics().await,
             _ => self.monitoring_endpoints.metrics().await,
         };
 

--- a/memory-mcp/src/server/tools/registry/builder_core.rs
+++ b/memory-mcp/src/server/tools/registry/builder_core.rs
@@ -63,7 +63,7 @@ pub(super) fn create_core_tools() -> Vec<Tool> {
                 "properties": {
                     "metric_type": {
                         "type": "string",
-                        "enum": ["all", "performance", "episodes", "system"],
+                        "enum": ["all", "performance", "episodes", "system", "retrieval"],
                         "default": "all",
                         "description": "Type of metrics to retrieve"
                     }

--- a/plans/DO_HARNESS_INTEGRATION_2026-09-05.md
+++ b/plans/DO_HARNESS_INTEGRATION_2026-09-05.md
@@ -1,0 +1,115 @@
+# do-harness Integration Plan (2026-09-05)
+
+## Purpose
+
+`do-harness` (github.com/d-o-hub/do-harness) is a compiled Rust CLI that operationalizes the
+exact "Agent = Model + Harness" model this repo already documents in `HARNESS.md`: feedforward
+guides (`AGENTS.md`, `.agents/skills/`) plus feedback sensors (computational checks), with a
+local libSQL state DB (`.do-harness/agent_state.db`) for sensor beats, fail-fast strikes, task
+gating, traces, and skill-eval history. It does **not** read `HARNESS.md`; it reads
+`do-harness.toml` (sensor definitions, hook staging) and `plans/invariants.json` (seed data).
+`HARNESS.md` stays our conceptual map; do-harness adds the executable sensor + state layer.
+
+## Install (already satisfied)
+
+- **No GitHub releases, no tags, no prebuilt binaries.** `cargo install` from source is the only path.
+- **Already installed**: `/home/do/.cargo/bin/do-harness` v0.1.0 (commit `3df96c2`, 2026-09-03),
+  built from `/home/do/git/do-bookster/vendor/do-harness/crates/do-harness`. Upstream HEAD is
+  `d7b8348` (2026-09-04) — a few commits ahead; no pinned versions exist upstream.
+- Rebuild/upgrade: `cargo install --path <checkout>/crates/do-harness` (small dep tree: clap,
+  tokio, libsql, serde, axum — builds in ~1-2 min). Do NOT build into this repo's shared `target/`.
+
+## Command Surface (cheatsheet)
+
+| Command | Purpose |
+|---|---|
+| `do-harness init [--language rust]` | Scaffold `do-harness.toml`, `plans/invariants.json`, skills, `scripts/check-loc.sh`; existing files untouched unless `--force` |
+| `do-harness list` | List sensor names from `do-harness.toml` |
+| `do-harness verify [--only <n>]... [--record] [--task <id>] [--format json]` | Run sensors; `--record` persists beats + error signatures |
+| `do-harness doctor` | Binary resolution, git-hook health, state-DB migration skew |
+| `do-harness hook install\|status\|uninstall` | Write pre-commit/pre-push/commit-msg hooks into `.git/hooks/` |
+| `do-harness task add\|advance\|done\|fail` | Task gate: `done` refuses until `verify --record` passes the named sensor |
+| `do-harness trace add` / `distill --from-trace` | Record resolved sensor fixes; distill heuristics into a skill |
+| `do-harness metrics` | Sensor stats, strikes, eval pass-rate history |
+| `do-harness errors list\|clear` / `audit-chain` | Fail-fast signatures / hash-chain integrity |
+
+## Recommended Sensor Pack (`do-harness.toml` — mirrors existing gates, no duplication)
+
+Keep sensors aligned with the repo's own commands (post-init edits):
+
+```toml
+language = "rust"
+[hooks]
+pre-commit = ["fmt", "loc"]   # cheap subset only
+pre-push = []
+
+[[sensors]] name = "fmt"     argv = ["cargo", "fmt", "--all", "--", "--check"]
+[[sensors]] name = "clippy"  argv = ["cargo", "clippy", "--workspace", "--", "-D", "warnings"]
+[[sensors]] name = "test"    argv = ["cargo", "nextest", "run", "--all"]   # repo standard
+[[sensors]] name = "deny"    argv = ["cargo", "deny", "check"]
+[[sensors]] name = "loc"     argv = ["bash", "scripts/check-loc.sh"]       # enforces ≤500 LOC invariant
+```
+
+## Proposed AGENTS.md Diff (exact markdown)
+
+1. Add one row to the Quick Reference table (after the Quality Gates row):
+
+```markdown
+| **Agent Harness** | `do-harness` | `do-harness verify --record` / `do-harness doctor` |
+```
+
+2. Add a new section directly above `## Steering Loop`:
+
+```markdown
+## Dev Harness (do-harness)
+
+Computational sensor runner + local agent state DB (`.do-harness/agent_state.db`, gitignored).
+Sensors are defined in `do-harness.toml`; `HARNESS.md` maps them to guides.
+
+- `do-harness verify --record` — run the sensor suite and persist beats (run before commit)
+- `do-harness verify --only <sensor>` — targeted re-run after a failure
+- `do-harness task done <id>` — task gate; refuses until its sensor passed via `verify --record`
+- `do-harness doctor` — after upgrading the binary (checks hook/DB migration skew)
+- Sensor fired? Fix the firing sensor first (`verify --only <name>`), then commit. Same
+  self-correction protocol as HARNESS.md; beats recorded by `--record` feed `do-harness metrics`.
+```
+
+3. Change Workflow: insert as new step 10 (renumber `git status` to 11):
+   `10. do-harness verify --record`
+
+## Recommended Workflow Hook + Rationale
+
+- **Hook point**: Change Workflow step (above) — NOT `scripts/quality-gates.sh` and NOT CI.
+  - `quality-gates.sh` already owns coverage/pattern thresholds; layering do-harness there
+    couples two failure domains. Keep verify as a separate, explicit step.
+  - `scripts/harness-check.sh` remains; do-harness adds state (beats/strikes) it lacks.
+- **Git hooks**: DEFER `do-harness hook install`. This repo's `.pre-commit-config.yaml` (pre-commit
+  framework) and do-harness both write `.git/hooks/pre-commit` — last installer wins. Current clone
+  has no hooks installed, so there is no clash today, but pick one owner before installing.
+- **CI**: AGAINST for now. CI already runs fmt/clippy/nextest/deny directly; there are no prebuilt
+  binaries, so CI would pay a build (~2 min) to re-run identical checks. Revisit only if JSON
+  evidence artifacts (`verify --format json`) become a requirement.
+- **Adoption steps (on a branch)**: run `do-harness init` → review diff → trim (see risks) →
+  edit sensors to the pack above → `do-harness init-db && do-harness seed` → `do-harness verify`.
+
+## Risks
+
+1. **`init` scaffolds 6 skill dirs** (`harness`, `htn-planner`, `spike-runner`, `skill-distiller`,
+   `event-modeler`, `skill-creator`) with their own `evals/`. `.agents/skills/skill-creator`
+   **collides by name** with our existing skill (its `SKILL.md` is safe — per-file write-if-absent —
+   but `scripts/init_skill.py` etc. would be injected). Post-init: delete unwanted dirs, keep at
+   most `harness`, and check `./scripts/run-evals.sh --fixtures` still passes (Skill Evals CI).
+2. **`.gitignore` pollution**: init appends `.agents/events/` — but this repo COMMITS those files
+   (Steering Loop metrics events). Remove that line after init (keep `.do-harness/`).
+3. **Sensor duplication**: `check-commitlint.sh` scaffold duplicates `commitlint.config.cjs` +
+   pre-commit; drop the scaffold or the pre-commit commitlint hook — do not run both.
+4. **Version drift**: no upstream tags/releases; installed binary comes from the do-bookster
+   vendored copy and is already behind HEAD. Decide a source of truth (vendor here like do-bookster,
+   or rebuild from upstream on demand) before depending on it.
+5. **Vacuous pass**: if `do-harness.toml` lists zero sensors, `verify` exits 0 meaninglessly —
+   keep the pack above populated.
+
+## Smoke-Test Evidence (2026-09-05)
+
+`--help`, `version`, `list`, `doctor`, `metrics` all green against installed binary; `init` ran
+clean in `/tmp/do-harness-init-test` (artifact list above verified). No repo files were modified.

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -1,15 +1,28 @@
 # Active Development Roadmap
 
-**Last Updated**: 2026-08-12
+**Last Updated**: 2026-09-05
 **Released Version**: v0.1.39 (latest tag)
 **Workspace Version**: 0.1.40 (post-v0.1.39 bump)
-**Active Sprint**: post-closure main (#947 merged 2026-08-12); awaiting maintainer ADR-079 stage-4 + ADR-080/081 lifecycle
+**Active Sprint**: observability wave — #962 retrieval telemetry in review; perf PRs #992-994/#978 in CI; release drift #976 pending ship
 **Plan**: merged #947 (2026-08-12); prior waves: `GOAP_PR_REVIEW_CI_FIX_WAVE_2026-08-07.md`, `GOAP_CIT_A1_A2_A3_WORKFLOW_WAVE_2026-08-06.md`, `GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md`, `GOAP_ADR081_CAPABILITY_TRUTH_2026-08-10.md` (all historical)
-**Branch**: main @ `872949b8` (PR #947 merged 2026-08-12)
-**Open PRs**: none (docs-only tracker PR transient)
-**Open issues**: none
+**Branch**: feat/retrieval-observability-962 (WIP) off main @ `5f2c215b`
+**Open PRs**: 13 (see #976 drift context)
+**Open issues**: 6 (#976 critical: release due)
+
+## Sprint 2026-09-05 — Observability + dev-harness adoption
+
+| Prio | Area | Item | Status |
+|------|------|------|--------|
+| P1 | Observability | #962 retrieval telemetry: bounded labels, MCP `get_metrics(retrieval)`, redaction tests | ✅ Implemented (branch feat/retrieval-observability-962) |
+| P1 | Build | Fix `.gitignore` swallowing `metrics/` sources; tokio `net` feature; wasm gate | ✅ Done |
+| P1 | Observability | Prometheus exposition validity (single TYPE per family, per-(op,tier) quantiles) | ✅ Done |
+| P2 | Observability | Module split ≤500 LOC (labels/registry/exposition) | ✅ Done |
+| P2 | Observability | CLI retrieval-metrics surface + docs dashboard example (#962 acceptance) | 🔄 In progress |
+| P2 | Workflow | do-harness dev harness adopted (sensors fmt/check/clippy/test/deny/loc) | ✅ Done |
+| P1 | Release | #976 drift (30 commits / 24 d): ship via release-guard once #962 lands | ⏳ Pending |
 
 ---
+
 
 ## Completed sprint 2026-07-22…25 — Ship + post-bump + gap analysis + R-F8/R-F9 + skills
 

--- a/plans/invariants.json
+++ b/plans/invariants.json
@@ -1,0 +1,20 @@
+[
+  {
+    "invariant": "Computational sensors strictly supersede LLM self-assessment",
+    "rationale": "Automated exit codes are the only proof a subtask is complete",
+    "sensor": "do-harness verify",
+    "category": "verification"
+  },
+  {
+    "invariant": "Maximum 500 LOC per source file; decompose when nearing 450",
+    "rationale": "Bounds per-file complexity so any slice stays reviewable and token-efficient",
+    "sensor": "scripts/check-loc.sh",
+    "category": "architecture"
+  },
+  {
+    "invariant": "Conventional commits with lowercase subject lines",
+    "rationale": "Machine-parseable history for the distillation loop",
+    "sensor": "CI Commit Message Lint (commitlint.config.cjs)",
+    "category": "workflow"
+  }
+]

--- a/scripts/check-loc.sh
+++ b/scripts/check-loc.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# check-loc.sh — enforces the 500 LOC per file invariant.
+#
+# Sensor: scripts/check-loc.sh
+# Fails if any .rs file under src/ or crates/ exceeds MAX lines.
+# Writes a warning when a file is at or above the decomposition threshold.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+MAX="${1:-500}"
+THRESHOLD=450
+FAIL=0
+
+while IFS= read -r file; do
+    lines="$(wc -l < "$file")"
+    if (( lines > MAX )); then
+        echo "FAIL: $file has $lines lines (max $MAX)"
+        FAIL=1
+    elif (( lines >= THRESHOLD )); then
+        echo "WARN: $file is nearing the limit: $lines lines"
+    fi
+done < <(find "$ROOT/src" "$ROOT/crates" -name '*.rs' -not -path '*/target/*' 2>/dev/null)
+
+if (( FAIL )); then
+    echo "LOC ceiling violated."
+    exit 1
+fi
+
+echo "check-loc OK: all source files under $MAX lines."


### PR DESCRIPTION
#962 — retrieval observability

## What

- Bounded-label telemetry registry (enum vocabularies, fixed-size storage,
  compile-time cardinality) with a process-global instance.
- Recording hooks on the real paths: query tiers (cache/hybrid/semantic/
  keyword/hierarchical/none), cascade tiers + fallback reasons, query-cache
  hits/misses, embedding calls by provider/outcome, feedback signals.
- Exports: MCP `get_metrics(metric_type="retrieval")`, Prometheus text
  (single HELP/TYPE per family), and `do-memory-cli monitor retrieval`.
- Docs: docs/RETRIEVAL_OBSERVABILITY.md with the four required PromQL
  panels (tier distribution, P95, cache hit rate, embedding rate).

## Hygiene fixed on the way

- `.gitignore`: bare `metrics/` silently ignored the new module sources;
  anchored to root-only `/metrics/`.
- `do-memory-core` standalone build was broken (tokio `net` feature missing);
  added on the native-only target and wasm-gated the metrics HTTP server.
- Prometheus exposition emitted duplicate TYPE lines and per-outcome
  duplicate quantile series; both fixed and unit-tested.
- `OperationLatency` percentiles could invert (p50 > p95); ordering now
  enforced (pre-existing failing test on main).
- `context.rs` and `eval.rs` exceeded the 500 LOC invariant; split.

## Test plan

- `cargo nextest run --all`: 3,897 passed; doctests + `cargo doc` clean.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- New tests: telemetry integration (query path, feedback, redaction marker),
  cardinality bounds, exposition validity, LOC-compliant module split.
- `do-harness verify --record` (new workflow step): all sensors pass.