### PR TITLE
fix(framework): bound limit in domain index recent episodes query

### DIFF
--- a/memory-core/src/spatiotemporal/index/domain_index.rs
+++ b/memory-core/src/spatiotemporal/index/domain_index.rs
@@ -138,6 +138,7 @@ impl DomainIndex {
     /// Vector of recent episode IDs.
     #[must_use]
     pub fn get_recent_episodes(&self, limit: usize) -> Vec<Uuid> {
+        let limit = limit.min(crate::storage::MAX_QUERY_LIMIT);
         let mut all_episodes: Vec<Uuid> = self.uncategorized_episodes.clone();
 
         for task_type_index in self.task_type_indices.values() {
@@ -235,6 +236,17 @@ mod tests {
 
         let recent = index.get_recent_episodes(3);
         assert_eq!(recent.len(), 3);
+    }
+
+    #[test]
+    fn test_get_recent_episodes_unbounded_limit() {
+        let mut index = DomainIndex::new("test-domain".to_string());
+        let episode = create_test_episode("test-domain", TaskType::CodeGeneration);
+        index.insert_episode(&episode);
+
+        let recent = index.get_recent_episodes(usize::MAX);
+        assert_eq!(recent.len(), 2);
+        assert!(recent.len() <= crate::storage::MAX_QUERY_LIMIT);
     }
 
     #[test]

--- a/progress/LEARNINGS.md
+++ b/progress/LEARNINGS.md
@@ -9,6 +9,11 @@
 **Learning:** Security bounds must be applied not just to scalar 'limit' parameters, but also to collection sizes (vectors/arrays) provided by users.
 **Prevention:** Use `.truncate(MAX_CONSTANT)` for user-provided lists and ensure all numeric/floating-point inputs are clamped to safe ranges.
 
+## 2026-03-06 — Unbounded limit in DomainIndex::get_recent_episodes
+**Vulnerability:** `DomainIndex::get_recent_episodes` accepted an unbounded `limit: usize` parameter which could lead to resource exhaustion when called with extreme values like `usize::MAX`.
+**Learning:** Index query routines returning collections must bound user-supplied limits against domain constants.
+**Prevention:** Clamp caller-provided `limit` parameters with `crate::storage::MAX_QUERY_LIMIT` at function entry.
+
 ## 2026-03-06 — Unbounded top_k in HierarchicalReranker::rerank_with_query
 **Vulnerability:** `HierarchicalReranker::rerank_with_query` accepted an unbounded `top_k: usize` parameter which was passed directly to `Vec::with_capacity(top_k)` in `select_diverse`, leading to potential out-of-memory panics (DoS) when called with large `top_k` values like `usize::MAX`.
 **Learning:** Public retrieval APIs accepting limits/top_k parameters must bound user-provided values prior to vector allocations.


### PR DESCRIPTION
### Severity
MEDIUM

### Finding
`DomainIndex::get_recent_episodes` accepted an unbounded `limit: usize` parameter without clamping it to system safety thresholds.

### Impact
Callers or API layers passing unbounded or excessively high `limit` parameters could cause excessive memory consumption when processing recent episodes across domain task-type indices.

### Fix
Clamped `limit` using `crate::storage::MAX_QUERY_LIMIT` (1000) at the start of `DomainIndex::get_recent_episodes` and added a unit test `test_get_recent_episodes_unbounded_limit`.

### Verification
Ran cargo test for `spatiotemporal::index::domain_index` module and verified clean results along with workspace quality checks.

---
*PR created automatically by Jules for task [7550407113251004923](https://jules.google.com/task/7550407113251004923) started by @d-o-hub*