### PR TITLE
chore(release): bump workspace to 0.1.41 after shipping v0.1.40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1675,7 +1675,7 @@ checksum = "2906d3628a885aa49a23b88e71f63e51ae8df41cd76652287f0a6179a11833a9"
 
 [[package]]
 name = "do-memory-benches"
-version = "0.1.40"
+version = "0.1.41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-cli"
-version = "0.1.40"
+version = "0.1.41"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-core"
-version = "0.1.40"
+version = "0.1.41"
 dependencies = [
  "agentfs-sdk",
  "anyhow",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-examples"
-version = "0.1.40"
+version = "0.1.41"
 dependencies = [
  "anyhow",
  "do-memory-core",
@@ -1793,7 +1793,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-mcp"
-version = "0.1.40"
+version = "0.1.41"
 dependencies = [
  "agentfs-sdk",
  "anyhow",
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-storage-redb"
-version = "0.1.40"
+version = "0.1.41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-storage-turso"
-version = "0.1.40"
+version = "0.1.41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "do-memory-test-utils"
-version = "0.1.40"
+version = "0.1.41"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1902,7 +1902,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "e2e-tests"
-version = "0.1.40"
+version = "0.1.41"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.1.40"
+version = "0.1.41"
 edition = "2024"
 authors = ["Self-Learning Memory Contributors"]
 license = "MIT"

--- a/plans/ROADMAPS/ROADMAP_ACTIVE.md
+++ b/plans/ROADMAPS/ROADMAP_ACTIVE.md
@@ -2,7 +2,7 @@
 
 **Last Updated**: 2026-09-05
 **Released Version**: v0.1.40 (latest tag)
-**Workspace Version**: 0.1.40 (release pending tag)
+**Workspace Version**: 0.1.41 (post-v0.1.40 bump)
 **Active Sprint**: observability wave — #962 retrieval telemetry in review; perf PRs #992-994/#978 in CI; release drift #976 pending ship
 **Plan**: merged #947 (2026-08-12); prior waves: `GOAP_PR_REVIEW_CI_FIX_WAVE_2026-08-07.md`, `GOAP_CIT_A1_A2_A3_WORKFLOW_WAVE_2026-08-06.md`, `GOAP_CIT_A4_A5_AND_PLAN_TRUTH_2026-08-06.md`, `GOAP_ADR081_CAPABILITY_TRUTH_2026-08-10.md` (all historical)
 **Branch**: feat/retrieval-observability-962 (WIP) off main @ `5f2c215b`

--- a/plans/STATUS/CURRENT.md
+++ b/plans/STATUS/CURRENT.md
@@ -1,8 +1,8 @@
 # Project Status — Self-Learning Memory System
 
 **Last Updated**: 2026-09-06
-**Released Version**: v0.1.40 (release pending tag)
-**Workspace Version**: 0.1.40 (matches release)
+**Released Version**: v0.1.40 (latest tag)
+**Workspace Version**: 0.1.41 (post-v0.1.40 bump)
 **Edition**: Rust 2024  
 **Active plan**: merged #952 (2026-08-13) — ADR-082 + ADR-025/054 canonicalization landed; no in-flight code plan; ADR-080/081/082 lifecycle acceptance remains an external-maintainer item
 **Branch**: main @ `9c8bfa79` (PR #952 merged 2026-08-13)


### PR DESCRIPTION
Post-release version bump per the Release Drift contract
(version_not_advanced fires when workspace equals the latest tag
with unreleased commits).

- Workspace version 0.1.40 -> 0.1.41 (+ lockfile)
- Released Version: v0.1.40 (latest tag) in ROADMAP_ACTIVE and
  STATUS/CURRENT